### PR TITLE
Additional testing for /api/course/search

### DIFF
--- a/autoscheduler/scraper/tests/api_tests.py
+++ b/autoscheduler/scraper/tests/api_tests.py
@@ -8,9 +8,10 @@ from scraper.serializers import CourseSerializer, SectionSerializer
 
 class APITests(APITestCase):
     """ Tests API functionality """
-    def setUp(self):
-        self.client = APIClient()
-        self.courses = [
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = APIClient()
+        cls.courses = [
             Course(id='CSCE181-201931', dept='CSCE', course_num='181',
                    title='Introduction to Computing', term='201931', credit_hours=3),
             Course(id='CSCE315-201931', dept='CSCE', course_num='315',
@@ -28,38 +29,34 @@ class APITests(APITestCase):
             Course(id='CSCE315-201731', dept='CSCE', course_num='315',
                    title='Programming Studio', term='201731', credit_hours=3),
         ]
-        test_instructors = [
+        cls.instructors = [
             Instructor(id='Akash Tyagi'),
             Instructor(id='John Moore'),
         ]
-        for instructor in test_instructors:
-            instructor.save()
-        self.sections = [
+        Instructor.objects.bulk_create(cls.instructors)
+        cls.sections = [
             Section(crn=12345, id='000001', subject='CSCE', course_num='310',
                     section_num='501', term_code='201931', min_credits='3',
                     honors=False, web=False, max_enrollment=50,
-                    current_enrollment=40, instructor=test_instructors[0]),
+                    current_enrollment=40, instructor=cls.instructors[0]),
             Section(crn=12346, id='000002', subject='CSCE', course_num='310',
                     section_num='502', term_code='201931', min_credits='3',
                     honors=False, web=False, max_enrollment=50,
-                    current_enrollment=40, instructor=test_instructors[1]),
+                    current_enrollment=40, instructor=cls.instructors[1]),
         ]
-        self.meetings = [
+        cls.meetings = [
             Meeting(id='0000010', meeting_days=[True] * 7, start_time=time(11, 30),
-                    end_time=time(12, 20), meeting_type='LEC', section=self.sections[0]),
+                    end_time=time(12, 20), meeting_type='LEC', section=cls.sections[0]),
             Meeting(id='0000011', meeting_days=[True] * 7, start_time=time(9, 10),
-                    end_time=time(10), meeting_type='LEC', section=self.sections[0]),
+                    end_time=time(10), meeting_type='LEC', section=cls.sections[0]),
             Meeting(id='0000020', meeting_days=[True] * 7, start_time=time(11, 30),
-                    end_time=time(12, 20), meeting_type='LEC', section=self.sections[1]),
+                    end_time=time(12, 20), meeting_type='LEC', section=cls.sections[1]),
             Meeting(id='0000021', meeting_days=[False] * 7, start_time=time(9, 10),
-                    end_time=time(10), meeting_type='LAB', section=self.sections[1]),
+                    end_time=time(10), meeting_type='LAB', section=cls.sections[1]),
         ]
-        for course in self.courses:
-            course.save()
-        for section in self.sections:
-            section.save()
-        for meeting in self.meetings:
-            meeting.save()
+        Course.objects.bulk_create(cls.courses)
+        Section.objects.bulk_create(cls.sections)
+        Meeting.objects.bulk_create(cls.meetings)
 
     def test_api_terms_displays_all_terms(self):
         """ Tests that /api/terms returns a list of all terms in database """
@@ -75,8 +72,7 @@ class APITests(APITestCase):
             Department(id='CSCE201931', code='CSCE', term='201931'),
             Department(id='CSCE202031', code='CSCE', term='202031'),
         ]
-        for dept in depts:
-            dept.save()
+        Department.objects.bulk_create(depts)
 
         # Act
         response = self.client.get('/api/terms')

--- a/autoscheduler/scraper/tests/api_tests.py
+++ b/autoscheduler/scraper/tests/api_tests.py
@@ -21,6 +21,10 @@ class APITests(APITestCase):
                    title='Public Speaking', term='201931', credit_hours=3),
             Course(id='LAW7500s-202031', dept='LAW', course_num='7500S',
                    title='Sports Law', term='202031', credit_hours=None),
+            Course(id='CSCE310-201731', dept='CSCE', course_num='310',
+                   title='Database Systems', term='201731', credit_hours=3),
+            Course(id='CSCE315-201731', dept='CSCE', course_num='315',
+                   title='Programming Studio', term='201731', credit_hours=3),
         ]
         test_instructors = [
             Instructor(id='Akash Tyagi'),
@@ -258,6 +262,36 @@ class APITests(APITestCase):
         # Arrange
         expected = {'results': ['COMM 203', 'CSCE 181', 'CSCE 315']}
         data = {'search': 'C', 'term': '201931'}
+
+        # Act
+        response = self.client.get('/api/course/search', data=data)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), expected)
+
+    def test_api_course_search_gives_correct_results_csce_3(self):
+        """ Tests that /api/course/search?search=CSCE%203&term=201731 gives correct
+            output
+        """
+        # Arrange
+        expected = {'results': ['CSCE 310', 'CSCE 315']}
+        data = {'search': 'CSCE%203', 'term': '201731'}
+
+        # Act
+        response = self.client.get('/api/course/search', data=data)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), expected)
+
+    def test_api_course_search_gives_correct_results_csce_lower(self):
+        """ Tests that /api/course/search?search=csce&term=201731 gives correct
+            output
+        """
+        # Arrange
+        expected = {'results': ['CSCE 310', 'CSCE 315']}
+        data = {'search': 'csce', 'term': '201731'}
 
         # Act
         response = self.client.get('/api/course/search', data=data)

--- a/autoscheduler/scraper/tests/api_tests.py
+++ b/autoscheduler/scraper/tests/api_tests.py
@@ -243,7 +243,9 @@ class APITests(APITestCase):
         self.assertEqual(response.json(), expected)
 
     def test_api_course_search_gives_correct_results_cs(self):
-        """ Tests that /api/course/search?search=CS&term=201931 gives correct output """
+        """ Tests that /api/course/search filters courses that don't match the entire
+            search term
+        """
         # Arrange
         expected = {'results': ['CSCE 181', 'CSCE 315']}
         data = {'search': 'CS', 'term': '201931'}
@@ -256,7 +258,9 @@ class APITests(APITestCase):
         self.assertEqual(response.json(), expected)
 
     def test_api_course_search_gives_correct_results_c(self):
-        """ Tests that /api/course/search?search=C&term=201931 gives correct output """
+        """ Tests that /api/course/search gives the correct response for a search
+            containing only uppercase letters
+        """
         # Arrange
         expected = {'results': ['COMM 203', 'CSCE 181', 'CSCE 315']}
         data = {'search': 'C', 'term': '201931'}
@@ -269,8 +273,8 @@ class APITests(APITestCase):
         self.assertEqual(response.json(), expected)
 
     def test_api_course_search_gives_correct_results_csce_3(self):
-        """ Tests that /api/course/search?search=CSCE%203&term=201731 gives correct
-            output
+        """ Tests that /api/course/search gives the correct response for a search
+            containing uppercase letters and a number
         """
         # Arrange
         expected = {'results': ['CSCE 310', 'CSCE 315']}
@@ -284,8 +288,8 @@ class APITests(APITestCase):
         self.assertEqual(response.json(), expected)
 
     def test_api_course_search_gives_correct_results_csce_lower(self):
-        """ Tests that /api/course/search?search=csce&term=201731 gives correct
-            output
+        """ Tests that /api/course/search gives the correct response for a search
+            containing only lowercase letters
         """
         # Arrange
         expected = {'results': ['CSCE 181', 'CSCE 310', 'CSCE 315']}
@@ -299,8 +303,8 @@ class APITests(APITestCase):
         self.assertEqual(response.json(), expected)
 
     def test_api_course_search_gives_correct_results_csce_3_lower(self):
-        """ Tests that /api/course/search?search=csce%203&term=201731 gives correct
-            output (lowercase search with a number works)
+        """ Tests that /api/course/search gives the correct response for a search
+            containing lowercase letters and a number
         """
         # Arrange
         expected = {'results': ['CSCE 310', 'CSCE 315']}

--- a/autoscheduler/scraper/tests/api_tests.py
+++ b/autoscheduler/scraper/tests/api_tests.py
@@ -21,6 +21,8 @@ class APITests(APITestCase):
                    title='Public Speaking', term='201931', credit_hours=3),
             Course(id='LAW7500s-202031', dept='LAW', course_num='7500S',
                    title='Sports Law', term='202031', credit_hours=None),
+            Course(id='CSCE181-201731', dept='CSCE', course_num='181',
+                   title='Introduction to Computing', term='201731', credit_hours=3),
             Course(id='CSCE310-201731', dept='CSCE', course_num='310',
                    title='Database Systems', term='201731', credit_hours=3),
             Course(id='CSCE315-201731', dept='CSCE', course_num='315',
@@ -290,8 +292,23 @@ class APITests(APITestCase):
             output
         """
         # Arrange
-        expected = {'results': ['CSCE 310', 'CSCE 315']}
+        expected = {'results': ['CSCE 181', 'CSCE 310', 'CSCE 315']}
         data = {'search': 'csce', 'term': '201731'}
+
+        # Act
+        response = self.client.get('/api/course/search', data=data)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), expected)
+
+    def test_api_course_search_gives_correct_results_csce_3_lower(self):
+        """ Tests that /api/course/search?search=csce%203&term=201731 gives correct
+            output (lowercase search with a number works)
+        """
+        # Arrange
+        expected = {'results': ['CSCE 310', 'CSCE 315']}
+        data = {'search': 'csce%203', 'term': '201731'}
 
         # Act
         response = self.client.get('/api/course/search', data=data)


### PR DESCRIPTION
Since the current tests for `/api/course/search` aren't all that thorough, I added tests to make sure that lowercase letters in searches, as well as numbers and spaces (encoded as `%20`), are correctly handled.