### PR TITLE
Section API Fixes

### DIFF
--- a/autoscheduler/scraper/serializers.py
+++ b/autoscheduler/scraper/serializers.py
@@ -1,6 +1,11 @@
+from datetime import time
 from rest_framework import serializers
+from time import strftime
 from .models.course import Course
 from .models.section import Section, Meeting
+
+def format_time(t: time) -> str:
+    return '' if t is None else t.strftime('%H:%M')
 
 class CourseSerializer(serializers.ModelSerializer):
     """ Serializes a course into an object with information needed by /api/course """
@@ -32,7 +37,7 @@ class SectionSerializer(serializers.ModelSerializer):
         return [{
             'id': str(meeting.id),
             'days': meeting.meeting_days,
-            'start_time': meeting.start_time,
-            'end_time': meeting.end_time,
+            'start_time': format_time(meeting.start_time),
+            'end_time': format_time(meeting.end_time),
             'type': meeting.meeting_type,
         } for meeting in meetings]

--- a/autoscheduler/scraper/serializers.py
+++ b/autoscheduler/scraper/serializers.py
@@ -1,11 +1,11 @@
 from datetime import time
 from rest_framework import serializers
-from time import strftime
 from .models.course import Course
 from .models.section import Section, Meeting
 
-def format_time(t: time) -> str:
-    return '' if t is None else t.strftime('%H:%M')
+def format_time(time_obj: time) -> str:
+    """ Formats a time object to a string HH:MM, for use with section serializer """
+    return '' if time_obj is None else time_obj.strftime('%H:%M')
 
 class CourseSerializer(serializers.ModelSerializer):
     """ Serializes a course into an object with information needed by /api/course """

--- a/autoscheduler/scraper/tests/api_tests.py
+++ b/autoscheduler/scraper/tests/api_tests.py
@@ -1,10 +1,7 @@
 from datetime import time
 from rest_framework.test import APITestCase, APIClient
-from scraper.models.course import Course
-from scraper.models.department import Department
-from scraper.models.instructor import Instructor
-from scraper.models.section import Section, Meeting
-from scraper.serializers import CourseSerializer, SectionSerializer
+from scraper.models import Course, Department, Instructor, Meeting, Section
+from scraper.serializers import CourseSerializer, SectionSerializer, format_time
 
 class APITests(APITestCase):
     """ Tests API functionality """
@@ -130,6 +127,62 @@ class APITests(APITestCase):
         # Assert
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), expected)
+
+    def test_api_section_serializer_format_time_handles_null(self):
+        """ Tests that the section serializer's format_time(time) function handles
+            a None time
+        """
+        # Arrange
+        test_time = None
+        expected = ''
+
+        # Act
+        result = format_time(test_time)
+
+        # Assert
+        self.assertEqual(expected, result)
+
+    def test_api_section_serializer_format_time_handles_hour(self):
+        """ Tests that the section serializer's format_time(time) function handles
+            a time with 0 minutes
+        """
+        # Arrange
+        test_time = time(10)
+        expected = '10:00'
+
+        # Act
+        result = format_time(test_time)
+
+        # Assert
+        self.assertEqual(expected, result)
+
+    def test_api_section_serializer_format_time_handles_leading_zero(self):
+        """ Tests that the section serializer's format_time(time) function pads zeroes
+            to a time with hour < 10 (ex. time(9) -> '09:00'
+        """
+        # Arrange
+        test_time = time(9)
+        expected = '09:00'
+
+        # Act
+        result = format_time(test_time)
+
+        # Assert
+        self.assertEqual(expected, result)
+
+    def test_api_section_serializer_format_time_handles_minutes(self):
+        """ Tests that the section serializer's format_time(time) function formats
+            minutes correctly
+        """
+        # Arrange
+        test_time = time(9, 10)
+        expected = '09:10'
+
+        # Act
+        result = format_time(test_time)
+
+        # Assert
+        self.assertEqual(expected, result)
 
     def test_api_section_serializer_gives_expected_output(self):
         """ Tests that the section serializer yields the correct data """

--- a/autoscheduler/scraper/tests/api_tests.py
+++ b/autoscheduler/scraper/tests/api_tests.py
@@ -134,10 +134,10 @@ class APITests(APITestCase):
     def test_api_section_serializer_gives_expected_output(self):
         """ Tests that the section serializer yields the correct data """
         # Arrange
-        first_start = time(11, 30)
-        first_end = time(12, 20)
-        second_start = time(9, 10)
-        second_end = time(10)
+        first_start = '11:30'
+        first_end = '12:20'
+        second_start = '09:10'
+        second_end = '10:00'
         meeting_days = [True] * 7
         expected = {
             'id': 1,
@@ -175,10 +175,10 @@ class APITests(APITestCase):
             correct output
         """
         # Arrange
-        first_start = time(11, 30)
-        first_end = time(12, 20)
-        second_start = time(9, 10)
-        second_end = time(10)
+        first_start = '11:30'
+        first_end = '12:20'
+        second_start = '09:10'
+        second_end = '10:00'
         meeting_days_true = [True] * 7
         meeting_days_false = [False] * 7
         expected = [
@@ -196,7 +196,7 @@ class APITests(APITestCase):
                         'type': 'LEC',
                     },
                     {
-                        'id': '20',
+                        'id': '11',
                         'days': meeting_days_true,
                         'start_time': second_start,
                         'end_time': second_end,


### PR DESCRIPTION
Fixed the expected formatting in section API tests, and changed `SectionSerializer` to format time objects correctly. I'd like @btgathright to review these changes and make sure everything is okay