### PR TITLE
Made course card padding depend on if there's a scrollbar or not

### DIFF
--- a/autoscheduler/frontend/src/components/CourseSelectColumn/CourseSelectColumn.css
+++ b/autoscheduler/frontend/src/components/CourseSelectColumn/CourseSelectColumn.css
@@ -28,7 +28,6 @@
 
 .row {
     padding-bottom: 10px;
-    padding-right: 2%;
 }
 
 .row:last-of-type {

--- a/autoscheduler/frontend/src/components/CourseSelectColumn/CourseSelectColumn.tsx
+++ b/autoscheduler/frontend/src/components/CourseSelectColumn/CourseSelectColumn.tsx
@@ -13,7 +13,7 @@ import { addCourseCard } from '../../redux/actions';
  */
 
 const updateCourseCardPadding = (): void => {
-  const container = document.getElementById('courseSelectContainer');
+  const container = document.getElementById('course-select-container');
   const hasScrollBar = container.scrollHeight > container.clientHeight;
   const cards = Array.from(document.getElementsByClassName(styles.row) as
                            HTMLCollectionOf<HTMLElement>);
@@ -33,9 +33,7 @@ const CourseSelectColumn: React.FC<RouteComponentProps> = () => {
   const rows: JSX.Element[] = [];
 
   // Recalculate padding of course cards after rendering component or resizing window
-  React.useEffect(() => {
-    updateCourseCardPadding();
-  }, [rows]);
+  React.useEffect(updateCourseCardPadding, [rows]);
   React.useEffect(() => {
     window.addEventListener('resize', updateCourseCardPadding);
     return (): void => window.removeEventListener('resize', updateCourseCardPadding);
@@ -61,7 +59,7 @@ const CourseSelectColumn: React.FC<RouteComponentProps> = () => {
   return (
     <div className={styles.container}>
       <div className={styles.columnWrapper}>
-        <div className={styles.courseSelectColumn} id="courseSelectContainer">
+        <div className={styles.courseSelectColumn} id="course-select-container">
           {rows}
         </div>
       </div>

--- a/autoscheduler/frontend/src/components/CourseSelectColumn/CourseSelectColumn.tsx
+++ b/autoscheduler/frontend/src/components/CourseSelectColumn/CourseSelectColumn.tsx
@@ -11,6 +11,18 @@ import { addCourseCard } from '../../redux/actions';
 /**
  * Renders a column of CourseSelectCards, as well as a button to add course cards
  */
+
+const updateCourseCardPadding = (): void => {
+  const container = document.getElementById('courseSelectContainer');
+  const hasScrollBar = container.scrollHeight > container.clientHeight;
+  const cards = Array.from(document.getElementsByClassName(styles.row) as
+                           HTMLCollectionOf<HTMLElement>);
+  const padding = hasScrollBar ? '2%' : '0%';
+  for (let i = 0; i < cards.length; i++) {
+    cards[i].style.paddingRight = padding;
+  }
+};
+
 const CourseSelectColumn: React.FC<RouteComponentProps> = () => {
   const courseCards = useSelector<RootState, CourseCardArray>(
     (state) => state.courseCards,
@@ -19,6 +31,15 @@ const CourseSelectColumn: React.FC<RouteComponentProps> = () => {
   const dispatch = useDispatch();
 
   const rows: JSX.Element[] = [];
+
+  // Recalculate padding of course cards after rendering component or resizing window
+  React.useEffect(() => {
+    updateCourseCardPadding();
+  }, [rows]);
+  React.useEffect(() => {
+    window.addEventListener('resize', updateCourseCardPadding);
+    return (): void => window.removeEventListener('resize', updateCourseCardPadding);
+  });
 
   // Add all of the course cards to rows to be displayed
   for (let i = 0; i < courseCards.numCardsCreated; i++) {
@@ -40,7 +61,7 @@ const CourseSelectColumn: React.FC<RouteComponentProps> = () => {
   return (
     <div className={styles.container}>
       <div className={styles.columnWrapper}>
-        <div className={styles.courseSelectColumn}>
+        <div className={styles.courseSelectColumn} id="courseSelectContainer">
           {rows}
         </div>
       </div>

--- a/autoscheduler/frontend/src/tests/CourseSelectColumn.test.tsx
+++ b/autoscheduler/frontend/src/tests/CourseSelectColumn.test.tsx
@@ -80,55 +80,118 @@ describe('CourseSelectColumn', () => {
   });
 
   describe('correctly determines padding of cards', () => {
-    test('when there is a scrollbar and course cards are changed', () => {
+    describe('when there should be no padding', () => {
+      test('and course cards are updated', () => {
+        // arrange
+        const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
+
+        const { getByText, getAllByText } = render(
+          <Provider store={store}>
+            <CourseSelectColumn />
+          </Provider>,
+        );
+
+        const courseSelectContainer = document.getElementById('course-select-container');
+        jest.spyOn(courseSelectContainer, 'clientHeight', 'get')
+          .mockImplementation(() => 500);
+        jest.spyOn(courseSelectContainer, 'scrollHeight', 'get')
+          .mockImplementation(() => 600);
+
+        // act
+        // add course to make course cards rerender with padding, then remove to rerender without it
+        act(() => { fireEvent.click(getByText('Add Course')); });
+        jest.spyOn(courseSelectContainer, 'scrollHeight', 'get')
+          .mockImplementation(() => 400);
+        act(() => { fireEvent.click(getAllByText('Remove')[0]); });
+        const courseCard = document.getElementsByClassName(styles.row)[0];
+        const courseCardStyle = window.getComputedStyle(courseCard);
+
+        // assert
+        expect(courseCardStyle.paddingRight).toBe('0%');
+      });
+
+      test('and the window is resized', () => {
+        // arrange
+        const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
+
+        render(
+          <Provider store={store}>
+            <CourseSelectColumn />
+          </Provider>,
+        );
+
+        const courseSelectContainer = document.getElementById('course-select-container');
+        jest.spyOn(courseSelectContainer, 'clientHeight', 'get')
+          .mockImplementation(() => 500);
+        jest.spyOn(courseSelectContainer, 'scrollHeight', 'get')
+          .mockImplementation(() => 600);
+
+        // act
+        // resize window to add padding then remove it
+        window.dispatchEvent(new Event('resize'));
+        jest.spyOn(courseSelectContainer, 'scrollHeight', 'get')
+          .mockImplementation(() => 400);
+        window.dispatchEvent(new Event('resize'));
+        const courseCard = document.getElementsByClassName(styles.row)[0];
+        const courseCardStyle = window.getComputedStyle(courseCard);
+
+        // assert
+        expect(courseCardStyle.paddingRight).toBe('0%');
+      });
+    });
+
+    describe('when padding should be added', () => {
+      test('and course cards are updated', () => {
+        // arrange
+        const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
+
+        const { getByText } = render(
+          <Provider store={store}>
+            <CourseSelectColumn />
+          </Provider>,
+        );
+
+        const courseSelectContainer = document.getElementById('course-select-container');
+        jest.spyOn(courseSelectContainer, 'clientHeight', 'get')
+          .mockImplementation(() => 500);
+        jest.spyOn(courseSelectContainer, 'scrollHeight', 'get')
+          .mockImplementation(() => 600);
+
+        // act
+        // add course to make course cards rerender, should add padding
+        act(() => { fireEvent.click(getByText('Add Course')); });
+        const courseCard = document.getElementsByClassName(styles.row)[0];
+        const courseCardStyle = window.getComputedStyle(courseCard);
+
+        // assert
+        expect(courseCardStyle.paddingRight).toBe('2%');
+      });
+    });
+
+    test('and the window is resized', () => {
       // arrange
       const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
 
-      const { getByText } = render(
+      render(
         <Provider store={store}>
           <CourseSelectColumn />
         </Provider>,
       );
-      const courseSelectContainer = document.getElementById('courseSelectContainer');
+
+      const courseSelectContainer = document.getElementById('course-select-container');
       jest.spyOn(courseSelectContainer, 'clientHeight', 'get')
         .mockImplementation(() => 500);
       jest.spyOn(courseSelectContainer, 'scrollHeight', 'get')
         .mockImplementation(() => 600);
 
       // act
-      // add course to make course cards rerender
-      act(() => { fireEvent.click(getByText('Add Course')); });
+      // resize window and expect padding to change
+      window.dispatchEvent(new Event('resize'));
       const courseCard = document.getElementsByClassName(styles.row)[0];
       const courseCardStyle = window.getComputedStyle(courseCard);
 
       // assert
       expect(courseCardStyle.paddingRight).toBe('2%');
-    });
-
-    test('when there is not a scrollbar and course cards are changed', () => {
-      // arrange
-      const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
-
-      const { getByText } = render(
-        <Provider store={store}>
-          <CourseSelectColumn />
-        </Provider>,
-      );
-
-      const courseSelectContainer = document.getElementById('courseSelectContainer');
-      jest.spyOn(courseSelectContainer, 'clientHeight', 'get')
-        .mockImplementation(() => 500);
-      jest.spyOn(courseSelectContainer, 'scrollHeight', 'get')
-        .mockImplementation(() => 400);
-
-      // act
-      // add course to make course cards rerender
-      act(() => { fireEvent.click(getByText('Add Course')); });
-      const courseCard = document.getElementsByClassName(styles.row)[0];
-      const courseCardStyle = window.getComputedStyle(courseCard);
-
-      // assert
-      expect(courseCardStyle.paddingRight).toBe('0%');
     });
   });
 });

--- a/autoscheduler/frontend/src/tests/CourseSelectColumn.test.tsx
+++ b/autoscheduler/frontend/src/tests/CourseSelectColumn.test.tsx
@@ -8,6 +8,7 @@ import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import autoSchedulerReducer from '../redux/reducers';
 import CourseSelectColumn from '../components/CourseSelectColumn/CourseSelectColumn';
+import * as styles from '../components/CourseSelectColumn/CourseSelectColumn.css';
 
 describe('CourseSelectColumn', () => {
   describe('Adds a course card', () => {
@@ -75,6 +76,59 @@ describe('CourseSelectColumn', () => {
 
       // assert
       expect(checked).toEqual(1);
+    });
+  });
+
+  describe('correctly determines padding of cards', () => {
+    test('when there is a scrollbar and course cards are changed', () => {
+      // arrange
+      const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
+
+      const { getByText } = render(
+        <Provider store={store}>
+          <CourseSelectColumn />
+        </Provider>,
+      );
+      const courseSelectContainer = document.getElementById('courseSelectContainer');
+      jest.spyOn(courseSelectContainer, 'clientHeight', 'get')
+        .mockImplementation(() => 500);
+      jest.spyOn(courseSelectContainer, 'scrollHeight', 'get')
+        .mockImplementation(() => 600);
+
+      // act
+      // add course to make course cards rerender
+      act(() => { fireEvent.click(getByText('Add Course')); });
+      const courseCard = document.getElementsByClassName(styles.row)[0];
+      const courseCardStyle = window.getComputedStyle(courseCard);
+
+      // assert
+      expect(courseCardStyle.paddingRight).toBe('2%');
+    });
+
+    test('when there is not a scrollbar and course cards are changed', () => {
+      // arrange
+      const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
+
+      const { getByText } = render(
+        <Provider store={store}>
+          <CourseSelectColumn />
+        </Provider>,
+      );
+
+      const courseSelectContainer = document.getElementById('courseSelectContainer');
+      jest.spyOn(courseSelectContainer, 'clientHeight', 'get')
+        .mockImplementation(() => 500);
+      jest.spyOn(courseSelectContainer, 'scrollHeight', 'get')
+        .mockImplementation(() => 400);
+
+      // act
+      // add course to make course cards rerender
+      act(() => { fireEvent.click(getByText('Add Course')); });
+      const courseCard = document.getElementsByClassName(styles.row)[0];
+      const courseCardStyle = window.getComputedStyle(courseCard);
+
+      // assert
+      expect(courseCardStyle.paddingRight).toBe('0%');
     });
   });
 });


### PR DESCRIPTION
I made the course cards in the course select column change their padding based on whether there is a scroll bar in the component or not, instead of always keeping 2% padding. Here's what it looks like:
![dynamic width](https://user-images.githubusercontent.com/28655462/78280933-7c4a6200-74df-11ea-9f8c-b203a1bee41f.gif)
I'm not sure if the way I select elements is the best way to do so (`getElementById` and `getElementsByClassName`). As far as I can tell, we would have to change this to a class component to use refs in order to modify CSS after rendering, but if there's a better way to do so I'd like to know.