### PR TITLE
Connects landing page to main page

### DIFF
--- a/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
+++ b/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {
   Menu, MenuItem, Button,
 } from '@material-ui/core';
+import { navigate } from '@reach/router';
 import { useDispatch } from 'react-redux';
 import setTerm from '../../../redux/actions/term';
 import * as styles from './SelectTerm.css';
@@ -52,7 +53,7 @@ const SelectTerm: React.SFC = () => {
     dispatch(setTerm({ term }));
 
     // Redirect to the main page
-    window.location.assign('/schedule');
+    navigate('/schedule');
   };
 
   return (

--- a/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
+++ b/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
@@ -9,12 +9,12 @@ import * as styles from './SelectTerm.css';
 
 const options = [
   'None',
-  'Semester 1',
-  'Semester 2',
-  'Semester 3',
-  'Semester 4',
-  'Semester 5',
-  'Semester 6',
+  'Fall 2020',
+  'Summer 2020',
+  'Spring 2020',
+  'Fall 2019',
+  'Summer 2019',
+  'Spring 2019',
 ];
 
 // Maps between the term description and its actual value (which we'll use to store)
@@ -23,12 +23,12 @@ const termMap: { [key: string]: any } = {
   // This lint is temporary, and shouldn't be needed for the future
   // eslint-disable-next-line quote-props
   'None': -1,
-  'Semester 1': 201931,
-  'Semester 2': 201931,
-  'Semester 3': 201931,
-  'Semester 4': 201931,
-  'Semester 5': 201931,
-  'Semester 6': 201931,
+  'Fall 2020': 202031,
+  'Summer 2020': 202021,
+  'Spring 2020': 202011,
+  'Fall 2019': 201931,
+  'Summer 2019': 201921,
+  'Spring 2019': 201911,
 };
 
 const SelectTerm: React.SFC = () => {

--- a/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
+++ b/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import {
   Menu, MenuItem, Button,
 } from '@material-ui/core';
+import { useDispatch } from 'react-redux';
+import setTerm from '../../../redux/actions/term';
 import * as styles from './SelectTerm.css';
 
 const options = [
@@ -14,11 +16,27 @@ const options = [
   'Semester 6',
 ];
 
+// Maps between the term description and its actual value (which we'll use to store)
+// We might not need this in the future?
+const termMap: { [key: string]: any } = {
+  // This lint is temporary, and shouldn't be needed for the future
+  // eslint-disable-next-line quote-props
+  'None': -1,
+  'Semester 1': 201931,
+  'Semester 2': 201931,
+  'Semester 3': 201931,
+  'Semester 4': 201931,
+  'Semester 5': 201931,
+  'Semester 6': 201931,
+};
+
 const SelectTerm: React.SFC = () => {
   // anchorEl tells the popover menu where to center itself. Null means the menu is hidden
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
-  const [selectedTerm, selectTerm] = React.useState(options[0]);
+  const [selectedTerm, setSelectedTerm] = React.useState(options[0]);
+
+  const dispatch = useDispatch();
 
   const handleClick = (event: React.MouseEvent<HTMLElement>): void => {
     setAnchorEl(event.currentTarget);
@@ -26,7 +44,15 @@ const SelectTerm: React.SFC = () => {
 
   const handleClose = (option: string): void => {
     setAnchorEl(null);
-    selectTerm(option);
+    setSelectedTerm(option);
+
+    // Get the corresponding option given the term's description
+    const term: number = termMap[option];
+
+    dispatch(setTerm({ term }));
+
+    // Redirect to the main page
+    window.location.href = '/schedule';
   };
 
   return (

--- a/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
+++ b/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
@@ -52,7 +52,7 @@ const SelectTerm: React.SFC = () => {
     dispatch(setTerm({ term }));
 
     // Redirect to the main page
-    window.location.href = '/schedule';
+    window.location.assign('/schedule');
   };
 
   return (

--- a/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
+++ b/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
@@ -50,7 +50,7 @@ const SelectTerm: React.SFC = () => {
     // Get the corresponding option given the term's description
     const term: number = termMap[option];
 
-    dispatch(setTerm({ term }));
+    dispatch(setTerm(term));
 
     // Redirect to the main page
     navigate('/schedule');

--- a/autoscheduler/frontend/src/redux/actions/term.ts
+++ b/autoscheduler/frontend/src/redux/actions/term.ts
@@ -1,11 +1,11 @@
-import { SET_TERM, SetTermAction, TermType } from '../reducers/term';
+import { SET_TERM, SetTermAction } from '../reducers/term';
 
 /**
  * Sets the current term.
  * Called from the landing page upon term selection
  * @param term The term, such as 201931
  */
-export default function setTerm(term: TermType): SetTermAction {
+export default function setTerm(term: number): SetTermAction {
   return {
     type: SET_TERM,
     term,

--- a/autoscheduler/frontend/src/redux/actions/term.ts
+++ b/autoscheduler/frontend/src/redux/actions/term.ts
@@ -1,0 +1,13 @@
+import { SET_TERM, SetTermAction, TermType } from '../reducers/term';
+
+/**
+ * Sets the current term.
+ * Called from the landing page upon term selection
+ * @param term The term, such as 201931
+ */
+export default function setTerm(term: TermType): SetTermAction {
+  return {
+    type: SET_TERM,
+    term,
+  };
+}

--- a/autoscheduler/frontend/src/redux/reducer.ts
+++ b/autoscheduler/frontend/src/redux/reducer.ts
@@ -7,6 +7,7 @@ import availabilityMode from './reducers/availabilityMode';
 import meetings from './reducers/meetings';
 import courseCards from './reducers/courseCards';
 import selectedAvailability from './reducers/selectedAvailability';
+import term from './reducers/term';
 
 const autoSchedulerReducer = combineReducers({
   meetings,
@@ -14,6 +15,7 @@ const autoSchedulerReducer = combineReducers({
   availabilityMode,
   availability,
   selectedAvailability,
+  term,
 });
 
 export default autoSchedulerReducer;

--- a/autoscheduler/frontend/src/redux/reducers/term.ts
+++ b/autoscheduler/frontend/src/redux/reducers/term.ts
@@ -1,0 +1,30 @@
+/**
+ * Stores the current term
+ */
+
+// type
+export class TermType {
+  term: number;
+}
+
+// action type string
+export const SET_TERM = 'SET_TERM';
+
+// action type interface
+export interface SetTermAction {
+  type: 'SET_TERM';
+  term: TermType;
+}
+
+// reducer
+export default function term(state: TermType = { term: 0 }, action: SetTermAction): TermType {
+  switch (action.type) {
+    case SET_TERM:
+      return {
+        ...state,
+        term: action.term.term,
+      };
+    default:
+      return state;
+  }
+}

--- a/autoscheduler/frontend/src/redux/reducers/term.ts
+++ b/autoscheduler/frontend/src/redux/reducers/term.ts
@@ -2,28 +2,20 @@
  * Stores the current term
  */
 
-// type
-export class TermType {
-  term: number;
-}
-
 // action type string
 export const SET_TERM = 'SET_TERM';
 
 // action type interface
 export interface SetTermAction {
   type: 'SET_TERM';
-  term: TermType;
+  term: number;
 }
 
 // reducer
-export default function term(state: TermType = { term: 0 }, action: SetTermAction): TermType {
+export default function term(state = 0, action: SetTermAction): number {
   switch (action.type) {
     case SET_TERM:
-      return {
-        ...state,
-        term: action.term.term,
-      };
+      return action.term;
     default:
       return state;
   }

--- a/autoscheduler/frontend/src/tests/SelectTerm.test.tsx
+++ b/autoscheduler/frontend/src/tests/SelectTerm.test.tsx
@@ -40,8 +40,10 @@ describe('SelectTerm', () => {
       // assert
       expect(document.getElementsByClassName('MuiPopover-root')[0]).toHaveAttribute('aria-hidden');
     });
+  });
 
-    test('after item is selected', () => {
+  describe('Redirects to /schedule', () => {
+    test('When term is selected', () => {
       // arrange
       const store = createStore(autoSchedulerReducer);
 
@@ -51,6 +53,9 @@ describe('SelectTerm', () => {
         </Provider>,
       );
 
+      // Mocks window.location.assign(url), so we can assert that it redirected to the correct url
+      const assignSpy = jest.spyOn(window.location, 'assign').mockImplementation();
+
       // act
       const button = getByText('Select Term');
       fireEvent.click(button);
@@ -58,7 +63,7 @@ describe('SelectTerm', () => {
       fireEvent.click(testSemester);
 
       // assert
-      expect(document.getElementsByClassName('MuiPopover-root')[0]).toHaveAttribute('aria-hidden');
+      expect(assignSpy).toHaveBeenCalledWith('/schedule');
     });
   });
 });

--- a/autoscheduler/frontend/src/tests/SelectTerm.test.tsx
+++ b/autoscheduler/frontend/src/tests/SelectTerm.test.tsx
@@ -1,27 +1,58 @@
 import { render, fireEvent } from '@testing-library/react';
 import * as React from 'react';
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
 import SelectTerm from '../components/LandingPage/SelectTerm/SelectTerm';
+import autoSchedulerReducer from '../redux/reducer';
 
 test('Menu is closed initially', () => {
-  render(<SelectTerm />);
+  // arrange/act
+  const store = createStore(autoSchedulerReducer);
 
+  render(
+    <Provider store={store}>
+      <SelectTerm />
+    </Provider>,
+  );
+
+  // assert
   expect(document.getElementsByClassName('MuiPopover-root')[0]).toHaveAttribute('aria-hidden');
 });
 
 test('Menu opens after button is clicked', () => {
-  const { getByText } = render(<SelectTerm />);
+  // arrange
+  const store = createStore(autoSchedulerReducer);
+
+  const { getByText } = render(
+    <Provider store={store}>
+      <SelectTerm />
+    </Provider>,
+  );
+
+  // act
   const button = getByText('Select Term');
   fireEvent.click(button);
 
+  // assert
   expect(document.getElementsByClassName('MuiPopover-root')[0]).not.toHaveAttribute('aria-hidden');
 });
 
 test('Menu closes after item is selected', () => {
-  const { getByText } = render(<SelectTerm />);
+  // arrange
+  const store = createStore(autoSchedulerReducer);
+
+  const { getByText } = render(
+    <Provider store={store}>
+      <SelectTerm />
+    </Provider>,
+  );
+
+  // act
   const button = getByText('Select Term');
   fireEvent.click(button);
   const testSemester = getByText('Semester 1');
   fireEvent.click(testSemester);
 
+  // assert
   expect(document.getElementsByClassName('MuiPopover-root')[0]).toHaveAttribute('aria-hidden');
 });

--- a/autoscheduler/frontend/src/tests/SelectTerm.test.tsx
+++ b/autoscheduler/frontend/src/tests/SelectTerm.test.tsx
@@ -2,8 +2,15 @@ import { render, fireEvent } from '@testing-library/react';
 import * as React from 'react';
 import { createStore } from 'redux';
 import { Provider } from 'react-redux';
+import { navigate } from '@reach/router';
 import SelectTerm from '../components/LandingPage/SelectTerm/SelectTerm';
 import autoSchedulerReducer from '../redux/reducer';
+
+// Mocks navigate, so we can assert that it redirected to the correct url for Redirects to /schedule
+// This must be outside of all describes in order to function correctly
+jest.mock('@reach/router', () => ({
+  navigate: jest.fn(),
+}));
 
 describe('SelectTerm', () => {
   describe('Menu opens', () => {
@@ -53,8 +60,6 @@ describe('SelectTerm', () => {
         </Provider>,
       );
 
-      // Mocks window.location.assign(url), so we can assert that it redirected to the correct url
-      const assignSpy = jest.spyOn(window.location, 'assign').mockImplementation();
 
       // act
       const button = getByText('Select Term');
@@ -63,7 +68,8 @@ describe('SelectTerm', () => {
       fireEvent.click(testSemester);
 
       // assert
-      expect(assignSpy).toHaveBeenCalledWith('/schedule');
+      // see jest.mock at top of the file
+      expect(navigate).toHaveBeenCalledWith('/schedule');
     });
   });
 });

--- a/autoscheduler/frontend/src/tests/SelectTerm.test.tsx
+++ b/autoscheduler/frontend/src/tests/SelectTerm.test.tsx
@@ -5,54 +5,60 @@ import { Provider } from 'react-redux';
 import SelectTerm from '../components/LandingPage/SelectTerm/SelectTerm';
 import autoSchedulerReducer from '../redux/reducer';
 
-test('Menu is closed initially', () => {
-  // arrange/act
-  const store = createStore(autoSchedulerReducer);
+describe('SelectTerm', () => {
+  describe('Menu opens', () => {
+    test('Menu opens after button is clicked', () => {
+      // arrange
+      const store = createStore(autoSchedulerReducer);
 
-  render(
-    <Provider store={store}>
-      <SelectTerm />
-    </Provider>,
-  );
+      const { getByText } = render(
+        <Provider store={store}>
+          <SelectTerm />
+        </Provider>,
+      );
 
-  // assert
-  expect(document.getElementsByClassName('MuiPopover-root')[0]).toHaveAttribute('aria-hidden');
-});
+      // act
+      const button = getByText('Select Term');
+      fireEvent.click(button);
 
-test('Menu opens after button is clicked', () => {
-  // arrange
-  const store = createStore(autoSchedulerReducer);
+      // assert
+      expect(document.getElementsByClassName('MuiPopover-root')[0]).not.toHaveAttribute('aria-hidden');
+    });
+  });
 
-  const { getByText } = render(
-    <Provider store={store}>
-      <SelectTerm />
-    </Provider>,
-  );
+  describe('Menu is closed', () => {
+    test('on initialization', () => {
+      // arrange/act
+      const store = createStore(autoSchedulerReducer);
 
-  // act
-  const button = getByText('Select Term');
-  fireEvent.click(button);
+      render(
+        <Provider store={store}>
+          <SelectTerm />
+        </Provider>,
+      );
 
-  // assert
-  expect(document.getElementsByClassName('MuiPopover-root')[0]).not.toHaveAttribute('aria-hidden');
-});
+      // assert
+      expect(document.getElementsByClassName('MuiPopover-root')[0]).toHaveAttribute('aria-hidden');
+    });
 
-test('Menu closes after item is selected', () => {
-  // arrange
-  const store = createStore(autoSchedulerReducer);
+    test('after item is selected', () => {
+      // arrange
+      const store = createStore(autoSchedulerReducer);
 
-  const { getByText } = render(
-    <Provider store={store}>
-      <SelectTerm />
-    </Provider>,
-  );
+      const { getByText } = render(
+        <Provider store={store}>
+          <SelectTerm />
+        </Provider>,
+      );
 
-  // act
-  const button = getByText('Select Term');
-  fireEvent.click(button);
-  const testSemester = getByText('Semester 1');
-  fireEvent.click(testSemester);
+      // act
+      const button = getByText('Select Term');
+      fireEvent.click(button);
+      const testSemester = getByText('Semester 1');
+      fireEvent.click(testSemester);
 
-  // assert
-  expect(document.getElementsByClassName('MuiPopover-root')[0]).toHaveAttribute('aria-hidden');
+      // assert
+      expect(document.getElementsByClassName('MuiPopover-root')[0]).toHaveAttribute('aria-hidden');
+    });
+  });
 });

--- a/autoscheduler/frontend/src/tests/SelectTerm.test.tsx
+++ b/autoscheduler/frontend/src/tests/SelectTerm.test.tsx
@@ -64,7 +64,7 @@ describe('SelectTerm', () => {
       // act
       const button = getByText('Select Term');
       fireEvent.click(button);
-      const testSemester = getByText('Semester 1');
+      const testSemester = getByText('Fall 2020');
       fireEvent.click(testSemester);
 
       // assert

--- a/autoscheduler/frontend/src/tests/redux/Term.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/Term.test.ts
@@ -9,9 +9,9 @@ describe('Terms redux', () => {
     const term = 201931;
 
     // act
-    store.dispatch(setTerm({ term }));
+    store.dispatch(setTerm(term));
 
     // assert
-    expect(store.getState().term.term).toEqual(term);
+    expect(store.getState().term).toEqual(term);
   });
 });

--- a/autoscheduler/frontend/src/tests/redux/Term.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/Term.test.ts
@@ -1,0 +1,17 @@
+import { createStore } from 'redux';
+import autoSchedulerReducer from '../../redux/reducer';
+import setTerm from '../../redux/actions/term';
+
+describe('Terms redux', () => {
+  test('setTerm sets the term', () => {
+    // arrange
+    const store = createStore(autoSchedulerReducer);
+    const term = 201931;
+
+    // act
+    store.dispatch(setTerm({ term }));
+
+    // assert
+    expect(store.getState().term.term).toEqual(term);
+  });
+});


### PR DESCRIPTION
Makes it so that when you select the term on the landing page, it brings you to `/scheduling`, and sets the current term in the Redux store so it can be accessed when we fetch to the backend.

Closes #146 