### PR TITLE
Improvements to course scraping

### DIFF
--- a/autoscheduler/scraper/management/commands/scrape_courses.py
+++ b/autoscheduler/scraper/management/commands/scrape_courses.py
@@ -34,7 +34,7 @@ def parse_meeting_days(meetings_data) -> List[bool]:
 
     return [meetings_data['meetingTime'][day] for day in meeting_class_days]
 
-def parse_section(course_data, instructor: Instructor):
+def parse_section(course_data, instructor: Instructor): # pylint: disable=too-many-locals
     """ Puts section data in database & calls parse_meeting.
         Called from parse_course.
     """

--- a/autoscheduler/scraper/management/commands/scrape_courses.py
+++ b/autoscheduler/scraper/management/commands/scrape_courses.py
@@ -1,4 +1,5 @@
 import asyncio
+from html import unescape
 import time
 import datetime
 from typing import List
@@ -44,21 +45,26 @@ def parse_section(course_data, instructor: Instructor):
     section_number = course_data['sequenceNumber']
     term_code = course_data['term']
 
-    crn = 0
-    if course_data['meetingsFaculty']:
-        crn = course_data['meetingsFaculty'][0]['courseReferenceNumber']
+    crn = course_data['courseReferenceNumber']
 
     min_credits = course_data['creditHourLow']
     max_credits = course_data['creditHourHigh']
     max_enrollment = course_data['maximumEnrollment']
     current_enrollment = course_data['enrollment']
+    # Go through section attributes to determine if the class is honors
+    honors = False
+    for attributes in course_data.get('sectionAttributes', []):
+        if attributes['description'] == "Honors":
+            honors = True
+            break
+
+    web = course_data.get('instructionalMethod', "") == "Web Based"
 
     # Creates and saves section object
     section_model = Section(
         id=section_id, subject=subject, course_num=course_number,
-        section_num=section_number, term_code=term_code,
-        crn=crn, min_credits=min_credits,
-        max_credits=max_credits, max_enrollment=max_enrollment,
+        section_num=section_number, term_code=term_code, crn=crn, min_credits=min_credits,
+        max_credits=max_credits, honors=honors, web=web, max_enrollment=max_enrollment,
         current_enrollment=current_enrollment, instructor=instructor)
     section_model.save()
 
@@ -121,12 +127,18 @@ def parse_course(course_data):
     # Generate the course's id using the above data
     course_id = generate_course_id(dept, course_number, term_code)
 
-    title = course_data['courseTitle']
+    # Some course titles contain escaped characters(ex. &amp;), so unescape them
+    title = unescape(course_data['courseTitle'])
+    # Some titles also start with "HNR-" if the first sections is honors, remove it
+    if title[0:4] == "HNR-":
+        title = title[4:]
     credit_hours = course_data['creditHourLow']
 
-    course_model = Course(id=course_id, dept=dept, course_num=course_number,
-                          title=title, credit_hours=credit_hours, term=term_code)
-    course_model.save()
+    # Save course only if it hasn't already been created
+    if course_id not in COURSES_SET:
+        course_model = Course(id=course_id, dept=dept, course_num=course_number,
+                              title=title, credit_hours=credit_hours, term=term_code)
+        course_model.save()
 
     COURSES_SET.add(course_id)
 

--- a/autoscheduler/scraper/management/commands/scrape_courses.py
+++ b/autoscheduler/scraper/management/commands/scrape_courses.py
@@ -85,6 +85,8 @@ def parse_meeting(meetings_data, section: Section, meeting_count: int):
     end_time = convert_meeting_time(meetings_data['meetingTime']['endTime'])
 
     building = meetings_data['meetingTime']['building']
+    if building:
+        building = unescape(building)
     class_type = meetings_data['meetingTime']['meetingType']
 
     meeting_model = Meeting(id=meeting_id, building=building, meeting_days=class_days,

--- a/autoscheduler/scraper/tests/data/section_input.json
+++ b/autoscheduler/scraper/tests/data/section_input.json
@@ -356,8 +356,398 @@
         }
       ],
       "termType": "STANDARD",
-      "instructionalMethod": "Web Based",
+      "instructionalMethod": "Traditional, Face to Face",
       "classRoster": "https://compass-sso.tamu.edu:443/ssomanager/c/SSB?pkg=bwykfcwl.P_FacClaListSum?term=202011&crn=36167",
+      "isAdvisor": null
+    },
+        {
+      "id": 469982,
+      "term": "201931",
+      "termDesc": "Fall 2019 - College Station",
+      "courseReferenceNumber": "13271",
+      "partOfTerm": "1",
+      "courseNumber": "207",
+      "subject": "POLS",
+      "subjectDescription": "POLS - Political Science",
+      "sequenceNumber": "200",
+      "campusDescription": "College Station",
+      "scheduleTypeDescription": "Lecture",
+      "courseTitle": "STATE &amp; LOCAL GOVT",
+      "creditHours": null,
+      "maximumEnrollment": 25,
+      "enrollment": 25,
+      "seatsAvailable": 0,
+      "waitCapacity": 0,
+      "waitCount": 0,
+      "waitAvailable": 0,
+      "crossList": null,
+      "crossListCapacity": null,
+      "crossListCount": null,
+      "crossListAvailable": null,
+      "creditHourHigh": null,
+      "creditHourLow": 3,
+      "creditHourIndicator": null,
+      "openSection": false,
+      "linkIdentifier": null,
+      "isSectionLinked": false,
+      "subjectCourse": "POLS207",
+      "faculty": 
+      [
+        {
+          "bannerId": "134617",
+          "category": null,
+          "class": "net.hedtech.banner.student.faculty.FacultyResultDecorator",
+          "courseReferenceNumber": "13271",
+          "displayName": "Douglas S. Thornton",
+          "emailAddress": "d-thornton@email.tamu.edu",
+          "id": null,
+          "primaryIndicator": true,
+          "term": "201931",
+          "version": null
+        }
+      ],
+      "meetingsFaculty": 
+      [
+        {
+          "category": "01",
+          "class": "net.hedtech.banner.student.schedule.SectionSessionDecorator",
+          "courseReferenceNumber": "13271",
+          "faculty": 
+          [
+          ],
+          "meetingTime": {
+            "beginTime": "1505",
+            "building": "ALLN",
+            "buildingDescription": "Bush Academic Building West",
+            "campus": "CS",
+            "campusDescription": "College Station",
+            "category": "01",
+            "class": "net.hedtech.banner.general.overall.MeetingTimeDecorator",
+            "courseReferenceNumber": "13271",
+            "creditHourSession": 3.0,
+            "endDate": "12/11/2019",
+            "endTime": "1620",
+            "friday": false,
+            "hoursWeek": 2.5,
+            "meetingScheduleType": "LEC",
+            "meetingType": "LEC",
+            "meetingTypeDescription": "Lecture",
+            "monday": false,
+            "room": "1005",
+            "saturday": false,
+            "startDate": "08/26/2019",
+            "sunday": false,
+            "term": "201931",
+            "thursday": true,
+            "tuesday": true,
+            "wednesday": false
+          },
+          "term": "201931"
+        }
+      ],
+      "reservedSeatSummary": null,
+      "sectionAttributes": 
+      [
+        {
+          "class": "net.hedtech.banner.student.schedule.SectionDegreeProgramAttributeDecorator",
+          "code": "ACST",
+          "courseReferenceNumber": "13271",
+          "description": "College Station",
+          "isZTCAttribute": false,
+          "termCode": "201931"
+        },
+        {
+          "class": "net.hedtech.banner.student.schedule.SectionDegreeProgramAttributeDecorator",
+          "code": "HONR",
+          "courseReferenceNumber": "13271",
+          "description": "Honors",
+          "isZTCAttribute": false,
+          "termCode": "201931"
+        },
+        {
+          "class": "net.hedtech.banner.student.schedule.SectionDegreeProgramAttributeDecorator",
+          "code": "KPLL",
+          "courseReferenceNumber": "13271",
+          "description": "Core Local Gov/Pol Sci (KPLL)",
+          "isZTCAttribute": false,
+          "termCode": "201931"
+        },
+        {
+          "class": "net.hedtech.banner.student.schedule.SectionDegreeProgramAttributeDecorator",
+          "code": "NTFA",
+          "courseReferenceNumber": "13271",
+          "description": "NonTraditional Format Approved",
+          "isZTCAttribute": false,
+          "termCode": "201931"
+        }
+      ],
+      "termType": "STANDARD",
+      "instructionalMethod": "Traditional, Face-to-Face",
+      "classRoster": "https://compass-sso.tamu.edu:443/ssomanager/c/SSB?pkg=bwykfcwl.P_FacClaListSum?term=201931&crn=13271",
+      "isAdvisor": null
+    },
+    {
+      "id": 467471,
+      "term": "201931",
+      "termDesc": "Fall 2019 - College Station",
+      "courseReferenceNumber": "10004",
+      "partOfTerm": "1",
+      "courseNumber": "229",
+      "subject": "ACCT",
+      "subjectDescription": "ACCT - Accounting",
+      "sequenceNumber": "202",
+      "campusDescription": "College Station",
+      "scheduleTypeDescription": "Lecture",
+      "courseTitle": "HNR-INTRO ACCOUNTING",
+      "creditHours": null,
+      "maximumEnrollment": 0,
+      "enrollment": 24,
+      "seatsAvailable": -24,
+      "waitCapacity": 0,
+      "waitCount": 0,
+      "waitAvailable": 0,
+      "crossList": null,
+      "crossListCapacity": null,
+      "crossListCount": null,
+      "crossListAvailable": null,
+      "creditHourHigh": null,
+      "creditHourLow": 3,
+      "creditHourIndicator": null,
+      "openSection": false,
+      "linkIdentifier": null,
+      "isSectionLinked": false,
+      "subjectCourse": "ACCT229",
+      "faculty": 
+      [
+        {
+          "bannerId": "134327",
+          "category": null,
+          "class": "net.hedtech.banner.student.faculty.FacultyResultDecorator",
+          "courseReferenceNumber": "10004",
+          "displayName": "Jerry R. Strawser",
+          "emailAddress": "jstrawser@email.tamu.edu",
+          "id": null,
+          "primaryIndicator": true,
+          "term": "201931",
+          "version": null
+        }
+      ],
+      "meetingsFaculty": 
+      [
+        {
+          "category": "01",
+          "class": "net.hedtech.banner.student.schedule.SectionSessionDecorator",
+          "courseReferenceNumber": "10004",
+          "faculty": 
+          [
+          ],
+          "meetingTime": {
+            "beginTime": "1500",
+            "building": "WCBA",
+            "buildingDescription": "Wehner - College of Business",
+            "campus": "CS",
+            "campusDescription": "College Station",
+            "category": "01",
+            "class": "net.hedtech.banner.general.overall.MeetingTimeDecorator",
+            "courseReferenceNumber": "10004",
+            "creditHourSession": 0.0,
+            "endDate": "12/11/2019",
+            "endTime": "1730",
+            "friday": false,
+            "hoursWeek": 2.5,
+            "meetingScheduleType": "LEC",
+            "meetingType": "LEC",
+            "meetingTypeDescription": "Lecture",
+            "monday": false,
+            "room": "490",
+            "saturday": false,
+            "startDate": "08/26/2019",
+            "sunday": false,
+            "term": "201931",
+            "thursday": false,
+            "tuesday": false,
+            "wednesday": true
+          },
+          "term": "201931"
+        }
+      ],
+      "reservedSeatSummary": null,
+      "sectionAttributes": 
+      [
+        {
+          "class": "net.hedtech.banner.student.schedule.SectionDegreeProgramAttributeDecorator",
+          "code": "ACST",
+          "courseReferenceNumber": "10004",
+          "description": "College Station",
+          "isZTCAttribute": false,
+          "termCode": "201931"
+        },
+        {
+          "class": "net.hedtech.banner.student.schedule.SectionDegreeProgramAttributeDecorator",
+          "code": "HONR",
+          "courseReferenceNumber": "10004",
+          "description": "Honors",
+          "isZTCAttribute": false,
+          "termCode": "201931"
+        }
+      ],
+      "termType": "STANDARD",
+      "instructionalMethod": "Traditional, Face-to-Face",
+      "classRoster": "https://compass-sso.tamu.edu:443/ssomanager/c/SSB?pkg=bwykfcwl.P_FacClaListSum?term=201931&crn=10004",
+      "isAdvisor": null
+    },
+    {
+      "id": 515269,
+      "term": "201931",
+      "termDesc": "Fall 2019 - College Station",
+      "courseReferenceNumber": "40978",
+      "partOfTerm": "MA",
+      "courseNumber": "121",
+      "subject": "CSCE",
+      "subjectDescription": "CSCE - Computer Sci &amp; Engr",
+      "sequenceNumber": "M99",
+      "campusDescription": "College Station",
+      "scheduleTypeDescription": "Lecture and Laboratory",
+      "courseTitle": "INTRO PGM DESIGN CONCEPT",
+      "creditHours": null,
+      "maximumEnrollment": 10,
+      "enrollment": 10,
+      "seatsAvailable": 0,
+      "waitCapacity": 0,
+      "waitCount": 0,
+      "waitAvailable": 0,
+      "crossList": null,
+      "crossListCapacity": null,
+      "crossListCount": null,
+      "crossListAvailable": null,
+      "creditHourHigh": null,
+      "creditHourLow": 4,
+      "creditHourIndicator": null,
+      "openSection": false,
+      "linkIdentifier": null,
+      "isSectionLinked": false,
+      "subjectCourse": "CSCE121",
+      "faculty": 
+      [
+        {
+          "bannerId": "119925",
+          "category": null,
+          "class": "net.hedtech.banner.student.faculty.FacultyResultDecorator",
+          "courseReferenceNumber": "40978",
+          "displayName": "John M. Moore",
+          "emailAddress": "jmichael@email.tamu.edu",
+          "id": null,
+          "primaryIndicator": true,
+          "term": "201931",
+          "version": null
+        }
+      ],
+      "meetingsFaculty": 
+      [
+        {
+          "category": "01",
+          "class": "net.hedtech.banner.student.schedule.SectionSessionDecorator",
+          "courseReferenceNumber": "40978",
+          "faculty": 
+          [
+          ],
+          "meetingTime": {
+            "beginTime": null,
+            "building": null,
+            "buildingDescription": null,
+            "campus": null,
+            "campusDescription": null,
+            "category": "01",
+            "class": "net.hedtech.banner.general.overall.MeetingTimeDecorator",
+            "courseReferenceNumber": "40978",
+            "creditHourSession": 4.0,
+            "endDate": "12/11/2019",
+            "endTime": null,
+            "friday": false,
+            "hoursWeek": 0.0,
+            "meetingScheduleType": "LL",
+            "meetingType": "LEC",
+            "meetingTypeDescription": "Lecture",
+            "monday": false,
+            "room": null,
+            "saturday": false,
+            "startDate": "08/26/2019",
+            "sunday": false,
+            "term": "201931",
+            "thursday": false,
+            "tuesday": false,
+            "wednesday": false
+          },
+          "term": "201931"
+        },
+        {
+          "category": "02",
+          "class": "net.hedtech.banner.student.schedule.SectionSessionDecorator",
+          "courseReferenceNumber": "40978",
+          "faculty": 
+          [
+          ],
+          "meetingTime": {
+            "beginTime": null,
+            "building": null,
+            "buildingDescription": null,
+            "campus": null,
+            "campusDescription": null,
+            "category": "02",
+            "class": "net.hedtech.banner.general.overall.MeetingTimeDecorator",
+            "courseReferenceNumber": "40978",
+            "creditHourSession": 0.0,
+            "endDate": "12/11/2019",
+            "endTime": null,
+            "friday": false,
+            "hoursWeek": 0.0,
+            "meetingScheduleType": "LL",
+            "meetingType": "LAB",
+            "meetingTypeDescription": "Laboratory",
+            "monday": false,
+            "room": null,
+            "saturday": false,
+            "startDate": "08/26/2019",
+            "sunday": false,
+            "term": "201931",
+            "thursday": false,
+            "tuesday": false,
+            "wednesday": false
+          },
+          "term": "201931"
+        }
+      ],
+      "reservedSeatSummary": null,
+      "sectionAttributes": 
+      [
+        {
+          "class": "net.hedtech.banner.student.schedule.SectionDegreeProgramAttributeDecorator",
+          "code": "AMCA",
+          "courseReferenceNumber": "40978",
+          "description": "McAllen",
+          "isZTCAttribute": false,
+          "termCode": "201931"
+        },
+        {
+          "class": "net.hedtech.banner.student.schedule.SectionDegreeProgramAttributeDecorator",
+          "code": "DIST",
+          "courseReferenceNumber": "40978",
+          "description": "Distance Education",
+          "isZTCAttribute": false,
+          "termCode": "201931"
+        },
+        {
+          "class": "net.hedtech.banner.student.schedule.SectionDegreeProgramAttributeDecorator",
+          "code": "NTFA",
+          "courseReferenceNumber": "40978",
+          "description": "NonTraditional Format Approved",
+          "isZTCAttribute": false,
+          "termCode": "201931"
+        }
+      ],
+      "termType": "STANDARD",
+      "instructionalMethod": "Web Based",
+      "classRoster": "https://compass-sso.tamu.edu:443/ssomanager/c/SSB?pkg=bwykfcwl.P_FacClaListSum?term=201931&crn=40978",
       "isAdvisor": null
     }
   ]

--- a/autoscheduler/scraper/tests/data/section_input.json
+++ b/autoscheduler/scraper/tests/data/section_input.json
@@ -749,6 +749,140 @@
       "instructionalMethod": "Web Based",
       "classRoster": "https://compass-sso.tamu.edu:443/ssomanager/c/SSB?pkg=bwykfcwl.P_FacClaListSum?term=201931&crn=40978",
       "isAdvisor": null
+    },
+    {
+      "id": 273268,
+      "term": "201531",
+      "termDesc": "Fall 2015 - College Station",
+      "courseReferenceNumber": "12480",
+      "partOfTerm": "1",
+      "courseNumber": "251",
+      "subject": "OCNG",
+      "subjectDescription": "OCNG - Oceanography",
+      "sequenceNumber": "202",
+      "campusDescription": "College Station",
+      "scheduleTypeDescription": "Lecture",
+      "courseTitle": "HNR-OCEANOGRAPHY",
+      "creditHours": null,
+      "maximumEnrollment": 20,
+      "enrollment": 20,
+      "seatsAvailable": 0,
+      "waitCapacity": 0,
+      "waitCount": 0,
+      "waitAvailable": 0,
+      "crossList": null,
+      "crossListCapacity": null,
+      "crossListCount": null,
+      "crossListAvailable": null,
+      "creditHourHigh": null,
+      "creditHourLow": 3,
+      "creditHourIndicator": null,
+      "openSection": false,
+      "linkIdentifier": null,
+      "isSectionLinked": false,
+      "subjectCourse": "OCNG251",
+      "faculty": 
+      [
+        {
+          "bannerId": "172665",
+          "category": null,
+          "class": "net.hedtech.banner.student.faculty.FacultyResultDecorator",
+          "courseReferenceNumber": "12480",
+          "displayName": "David Brooks",
+          "emailAddress": "dabrooks@email.tamu.edu",
+          "id": null,
+          "primaryIndicator": true,
+          "term": "201531",
+          "version": null
+        }
+      ],
+      "meetingsFaculty": 
+      [
+        {
+          "category": "01",
+          "class": "net.hedtech.banner.student.schedule.SectionSessionDecorator",
+          "courseReferenceNumber": "12480",
+          "faculty": 
+          [
+          ],
+          "meetingTime": {
+            "beginTime": "0935",
+            "building": "O&amp;M",
+            "buildingDescription": "Eller Oceanography &amp; Metr Bldg",
+            "campus": "CS",
+            "campusDescription": "College Station",
+            "category": "01",
+            "class": "net.hedtech.banner.general.overall.MeetingTimeDecorator",
+            "courseReferenceNumber": "12480",
+            "creditHourSession": 3.0,
+            "endDate": "12/16/2015",
+            "endTime": "1050",
+            "friday": false,
+            "hoursWeek": 2.5,
+            "meetingScheduleType": "LEC",
+            "meetingType": "LEC",
+            "meetingTypeDescription": "Lecture",
+            "monday": false,
+            "room": "303",
+            "saturday": false,
+            "startDate": "08/31/2015",
+            "sunday": false,
+            "term": "201531",
+            "thursday": true,
+            "tuesday": true,
+            "wednesday": false
+          },
+          "term": "201531"
+        }
+      ],
+      "reservedSeatSummary": null,
+      "sectionAttributes": 
+      [
+        {
+          "class": "net.hedtech.banner.student.schedule.SectionDegreeProgramAttributeDecorator",
+          "code": "030",
+          "courseReferenceNumber": "12480",
+          "description": "030",
+          "isZTCAttribute": false,
+          "termCode": "201531"
+        },
+        {
+          "class": "net.hedtech.banner.student.schedule.SectionDegreeProgramAttributeDecorator",
+          "code": "031",
+          "courseReferenceNumber": "12480",
+          "description": "031",
+          "isZTCAttribute": false,
+          "termCode": "201531"
+        },
+        {
+          "class": "net.hedtech.banner.student.schedule.SectionDegreeProgramAttributeDecorator",
+          "code": "HONR",
+          "courseReferenceNumber": "12480",
+          "description": "Honors",
+          "isZTCAttribute": false,
+          "termCode": "201531"
+        },
+        {
+          "class": "net.hedtech.banner.student.schedule.SectionDegreeProgramAttributeDecorator",
+          "code": "KLPS",
+          "courseReferenceNumber": "12480",
+          "description": "Core Life/Physical Sci (KLPS)",
+          "isZTCAttribute": false,
+          "termCode": "201531"
+        },
+        {
+          "class": "net.hedtech.banner.student.schedule.SectionDegreeProgramAttributeDecorator",
+          "code": "USC2",
+          "courseReferenceNumber": "12480",
+          "description": "Univ Req-Nat Sci Tier2 (USC2)",
+          "isZTCAttribute": false,
+          "termCode": "201531"
+        }
+      ],
+      "termType": "STANDARD",
+      "instructionalMethod": "Traditional, Face-to-Face",
+      "classRoster": "https://compass-sso.tamu.edu:443/ssomanager/c/SSB?pkg=bwykfcwl.P_FacClaListSum?term=201531&crn=12480",
+      "isAdvisor": null
     }
   ]
 }


### PR DESCRIPTION
Making the scheduling algorithm, I realized that we don't actually scrape whether sections are web or online (which I need to test section filtering), so I added that functionality. I also made slight improvements to `parse_course` (see my commit messages) fixed a bug with honors section titles (which start with `HNR-`) being parsed directly, and added tests for these new functionalities.
