### PR TITLE
Redux updates to handle availability

### DIFF
--- a/autoscheduler/frontend/src/.eslintrc.js
+++ b/autoscheduler/frontend/src/.eslintrc.js
@@ -58,5 +58,7 @@ module.exports = {
       ],
     }],
     "@typescript-eslint/no-explicit-any": 0,
+    "semi": "off",
+    "@typescript-eslint/semi": ["error"],
   },
 };

--- a/autoscheduler/frontend/src/redux/actionTypes.ts
+++ b/autoscheduler/frontend/src/redux/actionTypes.ts
@@ -6,6 +6,7 @@
  */
 import Meeting from '../types/Meeting';
 import { CourseCardOptions } from '../types/CourseCardOptions';
+import { AvailabilityType, AvailabilityArgs } from '../types/Availability';
 
 /* Meeting actions */
 export const ADD_MEETING = 'ADD_MEETING';
@@ -46,3 +47,46 @@ export interface UpdateCourseAction {
 }
 
 export type CourseCardAction = AddCourseAction | RemoveCourseAction | UpdateCourseAction;
+
+/* Availability actions */
+export const SET_AVAILABILITY_MODE = 'SET_AVAILABILITY_MODE';
+export const ADD_AVAILABILITY = 'ADD_AVAILABILITY';
+export const DELETE_AVAILABILITY = 'DELETE_AVAILABILITY';
+export const UPDATE_AVAILABILITY = 'UPDATE_AVAILABILITY';
+export const MERGE_AVAILABILITY = 'MERGE_AVAILABILITY';
+
+export interface AvailabilityModeAction {
+    type: 'SET_AVAILABILITY_MODE';
+    mode: AvailabilityType;
+}
+
+export interface AddAvailabilityAction {
+    type: 'ADD_AVAILABILITY';
+    availability: AvailabilityArgs;
+}
+
+export interface DeleteAvailabilityAction {
+    type: 'DELETE_AVAILABILITY';
+    availability: AvailabilityArgs;
+}
+
+export interface UpdateAvailabilityAction {
+    type: 'UPDATE_AVAILABILITY';
+    availability: AvailabilityArgs;
+}
+
+export interface MergeAvailabilityAction {
+    type: 'MERGE_AVAILABILITY';
+}
+
+export type AvailabilityAction =
+    AddAvailabilityAction | DeleteAvailabilityAction |
+    UpdateAvailabilityAction | MergeAvailabilityAction;
+
+/* Availability To Update actions */
+export const SET_SELECTED_AVAILABILITY = 'SET_SELECTED_AVAILABILITY';
+
+export interface SetSelectedAvailabilityAction {
+    type: 'SET_SELECTED_AVAILABILITY';
+    availability: AvailabilityArgs;
+}

--- a/autoscheduler/frontend/src/redux/actions.ts
+++ b/autoscheduler/frontend/src/redux/actions.ts
@@ -8,11 +8,15 @@ import Meeting from '../types/Meeting';
 import {
   ADD_MEETING, REMOVE_MEETING, REPLACE_MEETINGS, SingleMeetingAction, MultiMeetingAction,
   AddCourseAction, ADD_COURSE_CARD, REMOVE_COURSE_CARD, UPDATE_COURSE_CARD, RemoveCourseAction,
-  UpdateCourseAction,
+  UpdateCourseAction, AvailabilityModeAction, SET_AVAILABILITY_MODE,
+  AddAvailabilityAction, ADD_AVAILABILITY, DeleteAvailabilityAction, DELETE_AVAILABILITY,
+  UpdateAvailabilityAction, UPDATE_AVAILABILITY, MERGE_AVAILABILITY,
+  SetSelectedAvailabilityAction, SET_SELECTED_AVAILABILITY, MergeAvailabilityAction,
 } from './actionTypes';
 import { CourseCardOptions, SectionSelected } from '../types/CourseCardOptions';
 import { RootState } from './reducers';
 import fetch from './testData';
+import { AvailabilityType, AvailabilityArgs } from '../types/Availability';
 
 export function addMeeting(meeting: Meeting): SingleMeetingAction {
   return {
@@ -112,5 +116,66 @@ export function updateCourseCard(index: number, courseCard: CourseCardOptions):
 
     // update the options in the course card
     return dispatch(updateCourseCardSync(index, courseCard));
+  };
+}
+
+/**
+ * Sets what type of availability the user is placing on the calendar. At present, the
+ * user can only specify busy times during which they absolutely cannot have classes,
+ * but in the future, they may also be able to add preferred times to have classes.
+ * @param mode probably AvailabilityType.BUSY for now
+ */
+export function setAvailabilityMode(mode: AvailabilityType): AvailabilityModeAction {
+  return {
+    type: SET_AVAILABILITY_MODE,
+    mode,
+  };
+}
+
+export function addAvailability(availability: AvailabilityArgs): AddAvailabilityAction {
+  return {
+    type: ADD_AVAILABILITY,
+    availability,
+  };
+}
+
+/**
+ * Deletes the availbility matching the given availability args. Enter the start time
+ * as `time1` and the end time as `time2`.
+ * @param availability
+ */
+export function deleteAvailability(availability: AvailabilityArgs): DeleteAvailabilityAction {
+  return {
+    type: DELETE_AVAILABILITY,
+    availability,
+  };
+}
+
+/**
+ * Updates the availability matching the given availability args. Enter the unchanged
+ * time as time1 and the changed time as time2
+ * @param availability
+ */
+export function updateAvailability(availability: AvailabilityArgs): UpdateAvailabilityAction {
+  return {
+    type: UPDATE_AVAILABILITY,
+    availability,
+  };
+}
+
+/**
+ * Merges the last-added availability with other availabilities in the Redux store
+ */
+export function mergeAvailability(): MergeAvailabilityAction {
+  return {
+    type: MERGE_AVAILABILITY,
+  };
+}
+
+export function setSelectedAvailability(availability: AvailabilityArgs):
+SetSelectedAvailabilityAction {
+  return {
+    type: SET_SELECTED_AVAILABILITY,
+    availability,
   };
 }

--- a/autoscheduler/frontend/src/redux/actions.ts
+++ b/autoscheduler/frontend/src/redux/actions.ts
@@ -140,7 +140,7 @@ export function addAvailability(availability: AvailabilityArgs): AddAvailability
 }
 
 /**
- * Deletes the availbility matching the given availability args. Enter the start time
+ * Deletes the availability matching the given availability args. Enter the start time
  * as `time1` and the end time as `time2`.
  * @param availability
  */
@@ -153,7 +153,8 @@ export function deleteAvailability(availability: AvailabilityArgs): DeleteAvaila
 
 /**
  * Updates the availability matching the given availability args. Enter the unchanged
- * time as time1 and the changed time as time2
+ * time as time1 and the changed time as time2. This action should be dispatched whenever
+ * an availability is updated by dragging its edges in the UI.
  * @param availability
  */
 export function updateAvailability(availability: AvailabilityArgs): UpdateAvailabilityAction {

--- a/autoscheduler/frontend/src/redux/reducers.ts
+++ b/autoscheduler/frontend/src/redux/reducers.ts
@@ -119,13 +119,10 @@ function availability(
     case ADD_AVAILABILITY:
     case MERGE_AVAILABILITY: {
       // check for overlaps between the availability to be added and pre-existing ones
-      let overlapsFound = 0; // counts merging overlaps only
-      let overlapIdx = -1;
-
       let newAv = action.type === ADD_AVAILABILITY
         ? argsToAvailability(action.availability)
         : state[state.length - 1];
-      const newState = state.reduce<Availability[]>((avsList, oldAv, idx): Availability[] => {
+      const newState = state.reduce<Availability[]>((avsList, oldAv): Availability[] => {
         // only counts as an overlap if they're on the same day of the week
         if (oldAv.dayOfWeek === newAv.dayOfWeek) {
           const avWithEarlierStart = getStart(oldAv) < getStart(newAv) ? oldAv : newAv;
@@ -134,9 +131,6 @@ function availability(
           if (getEnd(avWithEarlierStart) >= getStart(avWithLaterStart)) {
             // if they're the same type, merge them
             if (oldAv.available === newAv.available) {
-              overlapsFound += 1;
-              const oldOverlapIdx = overlapIdx;
-              overlapIdx = idx;
               const newEnd = Math.max(getEnd(oldAv), getEnd(newAv));
               const newEndHrs = Math.floor(newEnd / 60);
               const newEndMins = newEnd % 60;

--- a/autoscheduler/frontend/src/redux/reducers.ts
+++ b/autoscheduler/frontend/src/redux/reducers.ts
@@ -149,9 +149,8 @@ function availability(
                 endTimeHours: newEndHrs,
                 endTimeMinutes: newEndMins,
               };
-              if (overlapsFound >= 2) {
+              if (overlapsFound === 2) {
                 avsList.splice(oldOverlapIdx, 1);
-                // avsList.push(newAv);
                 return avsList;
               }
               return avsList.filter((av) => av !== oldAv);
@@ -163,7 +162,6 @@ function availability(
         avsList.push(oldAv);
         return avsList;
       }, []);
-      // if (!overlapsFound) { newState.push(initNewAv); }
       newState.push(newAv);
       return newState;
     }

--- a/autoscheduler/frontend/src/redux/reducers.ts
+++ b/autoscheduler/frontend/src/redux/reducers.ts
@@ -45,10 +45,9 @@ const time1And2Mismatch = (av: Availability, avArgs: AvailabilityArgs): boolean 
  * @param avArgs
  */
 const time1OnlyMismatch = (av: Availability, avArgs: AvailabilityArgs): boolean => (
-  (av.available !== avArgs.available
+  av.available !== avArgs.available
   || av.dayOfWeek !== avArgs.dayOfWeek
-  || (getStart(av) !== avArgs.time1
-  && getEnd(av) !== avArgs.time1))
+  || (getStart(av) !== avArgs.time1 && getEnd(av) !== avArgs.time1)
 );
 
 
@@ -172,15 +171,21 @@ function availability(
       return state.filter((av) => time1And2Mismatch(av, action.availability));
     case UPDATE_AVAILABILITY: {
       const { time1, time2 } = action.availability;
-      return state.map((av) => (time1OnlyMismatch(av, action.availability)
-        ? av
-        : {
+      return state.map((av) => {
+        // if av doesn't match the args, then leave the availability as is
+        if (time1OnlyMismatch(av, action.availability)) return av;
+
+        // if av does match args, return the updated availability
+        const startTime = Math.min(time1, time2);
+        const endTime = Math.max(time1, time2);
+        return {
           ...av,
-          startTimeHours: Math.floor(Math.min(time1, time2) / 60),
-          startTimeMinutes: Math.min(time1, time2) % 60,
-          endTimeHours: Math.floor(Math.max(time1, time2) / 60),
-          endTimeMinutes: Math.max(time1, time2) % 60,
-        }));
+          startTimeHours: Math.floor(startTime / 60),
+          startTimeMinutes: startTime % 60,
+          endTimeHours: Math.floor(endTime / 60),
+          endTimeMinutes: endTime % 60,
+        };
+      });
     }
     default:
       return state;

--- a/autoscheduler/frontend/src/redux/reducers.ts
+++ b/autoscheduler/frontend/src/redux/reducers.ts
@@ -4,11 +4,15 @@
  */
 import { combineReducers } from 'redux';
 import {
-  MeetingAction, ADD_MEETING, REMOVE_MEETING, REPLACE_MEETINGS, CourseCardAction,
-  ADD_COURSE_CARD, REMOVE_COURSE_CARD, UPDATE_COURSE_CARD,
+  MeetingAction, ADD_MEETING, REMOVE_MEETING, REPLACE_MEETINGS,
+  CourseCardAction, ADD_COURSE_CARD, REMOVE_COURSE_CARD, UPDATE_COURSE_CARD,
+  AvailabilityModeAction, SET_AVAILABILITY_MODE,
+  AvailabilityAction, ADD_AVAILABILITY, DELETE_AVAILABILITY, UPDATE_AVAILABILITY,
+  SetSelectedAvailabilityAction, SET_SELECTED_AVAILABILITY, MERGE_AVAILABILITY,
 } from './actionTypes';
-import Meeting from '../types/Meeting';
 import { CourseCardArray, CustomizationLevel } from '../types/CourseCardOptions';
+import Meeting from '../types/Meeting';
+import Availability, { AvailabilityType, argsToAvailability, AvailabilityArgs } from '../types/Availability';
 
 // manage actions that affect meetings
 function meetings(state: Meeting[] = [], action: MeetingAction): Meeting[] {
@@ -61,10 +65,120 @@ function courseCards(
   }
 }
 
+// sets whether the user is selecting busy time or not
+// in the future, this could also support preferred times
+function availabilityMode(
+  state: AvailabilityType = AvailabilityType.NONE, action: AvailabilityModeAction,
+): AvailabilityType {
+  if (action.type === SET_AVAILABILITY_MODE) { return action.mode; }
+  return state;
+}
+
+// stores all information about the user's availability
+function availability(
+  state: Availability[] = [], action: AvailabilityAction,
+): Availability[] {
+  switch (action.type) {
+    case ADD_AVAILABILITY:
+    case MERGE_AVAILABILITY: {
+      // helper functions to get the start and end times of an availability object in minutes
+      const getStart = (av: Availability): number => av.startTimeHours * 60 + av.startTimeMinutes;
+      const getEnd = (av: Availability): number => av.endTimeHours * 60 + av.endTimeMinutes;
+
+      // check for overlaps between the availability to be added and pre-existing ones
+      let overlapsFound = 0; // counts merging overlaps only
+      let overlapIdx = -1;
+
+      const initNewAv = action.type === ADD_AVAILABILITY
+        ? argsToAvailability(action.availability)
+        : state[state.length - 1];
+      let newAv = initNewAv;
+      return state.reduce<Availability[]>((avsList, oldAv, idx): Availability[] => {
+        // only counts as an overlap if they're on the same day of the week
+        if (oldAv.dayOfWeek === newAv.dayOfWeek) {
+          const avWithEarlierStart = getStart(oldAv) < getStart(newAv) ? oldAv : newAv;
+          const avWithLaterStart = avWithEarlierStart === oldAv ? newAv : oldAv;
+          // overlap detected
+          if (getEnd(avWithEarlierStart) >= getStart(avWithLaterStart)) {
+            // if they're the same type, merge them
+            if (oldAv.available === newAv.available) {
+              overlapsFound += 1;
+              const oldOverlapIdx = overlapIdx;
+              overlapIdx = idx;
+              const newEnd = Math.max(getEnd(oldAv), getEnd(newAv));
+              const newEndHrs = Math.floor(newEnd / 60);
+              const newEndMins = newEnd % 60;
+              newAv = {
+                available: oldAv.available,
+                dayOfWeek: oldAv.dayOfWeek,
+                startTimeHours: avWithEarlierStart.startTimeHours,
+                startTimeMinutes: avWithEarlierStart.startTimeMinutes,
+                endTimeHours: newEndHrs,
+                endTimeMinutes: newEndMins,
+              };
+              if (overlapsFound === 2) {
+                return avsList.slice(0, oldOverlapIdx)
+                  .concat(avsList.slice(oldOverlapIdx + 1))
+                  .concat(newAv);
+              }
+              return avsList.filter((av) => av !== oldAv).concat(newAv);
+            }
+            // if they're different types, then set the new one to the old one's borders
+            // TODO
+          }
+        }
+        // if no overlap
+        return avsList.concat(oldAv);
+      }, []).concat(overlapsFound ? [] : initNewAv);
+    }
+    case DELETE_AVAILABILITY:
+      // filters the availability list for the availabiltiy matching the action args
+      return state.filter((av) => av.available !== action.availability.available
+        || av.dayOfWeek !== action.availability.dayOfWeek
+        || av.startTimeHours * 60 + av.startTimeMinutes !== action.availability.time1
+        || av.endTimeHours * 60 + av.endTimeMinutes !== action.availability.time2);
+    case UPDATE_AVAILABILITY: {
+      const { time1, time2 } = action.availability;
+      return state.map((av) => ((av.available !== action.availability.available
+        || av.dayOfWeek !== action.availability.dayOfWeek
+        || (av.startTimeHours * 60 + av.startTimeMinutes !== time1
+        && av.endTimeHours * 60 + av.endTimeMinutes !== time1))
+        ? av
+        : {
+          ...av,
+          startTimeHours: Math.floor(Math.min(time1, time2) / 60),
+          startTimeMinutes: Math.min(time1, time2) % 60,
+          endTimeHours: Math.floor(Math.max(time1, time2) / 60),
+          endTimeMinutes: Math.max(time1, time2) % 60,
+        }));
+    }
+    default:
+      return state;
+  }
+}
+
+/**
+ * Stores the currently selected availability in the schedule, so that the schedule can update
+ * the appropriate availability as the user drags
+ * @param state The previous value of `selectedAvailability`
+ * @param action The update to apply, in this case, always a `SetSelectedAvailabilityAction`
+ */
+function selectedAvailability(
+  state: AvailabilityArgs = null, action: SetSelectedAvailabilityAction,
+): AvailabilityArgs {
+  if (action.type === SET_SELECTED_AVAILABILITY) {
+    return action.availability;
+  }
+  return state;
+}
+
 // return combined reducer for entire app
 const autoSchedulerReducer = combineReducers({
   meetings,
   courseCards,
+  availabilityMode,
+  availability,
+  selectedAvailability,
 });
 
 export default autoSchedulerReducer;

--- a/autoscheduler/frontend/src/redux/reducers.ts
+++ b/autoscheduler/frontend/src/redux/reducers.ts
@@ -149,12 +149,12 @@ function availability(
                 endTimeHours: newEndHrs,
                 endTimeMinutes: newEndMins,
               };
-              if (overlapsFound === 2) {
+              if (overlapsFound >= 2) {
                 avsList.splice(oldOverlapIdx, 1);
-                avsList.push(newAv);
+                // avsList.push(newAv);
                 return avsList;
               }
-              return avsList.filter((av) => av !== oldAv).concat(newAv);
+              return avsList.filter((av) => av !== oldAv);
             }
             // if they're different types, then set the new one to the old one's borders
           }
@@ -163,7 +163,8 @@ function availability(
         avsList.push(oldAv);
         return avsList;
       }, []);
-      if (!overlapsFound) { newState.push(initNewAv); }
+      // if (!overlapsFound) { newState.push(initNewAv); }
+      newState.push(newAv);
       return newState;
     }
     case DELETE_AVAILABILITY:

--- a/autoscheduler/frontend/src/redux/reducers.ts
+++ b/autoscheduler/frontend/src/redux/reducers.ts
@@ -20,7 +20,7 @@ import Availability, { AvailabilityType, argsToAvailability, AvailabilityArgs } 
  */
 const getStart = (av: Availability): number => av.startTimeHours * 60 + av.startTimeMinutes;
 /**
- * Returns the start time of an availability, in minutes past midnight
+ * Returns the end time of an availability, in minutes past midnight
  * @param av
  */
 const getEnd = (av: Availability): number => av.endTimeHours * 60 + av.endTimeMinutes;
@@ -168,7 +168,7 @@ function availability(
       return newState;
     }
     case DELETE_AVAILABILITY:
-      // filters the availability list for the availabiltiy matching the action args
+      // filters the availability list for the availability matching the action args
       return state.filter((av) => time1And2Mismatch(av, action.availability));
     case UPDATE_AVAILABILITY: {
       const { time1, time2 } = action.availability;

--- a/autoscheduler/frontend/src/redux/reducers.ts
+++ b/autoscheduler/frontend/src/redux/reducers.ts
@@ -151,12 +151,11 @@ function availability(
                 endTimeMinutes: newEndMins,
               };
               if (overlapsFound === 2) {
-                avsList.slice(0, oldOverlapIdx)
-                  .push(...avsList.slice(oldOverlapIdx + 1), newAv);
+                avsList.splice(oldOverlapIdx, 1);
+                avsList.push(newAv);
                 return avsList;
               }
-              avsList.filter((av) => av !== oldAv).push(newAv);
-              return avsList;
+              return avsList.filter((av) => av !== oldAv).concat(newAv);
             }
             // if they're different types, then set the new one to the old one's borders
             // TODO

--- a/autoscheduler/frontend/src/redux/reducers.ts
+++ b/autoscheduler/frontend/src/redux/reducers.ts
@@ -158,7 +158,6 @@ function availability(
               return avsList.filter((av) => av !== oldAv).concat(newAv);
             }
             // if they're different types, then set the new one to the old one's borders
-            // TODO
           }
         }
         // if no overlap

--- a/autoscheduler/frontend/src/redux/reducers.ts
+++ b/autoscheduler/frontend/src/redux/reducers.ts
@@ -122,10 +122,9 @@ function availability(
       let overlapsFound = 0; // counts merging overlaps only
       let overlapIdx = -1;
 
-      const initNewAv = action.type === ADD_AVAILABILITY
+      let newAv = action.type === ADD_AVAILABILITY
         ? argsToAvailability(action.availability)
         : state[state.length - 1];
-      let newAv = initNewAv;
       const newState = state.reduce<Availability[]>((avsList, oldAv, idx): Availability[] => {
         // only counts as an overlap if they're on the same day of the week
         if (oldAv.dayOfWeek === newAv.dayOfWeek) {
@@ -149,11 +148,7 @@ function availability(
                 endTimeHours: newEndHrs,
                 endTimeMinutes: newEndMins,
               };
-              if (overlapsFound === 2) {
-                avsList.splice(oldOverlapIdx, 1);
-                return avsList;
-              }
-              return avsList.filter((av) => av !== oldAv);
+              return avsList;
             }
             // if they're different types, then set the new one to the old one's borders
           }

--- a/autoscheduler/frontend/src/tests/Redux.test.ts
+++ b/autoscheduler/frontend/src/tests/Redux.test.ts
@@ -4,16 +4,12 @@ import autoSchedulerReducer from '../redux/reducers';
 import {
   addMeeting, removeMeeting, replaceMeetings,
   addCourseCard, removeCourseCard, updateCourseCard,
-  addAvailability,
-  deleteAvailability,
-  updateAvailability,
 } from '../redux/actions';
 import Section from '../types/Section';
 import Instructor from '../types/Instructor';
 import Meeting, { MeetingType } from '../types/Meeting';
 import { CustomizationLevel } from '../types/CourseCardOptions';
 import 'isomorphic-fetch';
-import Availability, { AvailabilityType, argsToAvailability } from '../types/Availability';
 
 const testSection = new Section({
   id: 123456,
@@ -187,153 +183,4 @@ test('Updates course card boolean field', () => {
 
   // assert
   expect(store.getState().courseCards[0].web).toBeTruthy();
-});
-
-test('Merges overlapping availabilities of same type', () => {
-  // arrange
-  const store = createStore(autoSchedulerReducer);
-
-  // act
-  store.dispatch(addAvailability({
-    available: AvailabilityType.BUSY,
-    dayOfWeek: 2,
-    time1: 8 * 60 + 0,
-    time2: 12 * 60 + 0,
-  }));
-  store.dispatch(addAvailability({
-    available: AvailabilityType.BUSY,
-    dayOfWeek: 2,
-    time1: 11 * 60 + 30,
-    time2: 13 * 60 + 42,
-  }));
-
-  // assert
-  expect(store.getState().availability).toEqual([{
-    available: AvailabilityType.BUSY,
-    dayOfWeek: 2,
-    startTimeHours: 8,
-    startTimeMinutes: 0,
-    endTimeHours: 13,
-    endTimeMinutes: 42,
-  }]);
-});
-
-test('Doesn\'t merge non-overlapping availabilities', () => {
-  // arrange
-  const store = createStore(autoSchedulerReducer);
-  const availability1 = {
-    available: AvailabilityType.BUSY,
-    dayOfWeek: 2,
-    time1: 8 * 60 + 0,
-    time2: 12 * 60 + 0,
-  };
-  const availability2 = {
-    available: AvailabilityType.BUSY,
-    dayOfWeek: 2,
-    time1: 12 * 60 + 30,
-    time2: 13 * 60 + 42,
-  };
-
-  // act
-  store.dispatch(addAvailability(availability1));
-  store.dispatch(addAvailability(availability2));
-
-  // assert
-  expect(store.getState().availability).toEqual(
-    [argsToAvailability(availability1), argsToAvailability(availability2)],
-  );
-});
-
-test('Merging availabilities works with overlaps on both ends', () => {
-  // arrange
-  const store = createStore(autoSchedulerReducer);
-
-  // act
-  store.dispatch(addAvailability({
-    available: AvailabilityType.BUSY,
-    dayOfWeek: 2,
-    time1: 11 * 60 + 30,
-    time2: 13 * 60 + 42,
-  }));
-  store.dispatch(addAvailability({
-    available: AvailabilityType.BUSY,
-    dayOfWeek: 2,
-    time1: 7 * 60 + 0,
-    time2: 8 * 60 + 30,
-  }));
-  store.dispatch(addAvailability({
-    available: AvailabilityType.BUSY,
-    dayOfWeek: 2,
-    time1: 8 * 60 + 0,
-    time2: 12 * 60 + 0,
-  }));
-
-  // assert
-  expect(store.getState().availability).toEqual([{
-    available: AvailabilityType.BUSY,
-    dayOfWeek: 2,
-    startTimeHours: 7,
-    startTimeMinutes: 0,
-    endTimeHours: 13,
-    endTimeMinutes: 42,
-  }]);
-});
-
-test('Deletes availability', () => {
-  // arrange
-  const store = createStore(autoSchedulerReducer);
-
-  // act
-  store.dispatch(addAvailability({
-    available: AvailabilityType.BUSY,
-    dayOfWeek: 2,
-    time1: 8 * 60 + 0,
-    time2: 12 * 60 + 0,
-  }));
-  const intermediateState = store.getState().availability;
-  store.dispatch(deleteAvailability({
-    available: AvailabilityType.BUSY,
-    dayOfWeek: 2,
-    time1: 8 * 60 + 0,
-    time2: 12 * 60 + 0,
-  }));
-
-  // assert
-  expect(intermediateState).toHaveLength(1);
-  expect(store.getState().availability).toHaveLength(0);
-});
-
-test('Updates availability', () => {
-  // arrange
-  const store = createStore(autoSchedulerReducer);
-
-  // act
-  store.dispatch(addAvailability({
-    available: AvailabilityType.BUSY,
-    dayOfWeek: 2,
-    time1: 8 * 60,
-    time2: 9 * 60,
-  }));
-  store.dispatch(updateAvailability({
-    available: AvailabilityType.BUSY,
-    dayOfWeek: 2,
-    time1: 8 * 60,
-    time2: 8 * 60 + 50,
-  }));
-  store.dispatch(updateAvailability({
-    available: AvailabilityType.BUSY,
-    dayOfWeek: 2,
-    time1: 8 * 60 + 50,
-    time2: 8 * 60 + 20,
-  }));
-
-  // assert
-  expect(store.getState().availability).toEqual<Availability[]>([{
-    available: AvailabilityType.BUSY,
-    dayOfWeek: 2,
-    startTimeHours: 8,
-    startTimeMinutes: 20,
-    endTimeHours: 8,
-    endTimeMinutes: 50,
-  }]);
 });

--- a/autoscheduler/frontend/src/tests/Redux.test.ts
+++ b/autoscheduler/frontend/src/tests/Redux.test.ts
@@ -279,7 +279,7 @@ test('Merging availabilities works with overlaps on both ends', () => {
   }]);
 });
 
-test('Deletes availbility', () => {
+test('Deletes availability', () => {
   // arrange
   const store = createStore(autoSchedulerReducer);
 

--- a/autoscheduler/frontend/src/tests/Redux.test.ts
+++ b/autoscheduler/frontend/src/tests/Redux.test.ts
@@ -2,13 +2,18 @@ import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import autoSchedulerReducer from '../redux/reducers';
 import {
-  addMeeting, removeMeeting, replaceMeetings, addCourseCard, removeCourseCard, updateCourseCard,
+  addMeeting, removeMeeting, replaceMeetings,
+  addCourseCard, removeCourseCard, updateCourseCard,
+  addAvailability,
+  deleteAvailability,
+  updateAvailability,
 } from '../redux/actions';
 import Section from '../types/Section';
 import Instructor from '../types/Instructor';
 import Meeting, { MeetingType } from '../types/Meeting';
 import { CustomizationLevel } from '../types/CourseCardOptions';
 import 'isomorphic-fetch';
+import Availability, { AvailabilityType, argsToAvailability } from '../types/Availability';
 
 const testSection = new Section({
   id: 123456,
@@ -182,4 +187,153 @@ test('Updates course card boolean field', () => {
 
   // assert
   expect(store.getState().courseCards[0].web).toBeTruthy();
+});
+
+test('Merges overlapping availabilities of same type', () => {
+  // arrange
+  const store = createStore(autoSchedulerReducer);
+
+  // act
+  store.dispatch(addAvailability({
+    available: AvailabilityType.BUSY,
+    dayOfWeek: 2,
+    time1: 8 * 60 + 0,
+    time2: 12 * 60 + 0,
+  }));
+  store.dispatch(addAvailability({
+    available: AvailabilityType.BUSY,
+    dayOfWeek: 2,
+    time1: 11 * 60 + 30,
+    time2: 13 * 60 + 42,
+  }));
+
+  // assert
+  expect(store.getState().availability).toEqual([{
+    available: AvailabilityType.BUSY,
+    dayOfWeek: 2,
+    startTimeHours: 8,
+    startTimeMinutes: 0,
+    endTimeHours: 13,
+    endTimeMinutes: 42,
+  }]);
+});
+
+test('Doesn\'t merge non-overlapping availabilities', () => {
+  // arrange
+  const store = createStore(autoSchedulerReducer);
+  const availability1 = {
+    available: AvailabilityType.BUSY,
+    dayOfWeek: 2,
+    time1: 8 * 60 + 0,
+    time2: 12 * 60 + 0,
+  };
+  const availability2 = {
+    available: AvailabilityType.BUSY,
+    dayOfWeek: 2,
+    time1: 12 * 60 + 30,
+    time2: 13 * 60 + 42,
+  };
+
+  // act
+  store.dispatch(addAvailability(availability1));
+  store.dispatch(addAvailability(availability2));
+
+  // assert
+  expect(store.getState().availability).toEqual(
+    [argsToAvailability(availability1), argsToAvailability(availability2)],
+  );
+});
+
+test('Merging availabilities works with overlaps on both ends', () => {
+  // arrange
+  const store = createStore(autoSchedulerReducer);
+
+  // act
+  store.dispatch(addAvailability({
+    available: AvailabilityType.BUSY,
+    dayOfWeek: 2,
+    time1: 11 * 60 + 30,
+    time2: 13 * 60 + 42,
+  }));
+  store.dispatch(addAvailability({
+    available: AvailabilityType.BUSY,
+    dayOfWeek: 2,
+    time1: 7 * 60 + 0,
+    time2: 8 * 60 + 30,
+  }));
+  store.dispatch(addAvailability({
+    available: AvailabilityType.BUSY,
+    dayOfWeek: 2,
+    time1: 8 * 60 + 0,
+    time2: 12 * 60 + 0,
+  }));
+
+  // assert
+  expect(store.getState().availability).toEqual([{
+    available: AvailabilityType.BUSY,
+    dayOfWeek: 2,
+    startTimeHours: 7,
+    startTimeMinutes: 0,
+    endTimeHours: 13,
+    endTimeMinutes: 42,
+  }]);
+});
+
+test('Deletes availbility', () => {
+  // arrange
+  const store = createStore(autoSchedulerReducer);
+
+  // act
+  store.dispatch(addAvailability({
+    available: AvailabilityType.BUSY,
+    dayOfWeek: 2,
+    time1: 8 * 60 + 0,
+    time2: 12 * 60 + 0,
+  }));
+  const intermediateState = store.getState().availability;
+  store.dispatch(deleteAvailability({
+    available: AvailabilityType.BUSY,
+    dayOfWeek: 2,
+    time1: 8 * 60 + 0,
+    time2: 12 * 60 + 0,
+  }));
+
+  // assert
+  expect(intermediateState).toHaveLength(1);
+  expect(store.getState().availability).toHaveLength(0);
+});
+
+test('Updates availability', () => {
+  // arrange
+  const store = createStore(autoSchedulerReducer);
+
+  // act
+  store.dispatch(addAvailability({
+    available: AvailabilityType.BUSY,
+    dayOfWeek: 2,
+    time1: 8 * 60,
+    time2: 9 * 60,
+  }));
+  store.dispatch(updateAvailability({
+    available: AvailabilityType.BUSY,
+    dayOfWeek: 2,
+    time1: 8 * 60,
+    time2: 8 * 60 + 50,
+  }));
+  store.dispatch(updateAvailability({
+    available: AvailabilityType.BUSY,
+    dayOfWeek: 2,
+    time1: 8 * 60 + 50,
+    time2: 8 * 60 + 20,
+  }));
+
+  // assert
+  expect(store.getState().availability).toEqual<Availability[]>([{
+    available: AvailabilityType.BUSY,
+    dayOfWeek: 2,
+    startTimeHours: 8,
+    startTimeMinutes: 20,
+    endTimeHours: 8,
+    endTimeMinutes: 50,
+  }]);
 });

--- a/autoscheduler/frontend/src/tests/ReduxAvailability.test.tsx
+++ b/autoscheduler/frontend/src/tests/ReduxAvailability.test.tsx
@@ -4,9 +4,10 @@ import {
   addAvailability,
   deleteAvailability,
   updateAvailability,
+  mergeAvailability,
 } from '../redux/actions';
 import 'isomorphic-fetch';
-import { AvailabilityType, argsToAvailability } from '../types/Availability';
+import Availability, { AvailabilityType, argsToAvailability } from '../types/Availability';
 import DayOfWeek from '../types/DayOfWeek';
 
 /**
@@ -80,6 +81,50 @@ describe('Availabilities', () => {
       store.dispatch(addAvailability(availability1));
       store.dispatch(addAvailability(availability2));
       store.dispatch(addAvailability(availability3));
+
+      // assert
+      expect(store.getState().availability).toEqual(expected);
+    });
+
+    test('only once when 3 or more coincide', () => {
+      // arrange
+      const store = createStore(autoSchedulerReducer);
+      const availability1 = {
+        ...dummyArgs,
+        time1: makeTime(13, 0),
+        time2: makeTime(14, 0),
+      };
+      const availability2 = {
+        ...dummyArgs,
+        time1: makeTime(15, 0),
+        time2: makeTime(16, 0),
+      };
+      const availability3 = {
+        ...dummyArgs,
+        time1: makeTime(12, 0),
+        time2: makeTime(12, 0),
+      };
+      const availability3New = {
+        ...dummyArgs,
+        time1: makeTime(12, 0),
+        time2: makeTime(15, 30),
+      };
+      const expected: Availability[] = [
+        {
+          ...dummyArgs,
+          startTimeHours: 12,
+          startTimeMinutes: 0,
+          endTimeHours: 16,
+          endTimeMinutes: 0,
+        },
+      ];
+
+      // act
+      store.dispatch(addAvailability(availability1));
+      store.dispatch(addAvailability(availability2));
+      store.dispatch(addAvailability(availability3));
+      store.dispatch(updateAvailability(availability3New));
+      store.dispatch(mergeAvailability());
 
       // assert
       expect(store.getState().availability).toEqual(expected);

--- a/autoscheduler/frontend/src/tests/ReduxAvailability.test.tsx
+++ b/autoscheduler/frontend/src/tests/ReduxAvailability.test.tsx
@@ -101,15 +101,39 @@ describe('Availabilities', () => {
       };
       const availability3 = {
         ...dummyArgs,
+        time1: makeTime(17, 0),
+        time2: makeTime(17, 30),
+      };
+      const availability4 = {
+        ...dummyArgs,
+        time1: makeTime(18, 0),
+        time2: makeTime(18, 30),
+      };
+      const availability5 = {
+        ...dummyArgs,
         time1: makeTime(12, 0),
         time2: makeTime(12, 0),
       };
-      const availability3New = {
+      const availability5New = {
         ...dummyArgs,
         time1: makeTime(12, 0),
         time2: makeTime(15, 30),
       };
       const expected: Availability[] = [
+        {
+          ...dummyArgs,
+          startTimeHours: 17,
+          startTimeMinutes: 0,
+          endTimeHours: 17,
+          endTimeMinutes: 30,
+        },
+        {
+          ...dummyArgs,
+          startTimeHours: 18,
+          startTimeMinutes: 0,
+          endTimeHours: 18,
+          endTimeMinutes: 30,
+        },
         {
           ...dummyArgs,
           startTimeHours: 12,
@@ -123,7 +147,9 @@ describe('Availabilities', () => {
       store.dispatch(addAvailability(availability1));
       store.dispatch(addAvailability(availability2));
       store.dispatch(addAvailability(availability3));
-      store.dispatch(updateAvailability(availability3New));
+      store.dispatch(addAvailability(availability4));
+      store.dispatch(addAvailability(availability5));
+      store.dispatch(updateAvailability(availability5New));
       store.dispatch(mergeAvailability());
 
       // assert

--- a/autoscheduler/frontend/src/tests/ReduxAvailability.test.tsx
+++ b/autoscheduler/frontend/src/tests/ReduxAvailability.test.tsx
@@ -1,0 +1,164 @@
+import { createStore } from 'redux';
+import autoSchedulerReducer from '../redux/reducers';
+import {
+  addAvailability,
+  deleteAvailability,
+  updateAvailability,
+} from '../redux/actions';
+import 'isomorphic-fetch';
+import Availability, { AvailabilityType, argsToAvailability } from '../types/Availability';
+import DayOfWeek from '../types/DayOfWeek';
+
+/**
+ * Converts a pair of hours and minutes into a number of minutes past midnight
+ */
+const makeTime = (h: number, m: number): number => h * 60 + m;
+/**
+ * Makes availabilities "Busy on Wednesday", since that part isn't being tested
+ */
+const dummyArgs = {
+  available: AvailabilityType.BUSY,
+  dayOfWeek: DayOfWeek.WED,
+};
+describe('Availabilities', () => {
+  describe('of the same type are merged', () => {
+    test('with an overlap on one end', () => {
+      // arrange
+      const store = createStore(autoSchedulerReducer);
+      const availability1 = {
+        ...dummyArgs,
+        time1: makeTime(8, 0),
+        time2: makeTime(12, 0),
+      };
+      const availability2 = {
+        ...dummyArgs,
+        time1: makeTime(11, 30),
+        time2: makeTime(13, 42),
+      };
+
+      // act
+      store.dispatch(addAvailability(availability1));
+      store.dispatch(addAvailability(availability2));
+
+      // assert
+      expect(store.getState().availability).toEqual([{
+        available: AvailabilityType.BUSY,
+        dayOfWeek: DayOfWeek.WED,
+        startTimeHours: 8,
+        startTimeMinutes: 0,
+        endTimeHours: 13,
+        endTimeMinutes: 42,
+      }]);
+    });
+    test('with overlaps on both ends', () => {
+      // arrange
+      const store = createStore(autoSchedulerReducer);
+      const availability1 = {
+        ...dummyArgs,
+        time1: makeTime(11, 30),
+        time2: makeTime(13, 42),
+      };
+      const availability2 = {
+        ...dummyArgs,
+        time1: makeTime(7, 0),
+        time2: makeTime(8, 30),
+      };
+      const availability3 = {
+        available: AvailabilityType.BUSY,
+        dayOfWeek: DayOfWeek.WED,
+        time1: makeTime(8, 0),
+        time2: makeTime(12, 0),
+      };
+
+      // act
+      store.dispatch(addAvailability(availability1));
+      store.dispatch(addAvailability(availability2));
+      store.dispatch(addAvailability(availability3));
+
+      // assert
+      expect(store.getState().availability).toEqual([{
+        available: AvailabilityType.BUSY,
+        dayOfWeek: DayOfWeek.WED,
+        startTimeHours: 7,
+        startTimeMinutes: 0,
+        endTimeHours: 13,
+        endTimeMinutes: 42,
+      }]);
+    });
+  });
+
+  test('that don\'t overlap are not merged', () => {
+    // arrange
+    const store = createStore(autoSchedulerReducer);
+    const availability1 = {
+      ...dummyArgs,
+      time1: makeTime(8, 0),
+      time2: makeTime(12, 0),
+    };
+    const availability2 = {
+      ...dummyArgs,
+      time1: makeTime(12, 30),
+      time2: makeTime(13, 42),
+    };
+
+    // act
+    store.dispatch(addAvailability(availability1));
+    store.dispatch(addAvailability(availability2));
+
+    // assert
+    expect(store.getState().availability).toEqual(
+      [argsToAvailability(availability1), argsToAvailability(availability2)],
+    );
+  });
+
+  test('are deleted', () => {
+    // arrange
+    const store = createStore(autoSchedulerReducer);
+    const availability1 = {
+      ...dummyArgs,
+      time1: makeTime(8, 0),
+      time2: makeTime(12, 0),
+    };
+
+    // act
+    store.dispatch(addAvailability(availability1));
+    const intermediateState = store.getState().availability;
+    store.dispatch(deleteAvailability(availability1));
+
+    // assert
+    expect(intermediateState).toHaveLength(1);
+    expect(store.getState().availability).toHaveLength(0);
+  });
+
+  test('are updated', () => {
+    // arrange
+    const store = createStore(autoSchedulerReducer);
+    const availability1 = {
+      ...dummyArgs,
+      time1: makeTime(8, 0),
+      time2: makeTime(9, 0),
+    };
+
+    // act
+    store.dispatch(addAvailability(availability1));
+    store.dispatch(updateAvailability({
+      ...availability1,
+      time2: makeTime(8, 50),
+    }));
+    store.dispatch(updateAvailability({
+      ...dummyArgs,
+      time1: makeTime(8, 50),
+      time2: makeTime(8, 20),
+    }));
+
+    // assert
+    expect(store.getState().availability).toEqual<Availability[]>([{
+      available: AvailabilityType.BUSY,
+      dayOfWeek: DayOfWeek.WED,
+      startTimeHours: 8,
+      startTimeMinutes: 20,
+      endTimeHours: 8,
+      endTimeMinutes: 50,
+    }]);
+  });
+});

--- a/autoscheduler/frontend/src/tests/ReduxAvailability.test.tsx
+++ b/autoscheduler/frontend/src/tests/ReduxAvailability.test.tsx
@@ -35,7 +35,7 @@ describe('Availabilities', () => {
         time1: makeTime(11, 30),
         time2: makeTime(13, 42),
       };
-      const mergedAvailability = [{
+      const expected = [{
         ...dummyArgs,
         startTimeHours: 8,
         startTimeMinutes: 0,
@@ -48,7 +48,7 @@ describe('Availabilities', () => {
       store.dispatch(addAvailability(availability2));
 
       // assert
-      expect(store.getState().availability).toEqual(mergedAvailability);
+      expect(store.getState().availability).toEqual(expected);
     });
     test('with overlaps on both ends', () => {
       // arrange
@@ -68,7 +68,7 @@ describe('Availabilities', () => {
         time1: makeTime(8, 0),
         time2: makeTime(12, 0),
       };
-      const mergedAvailability = [{
+      const expected = [{
         ...dummyArgs,
         startTimeHours: 7,
         startTimeMinutes: 0,
@@ -82,7 +82,7 @@ describe('Availabilities', () => {
       store.dispatch(addAvailability(availability3));
 
       // assert
-      expect(store.getState().availability).toEqual(mergedAvailability);
+      expect(store.getState().availability).toEqual(expected);
     });
   });
 

--- a/autoscheduler/frontend/src/types/Availability.ts
+++ b/autoscheduler/frontend/src/types/Availability.ts
@@ -1,0 +1,38 @@
+export enum AvailabilityType {
+  NONE, BUSY
+}
+
+export default interface Availability {
+  dayOfWeek: number;
+  startTimeHours: number;
+  startTimeMinutes: number;
+  endTimeHours: number;
+  endTimeMinutes: number;
+  available: AvailabilityType;
+// eslint-disable-next-line semi
+}
+
+export interface AvailabilityArgs {
+  dayOfWeek: number;
+  time1: number;
+  time2: number;
+  available: AvailabilityType;
+}
+
+export function argsToAvailability(avArgs: AvailabilityArgs): Availability {
+  const startTime = Math.min(avArgs.time1, avArgs.time2);
+  const startTimeHours = Math.floor(startTime / 60);
+  const startTimeMinutes = startTime % 60;
+  const endTime = Math.max(avArgs.time1, avArgs.time2);
+  const endTimeHours = Math.floor(endTime / 60);
+  const endTimeMinutes = endTime % 60;
+
+  return {
+    dayOfWeek: avArgs.dayOfWeek,
+    available: avArgs.available,
+    startTimeHours,
+    startTimeMinutes,
+    endTimeHours,
+    endTimeMinutes,
+  };
+}

--- a/autoscheduler/frontend/src/types/Availability.ts
+++ b/autoscheduler/frontend/src/types/Availability.ts
@@ -4,6 +4,10 @@ export enum AvailabilityType {
   NONE, BUSY
 }
 
+/**
+ * A block of availability, which occurs on a particular day of the week, from a specific start
+ * time to a specific end time, and is of one of the valid `AvailabilityType`s
+ */
 export default interface Availability {
   dayOfWeek: DayOfWeek;
   startTimeHours: number;
@@ -13,6 +17,12 @@ export default interface Availability {
   available: AvailabilityType;
 }
 
+/**
+ * Represents arguments passed to an availability action to describe a block of availability.
+ * The primary difference between this and `Availability` is that the start time and end time
+ * are passed as `time1` and `time2`, which are measured in minutes past midnight and
+ * interpreted flexibly by the reducer.
+ */
 export interface AvailabilityArgs {
   dayOfWeek: DayOfWeek;
   time1: number;
@@ -20,6 +30,11 @@ export interface AvailabilityArgs {
   available: AvailabilityType;
 }
 
+/**
+ * Converts a set of `AvailabilityArgs` to an `Availability` object, assuming that
+ * `time1` is the start time and `time2` is the end time.
+ * @param avArgs
+ */
 export function argsToAvailability(avArgs: AvailabilityArgs): Availability {
   const startTime = Math.min(avArgs.time1, avArgs.time2);
   const startTimeHours = Math.floor(startTime / 60);

--- a/autoscheduler/frontend/src/types/Availability.ts
+++ b/autoscheduler/frontend/src/types/Availability.ts
@@ -1,19 +1,20 @@
+import DayOfWeek from './DayOfWeek';
+
 export enum AvailabilityType {
   NONE, BUSY
 }
 
 export default interface Availability {
-  dayOfWeek: number;
+  dayOfWeek: DayOfWeek;
   startTimeHours: number;
   startTimeMinutes: number;
   endTimeHours: number;
   endTimeMinutes: number;
   available: AvailabilityType;
-// eslint-disable-next-line semi
 }
 
 export interface AvailabilityArgs {
-  dayOfWeek: number;
+  dayOfWeek: DayOfWeek;
   time1: number;
   time2: number;
   available: AvailabilityType;

--- a/autoscheduler/frontend/src/types/DayOfWeek.ts
+++ b/autoscheduler/frontend/src/types/DayOfWeek.ts
@@ -1,0 +1,5 @@
+enum DayOfWeek {
+    MON, TUE, WED, THU, FRI, SAT, SUN
+}
+
+export default DayOfWeek;


### PR DESCRIPTION
"Squashed" all of the Redux updates for availability input into one separate PR. Now that I think about it, I think one of the benefits of Redux is supposed to be isolation of logic from UI, which I guess is coming in handy now.

"Squash" is in quotes because I actually just used `git checkout frontend/availability redux/`, which has effectively the same result.