### PR TITLE
Fixed bug when clicking on second course card

### DIFF
--- a/autoscheduler/frontend/src/components/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.tsx
+++ b/autoscheduler/frontend/src/components/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.tsx
@@ -11,8 +11,8 @@ interface BasicSelectProps {
 }
 
 const BasicSelect: React.FC<BasicSelectProps> = ({ id }) => {
-  const web = useSelector<RootState, boolean>((state) => state.courseCards[id].web);
-  const honors = useSelector<RootState, boolean>((state) => state.courseCards[id].honors);
+  const web = useSelector<RootState, boolean>((state) => state.courseCards[id].web || false);
+  const honors = useSelector<RootState, boolean>((state) => state.courseCards[id].honors || false);
   const dispatch = useDispatch();
 
   return (

--- a/autoscheduler/frontend/src/tests/CourseSelectColumn.test.tsx
+++ b/autoscheduler/frontend/src/tests/CourseSelectColumn.test.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 
-import { render, fireEvent, act } from '@testing-library/react';
+import {
+  render, fireEvent, act,
+} from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
@@ -52,6 +54,27 @@ describe('CourseSelectColumn', () => {
       // assert
       // Starts with 1 by default, so removing one should make it 0
       expect(cardsCount).toEqual(0);
+    });
+  });
+
+  describe('Web Only box is checked', () => {
+    test('when it is clicked on the second course card', async () => {
+      // arrange
+      const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
+
+      const { getAllByText, getByText } = render(
+        <Provider store={store}>
+          <CourseSelectColumn />
+        </Provider>,
+      );
+
+      // act
+      fireEvent.click(getByText('Add Course'));
+      fireEvent.click(getAllByText('Web Only')[1]);
+      const checked = document.getElementsByClassName('Mui-checked').length;
+
+      // assert
+      expect(checked).toEqual(1);
     });
   });
 });


### PR DESCRIPTION
Due to an error I made when connecting `<BasicSelect />` to Redux, there was a bug in that clicking on "Web Only" or "Honors Only" on any course card other than the first would cause the box to not actually be checked, along with an error message about an uncontrolled component becoming controlled. Since this was my fault originally, I have resolved this bug by assuming that all checkboxes should be false in the initial state, and I now propose that this branch be merged into the main `frontend/course-picker` branch.