### PR TITLE
Scraper API Term & Course Search

### DIFF
--- a/autoscheduler/scraper/models/course.py
+++ b/autoscheduler/scraper/models/course.py
@@ -8,7 +8,7 @@ def generate_course_id(dept: str, course_num: str, term: str):
 class Course(models.Model):
     """ Basic course model """
 
-    id = models.CharField(max_length=15, primary_key=True) # Could be dept+course_num
+    id = models.CharField(max_length=15, primary_key=True) # i.e ACCT628-201931
     dept = models.CharField(max_length=4, db_index=True) # CSCE
     course_num = models.CharField(max_length=5, db_index=True) # i.e. 314
     title = models.CharField(max_length=100) # Course title, i.e. "Programming Languages"

--- a/autoscheduler/scraper/serializers.py
+++ b/autoscheduler/scraper/serializers.py
@@ -1,41 +1,6 @@
 from rest_framework import serializers
 from scraper.models import Course, Section, Meeting, Department
 
-class CourseSerializer(serializers.ModelSerializer):
-    """ Serializes a course into an object with information needed by /api/course """
-    class Meta:
-        model = Course
-        fields = ['title', 'credit_hours']
-
-class SectionSerializer(serializers.ModelSerializer):
-    """ Serializes a section into an object with information needed by /api/sections """
-    instructor_name = serializers.SerializerMethodField()
-    meetings = serializers.SerializerMethodField()
-
-    class Meta:
-        model = Section
-        fields = ['id', 'crn', 'instructor_name', 'honors', 'meetings',
-                  'section_num', 'web']
-
-    def get_instructor_name(self, obj): # pylint: disable=no-self-use
-        """ Get the name (id) of this section's instructor.
-            This function is used to compute the value of the instructor_name field.
-        """
-        return obj.instructor.id
-
-    def get_meetings(self, obj): # pylint: disable=no-self-use
-        """ Gets meeting information for this section
-            This function is used to compute the value of the meetings field.
-        """
-        meetings = Meeting.objects.filter(section__id=obj.id)
-        return [{
-            'id': str(meeting.id),
-            'days': meeting.meeting_days,
-            'start_time': meeting.start_time,
-            'end_time': meeting.end_time,
-            'type': meeting.meeting_type,
-        } for meeting in meetings]
-
 class TermSerializer(serializers.ModelSerializer):
     """ Serializes a department into an object with information needed by /api/terms """
     desc = serializers.SerializerMethodField()
@@ -94,5 +59,5 @@ class CourseSearchSerializer(serializers.ModelSerializer):
         fields = ['course']
 
     def get_course(self, obj):
-        """ Gets list of items in for dept course i.e CSCE 121"""
-        return obj.dept + " " + obj.course_num
+        """ Gets list of items in for dept course i.e CSCE 121 """
+        return f"{obj.dept} {obj.course_num}"

--- a/autoscheduler/scraper/serializers.py
+++ b/autoscheduler/scraper/serializers.py
@@ -36,7 +36,7 @@ class TermSerializer(serializers.ModelSerializer):
         fields = ['term', 'desc']
 
 
-    def get_desc(self, obj):
+    def get_desc(self, obj): # pylint: disable=no-self-use
         """ Uses term field to generate description for the term in the
             format "Fall - College Station"
         """
@@ -57,6 +57,6 @@ class CourseSearchSerializer(serializers.ModelSerializer):
         model = Course
         fields = ['course']
 
-    def get_course(self, obj):
+    def get_course(self, obj): # pylint: disable=no-self-use
         """ Gets list of items in for dept course i.e CSCE 121 """
         return f"{obj.dept} {obj.course_num}"

--- a/autoscheduler/scraper/serializers.py
+++ b/autoscheduler/scraper/serializers.py
@@ -1,5 +1,45 @@
+from datetime import time
 from rest_framework import serializers
 from scraper.models import Course, Section, Meeting, Department
+
+def format_time(time_obj: time) -> str:
+    """ Formats a time object to a string HH:MM, for use with section serializer """
+    return '' if time_obj is None else time_obj.strftime('%H:%M')
+
+class CourseSerializer(serializers.ModelSerializer):
+    """ Serializes a course into an object with information needed by /api/course """
+    class Meta:
+        model = Course
+        fields = ['title', 'credit_hours']
+
+class SectionSerializer(serializers.ModelSerializer):
+    """ Serializes a section into an object with information needed by /api/sections """
+    instructor_name = serializers.SerializerMethodField()
+    meetings = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Section
+        fields = ['id', 'crn', 'instructor_name', 'honors', 'meetings',
+                  'section_num', 'web']
+
+    def get_instructor_name(self, obj): # pylint: disable=no-self-use
+        """ Get the name (id) of this section's instructor.
+            This function is used to compute the value of the instructor_name field.
+        """
+        return obj.instructor.id
+
+    def get_meetings(self, obj): # pylint: disable=no-self-use
+        """ Gets meeting information for this section
+            This function is used to compute the value of the meetings field.
+        """
+        meetings = Meeting.objects.filter(section__id=obj.id)
+        return [{
+            'id': str(meeting.id),
+            'days': meeting.meeting_days,
+            'start_time': format_time(meeting.start_time),
+            'end_time': format_time(meeting.end_time),
+            'type': meeting.meeting_type,
+        } for meeting in meetings]
 
 def season_num_to_string(season_num):
     """ Converts int representing season in 'term' field to a string to

--- a/autoscheduler/scraper/serializers.py
+++ b/autoscheduler/scraper/serializers.py
@@ -1,6 +1,32 @@
 from rest_framework import serializers
 from scraper.models import Course, Section, Meeting, Department
 
+def season_num_to_string(season_num):
+    """ Converts int representing season in 'term' field to a string to
+        use in get_term
+    """
+    # Put all translations here. Possibly incomplete.
+    seasons = {
+        1: "Spring",
+        2: "Summer",
+        3: "Fall",
+        4: "Full Yr Professional",
+        }
+    return seasons.get(season_num, "NO SEASON")
+
+def campus_num_to_string(campus_num):
+    """ Converts int representing campus in 'term' field to a string to
+        use in get_term
+    """
+    # Put all translations here. Possibly incomplete.
+    campus = {
+        1: "College Station",
+        2: "Galveston",
+        3: "Qatar",
+        5: "Half Year Term",
+        }
+    return campus.get(campus_num, "NO CAMPUS")
+
 class TermSerializer(serializers.ModelSerializer):
     """ Serializes a department into an object with information needed by /api/terms """
     desc = serializers.SerializerMethodField()
@@ -14,33 +40,6 @@ class TermSerializer(serializers.ModelSerializer):
         """ Uses term field to generate description for the term in the
             format "Fall - College Station"
         """
-
-        def season_num_to_string(season_num):
-            """ Converts int representing season in 'term' field to a string to
-                use in get_term
-            """
-            # Put all translations here. Possibly incomplete.
-            seasons = {
-                1: "Spring",
-                2: "Summer",
-                3: "Fall",
-                4: "Full Yr Professional",
-            }
-            return seasons.get(season_num, "NO SEASON")
-
-        def campus_num_to_string(campus_num):
-            """ Converts int representing campus in 'term' field to a string to
-                use in get_term
-            """
-            # Put all translations here. Possibly incomplete.
-            campus = {
-                1: "College Station",
-                2: "Galveston",
-                3: "Qatar",
-                5: "Half Year Term",
-            }
-            return campus.get(campus_num, "NO CAMPUS")
-
         year_string = obj.term[0:4] # Takes digits that represent year from termcode.
         season_string = season_num_to_string(int(obj.term[4]))
         if season_string == "Full Yr Professional":

--- a/autoscheduler/scraper/serializers.py
+++ b/autoscheduler/scraper/serializers.py
@@ -59,7 +59,7 @@ class TermSerializer(serializers.ModelSerializer):
                 1: "Spring",
                 2: "Summer",
                 3: "Fall",
-                4: "Winter",
+                4: "Full Yr Professional",
             }
             return seasons.get(season_num, "NO SEASON")
 
@@ -70,13 +70,17 @@ class TermSerializer(serializers.ModelSerializer):
             # Put all translations here. Possibly incomplete.
             campus = {
                 1: "College Station",
+                2: "Galveston",
+                3: "Qatar",
+                5: "Half Year Term",
             }
             return campus.get(campus_num, "NO CAMPUS")
 
         year_string = obj.term[0:4] # Takes digits that represent year from termcode.
         season_string = season_num_to_string(int(obj.term[4]))
+        if season_string == "Full Yr Professional":
+            return f"{season_string} {year_string} - {int(year_string) + 1}"
         campus_string = campus_num_to_string(int(obj.term[5]))
-        year_string = obj.term[0:4] #takes digits that represent year from termcode
         return f"{season_string} {year_string} - {campus_string}"
 
 class CourseSearchSerializer(serializers.ModelSerializer):

--- a/autoscheduler/scraper/serializers.py
+++ b/autoscheduler/scraper/serializers.py
@@ -51,8 +51,9 @@ class TermSerializer(serializers.ModelSerializer):
         """
 
         def season_num_to_string(season_num):
-            """" Converts int representing season in 'term' field to a string to
-                use in get_term """
+            """ Converts int representing season in 'term' field to a string to
+                use in get_term
+            """
             # Put all translations here. Possibly incomplete.
             seasons = {
                 1: "Spring",
@@ -63,23 +64,25 @@ class TermSerializer(serializers.ModelSerializer):
             return seasons.get(season_num, "NO SEASON")
 
         def campus_num_to_string(campus_num):
-            """" Converts int representing campus in 'term' field to a string to
-                use in get_term """
-            # put all translations here. Possibly inaccurate atm.
+            """ Converts int representing campus in 'term' field to a string to
+                use in get_term
+            """
+            # Put all translations here. Possibly incomplete.
             campus = {
                 1: "College Station",
             }
             return campus.get(campus_num, "NO CAMPUS")
 
+        year_string = obj.term[0:4] # Takes digits that represent year from termcode.
         season_string = season_num_to_string(int(obj.term[4]))
         campus_string = campus_num_to_string(int(obj.term[5]))
         year_string = obj.term[0:4] #takes digits that represent year from termcode
-        desc = season_string + " " + year_string + " - " + campus_string
-
-        return desc
+        return f"{season_string} {year_string} - {campus_string}"
 
 class CourseSearchSerializer(serializers.ModelSerializer):
-    """ Serializes a course into an object with information needed by /api/course/search """
+    """ Serializes a course into an object with information needed
+        by /api/course/search
+    """
     course = serializers.SerializerMethodField()
 
     class Meta:

--- a/autoscheduler/scraper/serializers.py
+++ b/autoscheduler/scraper/serializers.py
@@ -1,38 +1,55 @@
 from rest_framework import serializers
+from .models.department import Department
 from .models.course import Course
-from .models.section import Section, Meeting
 
-class CourseSerializer(serializers.ModelSerializer):
-    """ Serializes a course into an object with information needed by /api/course """
+class TermSerializer(serializers.ModelSerializer):
+    """ Serializes a term into an object with information needed by /api/terms """
+    desc = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Department
+        fields = ['term', 'desc']
+
+
+    def get_desc(self, obj):
+        """ Uses term field to generate description for the term in the
+            form "Fall - College Station" format"""
+
+        def season_num_to_string(season_num):
+            """" Converts int representing season in 'term' field to a string to
+                use in get_term """
+            # put all translations here. Possibly inaccurate atm.
+            seasons = {
+                1: "Spring",
+                2: "Summer",
+                3: "Fall",
+                4: "Winter",
+            }
+            return seasons.get(season_num, "NO SEASON")
+
+        def campus_num_to_string(campus_num):
+            """" Converts int representing campus in 'term' field to a string to
+                use in get_term """
+            # put all translations here. Possibly inaccurate atm.
+            campus = {
+                1: "College Station",
+            }
+            return campus.get(campus_num, "NO CAMPUS")
+
+        season_string = season_num_to_string(int(obj.term[4]))
+        campus_string = campus_num_to_string(int(obj.term[5]))
+        desc = season_string + " - " + campus_string
+
+        return desc
+
+class CourseSearchSerializer(serializers.ModelSerializer):
+    """ Serializes a course into an an with information needed by /api/terms """
+    course = serializers.SerializerMethodField()
+
     class Meta:
         model = Course
-        fields = ['title', 'credit_hours']
+        fields = ['course']
 
-class SectionSerializer(serializers.ModelSerializer):
-    """ Serializes a section into an object with information needed by /api/sections """
-    instructor_name = serializers.SerializerMethodField()
-    meetings = serializers.SerializerMethodField()
-
-    class Meta:
-        model = Section
-        fields = ['id', 'crn', 'instructor_name', 'honors', 'meetings',
-                  'section_num', 'web']
-
-    def get_instructor_name(self, obj): # pylint: disable=no-self-use
-        """ Get the name (id) of this section's instructor.
-            This function is used to compute the value of the instructor_name field.
-        """
-        return obj.instructor.id
-
-    def get_meetings(self, obj): # pylint: disable=no-self-use
-        """ Gets meeting information for this section
-            This function is used to compute the value of the meetings field.
-        """
-        meetings = Meeting.objects.filter(section__id=obj.id)
-        return [{
-            'id': str(meeting.id),
-            'days': meeting.meeting_days,
-            'start_time': meeting.start_time,
-            'end_time': meeting.end_time,
-            'type': meeting.meeting_type,
-        } for meeting in meetings]
+    def get_course(self, obj):
+        """ Gets list of items in for dept course i.e CSCE 121"""
+        return obj.dept + " " + obj.course_num

--- a/autoscheduler/scraper/serializers.py
+++ b/autoscheduler/scraper/serializers.py
@@ -51,7 +51,7 @@ def season_num_to_string(season_num):
         2: "Summer",
         3: "Fall",
         4: "Full Yr Professional",
-        }
+    }
     return seasons.get(season_num, "NO SEASON")
 
 def campus_num_to_string(campus_num):
@@ -64,7 +64,7 @@ def campus_num_to_string(campus_num):
         2: "Galveston",
         3: "Qatar",
         5: "Half Year Term",
-        }
+    }
     return campus.get(campus_num, "NO CAMPUS")
 
 class TermSerializer(serializers.ModelSerializer):
@@ -74,7 +74,6 @@ class TermSerializer(serializers.ModelSerializer):
     class Meta:
         model = Department
         fields = ['term', 'desc']
-
 
     def get_desc(self, obj): # pylint: disable=no-self-use
         """ Uses term field to generate description for the term in the

--- a/autoscheduler/scraper/tests/api_tests.py
+++ b/autoscheduler/scraper/tests/api_tests.py
@@ -11,15 +11,15 @@ class APITests(APITestCase):
     def setUp(self):
         self.client = APIClient()
         self.courses = [
-            Course(id='123123', dept='CSCE', course_num='181',
+            Course(id='CSCE181-201931', dept='CSCE', course_num='181',
                    title='Introduction to Computing', term='201931', credit_hours=3),
-            Course(id='123124', dept='CSCE', course_num='315',
+            Course(id='CSCE315-201931', dept='CSCE', course_num='315',
                    title='Programming Studio', term='201931', credit_hours=3),
-            Course(id='123125', dept='COMM', course_num='203',
+            Course(id='COMM203-201831', dept='COMM', course_num='203',
                    title='Public Speaking', term='201831', credit_hours=3),
-            Course(id='123126', dept='COMM', course_num='203',
+            Course(id='COMM203-201931', dept='COMM', course_num='203',
                    title='Public Speaking', term='201931', credit_hours=3),
-            Course(id='123127', dept='LAW', course_num='7500S',
+            Course(id='LAW7500S-202031', dept='LAW', course_num='7500S',
                    title='Sports Law', term='202031', credit_hours=None),
         ]
         test_instructors = [
@@ -77,7 +77,7 @@ class APITests(APITestCase):
 
         # Assert
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(expected, response)
+        self.assertEqual(expected, response.json())
 
     def test_api_course_serializer_gives_expected_output(self):
         """ Tests that the course serializer yields the correct data """

--- a/autoscheduler/scraper/tests/api_tests.py
+++ b/autoscheduler/scraper/tests/api_tests.py
@@ -320,7 +320,7 @@ class APITests(APITestCase):
         self.assertEqual(response.json(), expected)
 
     def test_api_term_serializer_gives_expected_output_non_professional(self):
-        """ Tests that the section serializer yields the correct data for
+        """ Tests that the term serializer yields the correct data for
             a non professional term
         """
         # Arrange
@@ -339,7 +339,7 @@ class APITests(APITestCase):
         self.assertEqual(expected, serializer.data)
 
     def test_api_term_serializer_gives_expected_output_professional(self):
-        """ Tests that the section serializer yields the correct data for
+        """ Tests that the term serializer yields the correct data for
             a professional term
         """
         # Arrange
@@ -443,7 +443,7 @@ class APITests(APITestCase):
         self.assertEqual(expected, result)
 
     def test_api_course_search_serializer_gives_expected_output(self):
-        """ Tests that the section serializer returns the correct data """
+        """ Tests that the course search serializer returns the correct data """
         # Arrange
         expected = {'course' : 'CSCE 181'}
 

--- a/autoscheduler/scraper/tests/api_tests.py
+++ b/autoscheduler/scraper/tests/api_tests.py
@@ -5,7 +5,7 @@ from scraper.serializers import (CourseSerializer, SectionSerializer, TermSerial
                                  CourseSearchSerializer, season_num_to_string,
                                  campus_num_to_string, format_time)
 
-class APITests(APITestCase):
+class APITests(APITestCase): #pylint: disable=too-many-public-methods
     """ Tests API functionality """
     @classmethod
     def setUpTestData(cls):
@@ -396,9 +396,7 @@ class APITests(APITestCase):
             'term' : '201831',
             'desc': 'Fall 2018 - College Station'
         }
-        # Save department for testing
         dept = Department(id='CSCE201831', code='CSCE', term='201831')
-        dept.save()
 
         # Act
         serializer = TermSerializer(dept)
@@ -415,9 +413,7 @@ class APITests(APITestCase):
             'term' : '201941',
             'desc': 'Full Yr Professional 2019 - 2020'
         }
-        # Save department for testing
         dept = Department(id='DDDS201941', code='DDDS', term='201941')
-        dept.save()
 
         # Act
         serializer = TermSerializer(dept)
@@ -459,8 +455,7 @@ class APITests(APITestCase):
         expected = ['College Station', 'Galveston', 'Qatar', 'Half Year Term']
 
         # Act
-        result = [campus_num_to_string(i) for i in range(1, 4)]
-        result.append(campus_num_to_string(5))
+        result = [campus_num_to_string(i) for i in (1, 2, 3, 5)]
 
         # Assert
         self.assertEqual(expected, result)
@@ -484,9 +479,7 @@ class APITests(APITestCase):
         """
         # Arrange
         expected = "Fall 2018 - College Station"
-        # Save Department for testing
         dept = Department(id='CSCE201831', code='CSCE', term='201831')
-        dept.save()
 
         # Act
         result = TermSerializer.get_desc(self, dept)
@@ -500,9 +493,7 @@ class APITests(APITestCase):
         """
         # Arrange
         expected = "Full Yr Professional 2019 - 2020"
-        # Save Department for testing
         dept = Department(id='DDDS201941', code='DDDS', term='201941')
-        dept.save()
 
         # Act
         result = TermSerializer.get_desc(self, dept)

--- a/autoscheduler/scraper/tests/api_tests.py
+++ b/autoscheduler/scraper/tests/api_tests.py
@@ -4,7 +4,9 @@ from scraper.models.course import Course
 from scraper.models.department import Department
 from scraper.models.instructor import Instructor
 from scraper.models.section import Section, Meeting
-from scraper.serializers import CourseSerializer, SectionSerializer
+from scraper.serializers import (CourseSerializer, SectionSerializer, TermSerializer,
+                                 CourseSearchSerializer, season_num_to_string,
+                                 campus_num_to_string)
 
 class APITests(APITestCase):
     """ Tests API functionality """
@@ -316,3 +318,150 @@ class APITests(APITestCase):
         # Assert
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), expected)
+
+    def test_api_term_serializer_gives_expected_output_non_professional(self):
+        """ Tests that the section serializer yields the correct data for
+            a non professional term
+        """
+        # Arrange
+        expected = {
+            'term' : '201831',
+            'desc': 'Fall 2018 - College Station'
+        }
+        # Save department for testing
+        dept = Department(id='CSCE201831', code='CSCE', term='201831')
+        dept.save()
+
+        # Act
+        serializer = TermSerializer(dept)
+
+        # Assert
+        self.assertEqual(expected, serializer.data)
+
+    def test_api_term_serializer_gives_expected_output_professional(self):
+        """ Tests that the section serializer yields the correct data for
+            a non professional term
+        """
+        # Arrange
+        expected = {
+            'term' : '201941',
+            'desc': 'Full Yr Professional 2019 - 2020'
+        }
+        # Save department for testing
+        dept = Department(id='DDDS201941', code='DDDS', term='201941')
+        dept.save()
+
+        # Act
+        serializer = TermSerializer(dept)
+
+        # Assert
+        self.assertEqual(expected, serializer.data)
+
+    def test_api_term_serializer_handles_defined_season_correctly(self):
+        """ Tests season_num_to_string function called in TermSerializer for all season
+            translations in dicitonary
+        """
+        # Arrange
+        expected = ['Spring', 'Summer', 'Fall', 'Full Yr Professional']
+
+        # Act
+        result = [season_num_to_string(i) for i in range(1, 5)]
+
+        # Assert
+        self.assertEqual(expected, result)
+
+    def test_api_term_serializer_handles_undefined_season_correctly(self):
+        """ Tests season_num_to_string function called in TermSerializer for value not
+            in translation dictionary
+        """
+        # Arrange
+        expected = 'NO SEASON'
+
+        # Act
+        result = season_num_to_string(17)
+
+        # Assert
+        self.assertEqual(expected, result)
+
+    def test_api_term_serializer_handles_defined_campus_correctly(self):
+        """ Tests campus_num_to_string function called in TermSerializer for all campus
+            translations in dictionary
+        """
+        # Arrange
+        expected = ['College Station', 'Galveston', 'Qatar', 'Half Year Term']
+
+        # Act
+        result = [campus_num_to_string(i) for i in range(1, 4)]
+        result.append(campus_num_to_string(5))
+
+        # Assert
+        self.assertEqual(expected, result)
+
+    def test_api_term_serializer_handles_undefined_campus_correctly(self):
+        """ Tests campus_num_to_string function called in TermSerializer for value not in
+            translation dictionary
+        """
+        # Arrange
+        expected = 'NO CAMPUS'
+
+        # Act
+        result = campus_num_to_string(17)
+
+        # Assert
+        self.assertEqual(expected, result)
+
+    def test_api_term_serializer_get_desc_correctly_formats_non_professional_term(self):
+        """ Checks that get_desc function in TermSerializer correctly combines components
+            when formatting a non professional term
+        """
+        # Arrange
+        expected = "Fall 2018 - College Station"
+        # Save Department for testing
+        dept = Department(id='CSCE201831', code='CSCE', term='201831')
+        dept.save()
+
+        # Act
+        result = TermSerializer.get_desc(self, dept)
+
+        # Assert
+        self.assertEqual(expected, result)
+
+    def test_api_term_serializer_get_desc_correctly_formats_professional_term(self):
+        """ Checks that get_desc function in TermSerializer correctly combines components
+            when formatting a professional term
+        """
+        # Arrange
+        expected = "Full Yr Professional 2019 - 2020"
+        # Save Department for testing
+        dept = Department(id='DDDS201941', code='DDDS', term='201941')
+        dept.save()
+
+        # Act
+        result = TermSerializer.get_desc(self, dept)
+
+        # Assert
+        self.assertEqual(expected, result)
+
+    def test_api_course_search_serializer_gives_expected_output(self):
+        """ Tests that the section serializer returns the correct data """
+        # Arrange
+        expected = {'course' : 'CSCE 181'}
+
+        # Act
+        serializer = CourseSearchSerializer(self.courses[0])
+
+        # Assert
+        self.assertEqual(expected, serializer.data)
+
+    def test_api_course_search_serializer_get_course_formats_correctly(self):
+        """ Tests that the get_course function in CourseSearchSerializer
+            correctly combines components
+        """
+        # Arrange
+        expected = "CSCE 181"
+
+        # Act
+        result = CourseSearchSerializer.get_course(self, self.courses[0])
+
+        # Assert
+        self.assertEqual(expected, result)

--- a/autoscheduler/scraper/tests/api_tests.py
+++ b/autoscheduler/scraper/tests/api_tests.py
@@ -21,6 +21,8 @@ class APITests(APITestCase):
                    title='Public Speaking', term='201931', credit_hours=3),
             Course(id='LAW7500S-202031', dept='LAW', course_num='7500S',
                    title='Sports Law', term='202031', credit_hours=None),
+            Course(id='CSCE181-201731', dept='CSCE', course_num='181',
+                   title='Introduction to Computing', term='201731', credit_hours=3),
             Course(id='CSCE310-201731', dept='CSCE', course_num='310',
                    title='Database Systems', term='201731', credit_hours=3),
             Course(id='CSCE315-201731', dept='CSCE', course_num='315',
@@ -290,8 +292,23 @@ class APITests(APITestCase):
             output
         """
         # Arrange
-        expected = {'results': ['CSCE 310', 'CSCE 315']}
+        expected = {'results': ['CSCE 181', 'CSCE 310', 'CSCE 315']}
         data = {'search': 'csce', 'term': '201731'}
+
+        # Act
+        response = self.client.get('/api/course/search', data=data)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), expected)
+
+    def test_api_course_search_gives_correct_results_csce_3_lower(self):
+        """ Tests that /api/course/search?search=csce%203&term=201731 gives correct
+            output (lowercase search with a number works)
+        """
+        # Arrange
+        expected = {'results': ['CSCE 310', 'CSCE 315']}
+        data = {'search': 'csce%203', 'term': '201731'}
 
         # Act
         response = self.client.get('/api/course/search', data=data)

--- a/autoscheduler/scraper/tests/api_tests.py
+++ b/autoscheduler/scraper/tests/api_tests.py
@@ -340,7 +340,7 @@ class APITests(APITestCase):
 
     def test_api_term_serializer_gives_expected_output_professional(self):
         """ Tests that the section serializer yields the correct data for
-            a non professional term
+            a professional term
         """
         # Arrange
         expected = {

--- a/autoscheduler/scraper/tests/api_tests.py
+++ b/autoscheduler/scraper/tests/api_tests.py
@@ -357,7 +357,7 @@ class APITests(APITestCase):
         # Assert
         self.assertEqual(expected, serializer.data)
 
-    def test_api_term_serializer_handles_defined_season_correctly(self):
+    def test_season_num_to_string_handles_defined_season_correctly(self):
         """ Tests season_num_to_string function called in TermSerializer for all season
             translations in dicitonary
         """
@@ -370,7 +370,7 @@ class APITests(APITestCase):
         # Assert
         self.assertEqual(expected, result)
 
-    def test_api_term_serializer_handles_undefined_season_correctly(self):
+    def test_season_num_to_string_handles_undefined_season_correctly(self):
         """ Tests season_num_to_string function called in TermSerializer for value not
             in translation dictionary
         """
@@ -383,7 +383,7 @@ class APITests(APITestCase):
         # Assert
         self.assertEqual(expected, result)
 
-    def test_api_term_serializer_handles_defined_campus_correctly(self):
+    def test_campus_num_to_string_handles_defined_campus_correctly(self):
         """ Tests campus_num_to_string function called in TermSerializer for all campus
             translations in dictionary
         """
@@ -397,7 +397,7 @@ class APITests(APITestCase):
         # Assert
         self.assertEqual(expected, result)
 
-    def test_api_term_serializer_handles_undefined_campus_correctly(self):
+    def test_campus_num_to_string_handles_undefined_campus_correctly(self):
         """ Tests campus_num_to_string function called in TermSerializer for value not in
             translation dictionary
         """

--- a/autoscheduler/scraper/tests/api_tests.py
+++ b/autoscheduler/scraper/tests/api_tests.py
@@ -319,6 +319,21 @@ class APITests(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), expected)
 
+    def test_api_course_search_gives_correct_results_csce_space_310_lower(self):
+        """ Tests that /api/course/search gives the correct response for a search
+            containing a space not already in %20
+        """
+        # Arrange
+        expected = {'results': ['CSCE 310']}
+        data = {'search': 'csce 310', 'term': '201731'}
+
+        # Act
+        response = self.client.get('/api/course/search', data=data)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), expected)
+
     def test_api_term_serializer_gives_expected_output_non_professional(self):
         """ Tests that the term serializer yields the correct data for
             a non professional term

--- a/autoscheduler/scraper/tests/api_tests.py
+++ b/autoscheduler/scraper/tests/api_tests.py
@@ -21,6 +21,10 @@ class APITests(APITestCase):
                    title='Public Speaking', term='201931', credit_hours=3),
             Course(id='LAW7500S-202031', dept='LAW', course_num='7500S',
                    title='Sports Law', term='202031', credit_hours=None),
+            Course(id='CSCE310-201731', dept='CSCE', course_num='310',
+                   title='Database Systems', term='201731', credit_hours=3),
+            Course(id='CSCE315-201731', dept='CSCE', course_num='315',
+                   title='Programming Studio', term='201731', credit_hours=3),
         ]
         test_instructors = [
             Instructor(id='Akash Tyagi'),
@@ -258,6 +262,36 @@ class APITests(APITestCase):
         # Arrange
         expected = {'results': ['COMM 203', 'CSCE 181', 'CSCE 315']}
         data = {'search': 'C', 'term': '201931'}
+
+        # Act
+        response = self.client.get('/api/course/search', data=data)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), expected)
+
+    def test_api_course_search_gives_correct_results_csce_3(self):
+        """ Tests that /api/course/search?search=CSCE%203&term=201731 gives correct
+            output
+        """
+        # Arrange
+        expected = {'results': ['CSCE 310', 'CSCE 315']}
+        data = {'search': 'CSCE%203', 'term': '201731'}
+
+        # Act
+        response = self.client.get('/api/course/search', data=data)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), expected)
+
+    def test_api_course_search_gives_correct_results_csce_lower(self):
+        """ Tests that /api/course/search?search=csce&term=201731 gives correct
+            output
+        """
+        # Arrange
+        expected = {'results': ['CSCE 310', 'CSCE 315']}
+        data = {'search': 'csce', 'term': '201731'}
 
         # Act
         response = self.client.get('/api/course/search', data=data)

--- a/autoscheduler/scraper/urls.py
+++ b/autoscheduler/scraper/urls.py
@@ -1,8 +1,12 @@
 from django.urls import path
+from scraper.views import RetrieveCourseView
+from scraper.views import ListSectionView
 from scraper.views import RetrieveTermView
 from scraper.views import RetrieveCourseSearchView
 
 urlpatterns = [
+    path('course', RetrieveCourseView.as_view()),
+    path('sections', ListSectionView.as_view()),
     path('terms', RetrieveTermView.as_view()),
     path('course/search', RetrieveCourseSearchView.as_view())
 ]

--- a/autoscheduler/scraper/urls.py
+++ b/autoscheduler/scraper/urls.py
@@ -4,6 +4,5 @@ from scraper.views import RetrieveCourseSearchView
 
 urlpatterns = [
     path('terms', RetrieveTermView.as_view()),
-    path('course/search', RetrieveCourseSearchView.as_view()),
-    path('course/search/', RetrieveCourseSearchView.as_view())
+    path('course/search', RetrieveCourseSearchView.as_view())
 ]

--- a/autoscheduler/scraper/urls.py
+++ b/autoscheduler/scraper/urls.py
@@ -1,8 +1,11 @@
 from django.urls import path
-from scraper.views import RetrieveTermView
-from scraper.views import RetrieveCourseSearchView
+from scraper.views import (
+    RetrieveTermView, RetrieveCourseSearchView, RetrieveCourseView, ListSectionView
+)
 
 urlpatterns = [
+    path('course', RetrieveCourseView.as_view()),
+    path('sections', ListSectionView.as_view()),
     path('terms', RetrieveTermView.as_view()),
-    path('course/search', RetrieveCourseSearchView.as_view())
+    path('course/search', RetrieveCourseSearchView.as_view()),
 ]

--- a/autoscheduler/scraper/urls.py
+++ b/autoscheduler/scraper/urls.py
@@ -1,12 +1,8 @@
 from django.urls import path
-from scraper.views import RetrieveCourseView
-from scraper.views import ListSectionView
 from scraper.views import RetrieveTermView
 from scraper.views import RetrieveCourseSearchView
 
 urlpatterns = [
-    path('course', RetrieveCourseView.as_view()),
-    path('sections', ListSectionView.as_view()),
     path('terms', RetrieveTermView.as_view()),
     path('course/search', RetrieveCourseSearchView.as_view())
 ]

--- a/autoscheduler/scraper/urls.py
+++ b/autoscheduler/scraper/urls.py
@@ -1,6 +1,9 @@
 from django.urls import path
-from scraper.views import RetrieveCourseView
+from scraper.views import RetrieveTermView
+from scraper.views import RetrieveCourseSearchView
 
 urlpatterns = [
-    path('course', RetrieveCourseView.as_view()),
+    path('terms', RetrieveTermView.as_view()),
+    path('course/search', RetrieveCourseSearchView.as_view()),
+    path('course/search/', RetrieveCourseSearchView.as_view())
 ]

--- a/autoscheduler/scraper/views.py
+++ b/autoscheduler/scraper/views.py
@@ -9,18 +9,19 @@ class RetrieveTermView(generics.ListAPIView):
 
         This view returns all the terms
     """
-    def list(self, request):
-        """Overrides default behavior of list method so terms are ouput in
+    def get_queryset(self):
+        return Department.objects.all().distinct('term').order_by('-term')
+
+    def list(self, request): # pylint: disable=arguments-differ
+        """ Overrides default behavior of list method so terms are ouput in
            the format {"201831": "Fall 2018 - College Station", ...} Does this by creating
            a new dictionary called formatted_data
         """
-
         queryset = self.get_queryset()
         serializer = TermSerializer(queryset, many=True)
         formatted_data = {obj['term']: obj['desc'] for obj in serializer.data}
         return Response(formatted_data)
 
-    queryset = Department.objects.all().distinct('term').order_by('-term')
     serializer_class = TermSerializer
 
 class RetrieveCourseSearchView(generics.ListAPIView):
@@ -36,13 +37,11 @@ class RetrieveCourseSearchView(generics.ListAPIView):
         return Course.objects.filter(
             id__startswith=search.replace("%20", "").upper(), term=term)
 
-
-    def list(self, request):
+    def list(self, request): # pylint: disable=arguments-differ
         """ Overrides default behavior of list method so terms are ouput in
            the format {'results': ["CSCE 181", "CSCE 315", ...]} Does this by creating
            a new dictionary called formatted_data
         """
-
         queryset = self.get_queryset()
         serializer = CourseSearchSerializer(queryset, many=True)
         formatted_data = {'results': [obj['course'] for obj in serializer.data]}

--- a/autoscheduler/scraper/views.py
+++ b/autoscheduler/scraper/views.py
@@ -1,8 +1,35 @@
 from rest_framework import generics
 from rest_framework.response import Response
-from scraper.serializers import TermSerializer
-from scraper.serializers import CourseSearchSerializer
+from scraper.serializers import (
+    TermSerializer, CourseSearchSerializer, CourseSerializer, SectionSerializer
+)
 from scraper.models import Course, Section, Department
+
+class RetrieveCourseView(generics.RetrieveAPIView):
+    """ API endpoint for viewing course information, used by /api/course.
+        This view returns a serialized course, should return its title and credit hours.
+    """
+    serializer_class = CourseSerializer
+
+    def get_object(self):
+        """ Overrides default behavior of get_object() to work without a primary key """
+        dept = self.request.query_params.get('dept')
+        course_num = self.request.query_params.get('course_num')
+        term = self.request.query_params.get('term')
+        return Course.objects.get(dept=dept, course_num=course_num, term=term)
+
+class ListSectionView(generics.ListAPIView):
+    """ API endpoint for viewing course information, used by /api/sections.
+        This view returns a serialized list of sections for a given course.
+    """
+    serializer_class = SectionSerializer
+
+    def get_queryset(self):
+        """ Overrides default behavior of get_queryset() to work without a primary key """
+        dept = self.request.query_params.get('dept')
+        course_num = self.request.query_params.get('course_num')
+        term = self.request.query_params.get('term')
+        return Section.objects.filter(subject=dept, course_num=course_num, term_code=term)
 
 class RetrieveTermView(generics.ListAPIView):
     """ API endpoint for viewing terms, used by /api/terms.

--- a/autoscheduler/scraper/views.py
+++ b/autoscheduler/scraper/views.py
@@ -32,10 +32,10 @@ class RetrieveCourseSearchView(generics.ListAPIView):
         """ Overrides default behavior of get_queryset() to work using
             search and term parameter in the url
         """
-        search = self.request.query_params.get('search')
+        search = self.request.query_params.get('search').replace("%20", "").upper()
         term = self.request.query_params.get('term')
         return Course.objects.filter(
-            id__startswith=search.replace("%20", "").upper(), term=term)
+            id__startswith=search, term=term)
 
     def list(self, request): # pylint: disable=arguments-differ
         """ Overrides default behavior of list method so terms are ouput in

--- a/autoscheduler/scraper/views.py
+++ b/autoscheduler/scraper/views.py
@@ -32,7 +32,8 @@ class RetrieveCourseSearchView(generics.ListAPIView):
         """ Overrides default behavior of get_queryset() to work using
             search and term parameter in the url
         """
-        search = self.request.query_params.get('search').replace("%20", "").upper()
+        search = self.request.query_params.get('search').replace("%20", "").replace(
+            " ", "").upper()
         term = self.request.query_params.get('term')
         return Course.objects.filter(
             id__startswith=search, term=term)

--- a/autoscheduler/scraper/views.py
+++ b/autoscheduler/scraper/views.py
@@ -21,7 +21,7 @@ class RetrieveTermView(generics.ListAPIView):
             formatted_data[i['term']] = i['desc']
         return Response(formatted_data)
 
-    queryset = Department.objects.all().distinct('term')
+    queryset = Department.objects.all().distinct('term').order_by('-term')
     serializer_class = TermSerializer
 
 class RetrieveCourseSearchView(generics.ListAPIView):

--- a/autoscheduler/scraper/views.py
+++ b/autoscheduler/scraper/views.py
@@ -1,10 +1,10 @@
 from collections import OrderedDict
 from rest_framework import generics
 from rest_framework.response import Response
-from .serializers import CourseSerializer
-from .serializers import SectionSerializer
-from .serializers import TermSerializer
-from .serializers import CourseSearchSerializer
+from scraper.serializers import CourseSerializer
+from scraper.serializers import SectionSerializer
+from scraper.serializers import TermSerializer
+from scraper.serializers import CourseSearchSerializer
 from .models.course import Course
 from scraper.models import Course, Section, Department
 
@@ -43,12 +43,12 @@ class RetrieveTermView(generics.ListAPIView):
     def list(self, request):
         """Overrides default behavior of list method so terms are ouput in
            the format {"201831": "Fall 2018 - College Station", ...} Does this by creating
-           a new ordered dictionary called formatted_data"""
+           a new dictionary called formatted_data
+        """
+
         queryset = self.get_queryset()
         serializer = TermSerializer(queryset, many=True)
-        formatted_data = OrderedDict()
-        for i in serializer.data:
-            formatted_data[i['term']] = i['desc']
+        formatted_data = {obj['term']: obj['desc'] for obj in serializer.data}
         return Response(formatted_data)
 
     queryset = Department.objects.all().distinct('term').order_by('-term')
@@ -56,26 +56,26 @@ class RetrieveTermView(generics.ListAPIView):
 
 class RetrieveCourseSearchView(generics.ListAPIView):
     """ API endpoint for viewing list of courses searched off of
-        searchText parameter"""
+        searchText parameter
+    """
     def get_queryset(self):
         """ Overrides default behavior of get_queryset() to work using
-            search and term parameter in the url"""
+            search and term parameter in the url
+        """
         search = self.request.query_params.get('search')
         term = self.request.query_params.get('term')
-        return Course.objects.filter(id__startswith=search.replace(" ", ""), term=term)
+        return Course.objects.filter(id__startswith=search.replace("%20", ""), term=term)
+
 
     def list(self, request):
-        """Overrides default behavior of list method so terms are ouput in
+        """ Overrides default behavior of list method so terms are ouput in
            the format {'results': ["CSCE 181", "CSCE 315", ...]} Does this by creating
-           a new ordered dictionary called formatted_data"""
+           a new dictionary called formatted_data
+        """
+
         queryset = self.get_queryset()
         serializer = CourseSearchSerializer(queryset, many=True)
-        formatted_data = OrderedDict()
-        courses = []
-        for i in serializer.data:
-            courses.append(i['course'])
-        formatted_data['results'] = courses
+        formatted_data = {'results': [obj['course'] for obj in serializer.data]}
         return Response(formatted_data)
 
-    queryset = Course.objects.filter()
     serializer_class = CourseSearchSerializer

--- a/autoscheduler/scraper/views.py
+++ b/autoscheduler/scraper/views.py
@@ -1,39 +1,8 @@
-from collections import OrderedDict
 from rest_framework import generics
 from rest_framework.response import Response
-from scraper.serializers import CourseSerializer
-from scraper.serializers import SectionSerializer
 from scraper.serializers import TermSerializer
 from scraper.serializers import CourseSearchSerializer
-from .models.course import Course
 from scraper.models import Course, Section, Department
-
-class RetrieveCourseView(generics.RetrieveAPIView):
-    """ API endpoint for viewing course information, used by /api/course.
-        This view returns a serialized course, should return its title and credit hours.
-    """
-    serializer_class = CourseSerializer
-
-    def get_object(self):
-        """ Overrides default behavior of get_object() to work without a primary key """
-        dept = self.request.query_params.get('dept')
-        course_num = self.request.query_params.get('course_num')
-        term = self.request.query_params.get('term')
-        return Course.objects.get(dept=dept, course_num=course_num, term=term)
-
-class ListSectionView(generics.ListAPIView):
-    """ API endpoint for viewing course information, used by /api/sections.
-        This view returns a serialized section, should
-        return list of all sections for a given course.
-    """
-    serializer_class = SectionSerializer
-
-    def get_queryset(self):
-        """ Overrides default behavior of get_queryset() to work without a primary key """
-        dept = self.request.query_params.get('dept')
-        course_num = self.request.query_params.get('course_num')
-        term = self.request.query_params.get('term')
-        return Section.objects.filter(subject=dept, course_num=course_num, term_code=term)
 
 class RetrieveTermView(generics.ListAPIView):
     """ API endpoint for viewing terms, used by /api/terms.
@@ -64,7 +33,8 @@ class RetrieveCourseSearchView(generics.ListAPIView):
         """
         search = self.request.query_params.get('search')
         term = self.request.query_params.get('term')
-        return Course.objects.filter(id__startswith=search.replace("%20", ""), term=term)
+        return Course.objects.filter(
+            id__startswith=search.replace("%20", "").upper(), term=term)
 
 
     def list(self, request):

--- a/autoscheduler/scraper/views.py
+++ b/autoscheduler/scraper/views.py
@@ -29,7 +29,9 @@ class ListSectionView(generics.ListAPIView):
         dept = self.request.query_params.get('dept')
         course_num = self.request.query_params.get('course_num')
         term = self.request.query_params.get('term')
-        return Section.objects.filter(subject=dept, course_num=course_num, term_code=term)
+        return Section.objects.filter(
+            subject=dept, course_num=course_num, term_code=term
+        ).order_by('id')
 
 class RetrieveTermView(generics.ListAPIView):
     """ API endpoint for viewing terms, used by /api/terms.
@@ -59,8 +61,8 @@ class RetrieveCourseSearchView(generics.ListAPIView):
         """ Overrides default behavior of get_queryset() to work using
             search and term parameter in the url
         """
-        search = self.request.query_params.get('search').replace("%20", "").replace(
-            " ", "").upper()
+        search = self.request.query_params.get('search')
+        search = search.replace("%20", "").replace(" ", "").upper()
         term = self.request.query_params.get('term')
         return Course.objects.filter(
             id__startswith=search, term=term)

--- a/autoscheduler/scraper/views.py
+++ b/autoscheduler/scraper/views.py
@@ -1,13 +1,43 @@
 from collections import OrderedDict
 from rest_framework import generics
 from rest_framework.response import Response
+from .serializers import CourseSerializer
+from .serializers import SectionSerializer
 from .serializers import TermSerializer
 from .serializers import CourseSearchSerializer
 from .models.course import Course
-from .models.department import Department
+from scraper.models import Course, Section, Department
+
+class RetrieveCourseView(generics.RetrieveAPIView):
+    """ API endpoint for viewing course information, used by /api/course.
+        This view returns a serialized course, should return its title and credit hours.
+    """
+    serializer_class = CourseSerializer
+
+    def get_object(self):
+        """ Overrides default behavior of get_object() to work without a primary key """
+        dept = self.request.query_params.get('dept')
+        course_num = self.request.query_params.get('course_num')
+        term = self.request.query_params.get('term')
+        return Course.objects.get(dept=dept, course_num=course_num, term=term)
+
+class ListSectionView(generics.ListAPIView):
+    """ API endpoint for viewing course information, used by /api/sections.
+        This view returns a serialized section, should
+        return list of all sections for a given course.
+    """
+    serializer_class = SectionSerializer
+
+    def get_queryset(self):
+        """ Overrides default behavior of get_queryset() to work without a primary key """
+        dept = self.request.query_params.get('dept')
+        course_num = self.request.query_params.get('course_num')
+        term = self.request.query_params.get('term')
+        return Section.objects.filter(subject=dept, course_num=course_num, term_code=term)
 
 class RetrieveTermView(generics.ListAPIView):
-    """ API endpoint for viewing terms, used by /api/term.
+    """ API endpoint for viewing terms, used by /api/terms.
+
         This view returns all the terms
     """
     def list(self, request):
@@ -32,7 +62,7 @@ class RetrieveCourseSearchView(generics.ListAPIView):
             search and term parameter in the url"""
         search = self.request.query_params.get('search')
         term = self.request.query_params.get('term')
-        return Course.objects.filter(id__contains=search, term=term)
+        return Course.objects.filter(id__startswith=search.replace(" ", ""), term=term)
 
     def list(self, request):
         """Overrides default behavior of list method so terms are ouput in

--- a/autoscheduler/scraper/views.py
+++ b/autoscheduler/scraper/views.py
@@ -1,16 +1,51 @@
+from collections import OrderedDict
 from rest_framework import generics
-from .serializers import CourseSerializer
+from rest_framework.response import Response
+from .serializers import TermSerializer
+from .serializers import CourseSearchSerializer
 from .models.course import Course
+from .models.department import Department
 
-class RetrieveCourseView(generics.RetrieveAPIView):
-    """ API endpoint for viewing course information, used by /api/course.
-        This view returns a serialized course, should return its title and credit hours.
+class RetrieveTermView(generics.ListAPIView):
+    """ API endpoint for viewing terms, used by /api/term.
+        This view returns all the terms
     """
-    serializer_class = CourseSerializer
+    def list(self, request):
+        """Overrides default behavior of list method so terms are ouput in
+           the format {"201831": "Fall 2018 - College Station", ...} Does this by creating
+           a new ordered dictionary called formatted_data"""
+        queryset = self.get_queryset()
+        serializer = TermSerializer(queryset, many=True)
+        formatted_data = OrderedDict()
+        for i in serializer.data:
+            formatted_data[i['term']] = i['desc']
+        return Response(formatted_data)
 
-    def get_object(self):
-        """ Overrides default behavior of get_object() to work without a primary key """
-        dept = self.request.query_params.get('dept')
-        course_num = self.request.query_params.get('course_num')
+    queryset = Department.objects.all().distinct('term')
+    serializer_class = TermSerializer
+
+class RetrieveCourseSearchView(generics.ListAPIView):
+    """ API endpoint for viewing list of courses searched off of
+        searchText parameter"""
+    def get_queryset(self):
+        """ Overrides default behavior of get_queryset() to work using
+            search and term parameter in the url"""
+        search = self.request.query_params.get('search')
         term = self.request.query_params.get('term')
-        return Course.objects.get(dept=dept, course_num=course_num, term=term)
+        return Course.objects.filter(id__contains=search, term=term)
+
+    def list(self, request):
+        """Overrides default behavior of list method so terms are ouput in
+           the format {'results': ["CSCE 181", "CSCE 315", ...]} Does this by creating
+           a new ordered dictionary called formatted_data"""
+        queryset = self.get_queryset()
+        serializer = CourseSearchSerializer(queryset, many=True)
+        formatted_data = OrderedDict()
+        courses = []
+        for i in serializer.data:
+            courses.append(i['course'])
+        formatted_data['results'] = courses
+        return Response(formatted_data)
+
+    queryset = Course.objects.filter()
+    serializer_class = CourseSearchSerializer


### PR DESCRIPTION
Implements api/terms and api/course/search. For api/course/search, white space between the department and course number is trimmed. Department must also be entered before course number in the search parameter.