### PR TITLE
Implemented scheduling api route

### DIFF
--- a/autoscheduler/autoscheduler/urls.py
+++ b/autoscheduler/autoscheduler/urls.py
@@ -19,5 +19,6 @@ from django.urls import path, include
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/', include('scraper.urls')),
+    path('scheduler/', include('scheduler.urls')),
     path('', include('frontend.urls')),
 ]

--- a/autoscheduler/scheduler/create_schedules.py
+++ b/autoscheduler/scheduler/create_schedules.py
@@ -113,7 +113,7 @@ def _schedule_valid(meetings: Tuple[Dict[str, Tuple[Meeting]]],
 def create_schedules(courses: List[CourseFilter], term: str,
                      unavailable_times: List[UnavailableTime],
                      include_full: bool,
-                     num_schedules: int = 10) -> List[Tuple[str]]:
+                     num_schedules: int = 10) -> List[Tuple[int]]:
     """ Generates and returns a schedule containing the courses provided as an argument.
 
     Args:

--- a/autoscheduler/scheduler/tests/api_tests.py
+++ b/autoscheduler/scheduler/tests/api_tests.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 from datetime import time
 from rest_framework.test import APITestCase, APIClient
-from scheduler.views import (_parse_course_filter, _parse_unavailable_times,
+from scheduler.views import (_parse_course_filter, _parse_unavailable_time,
                              _serialize_schedules)
 from scheduler.utils import UnavailableTime, CourseFilter
 from scraper.models import Section, Instructor
@@ -30,45 +30,37 @@ class SchedulingAPITests(APITestCase):
         """ Tests that _parse_counter_filter works on a typical input """
 
         # Arrange
-        courses = [
-            {
-                "subject": "CSCE",
-                "courseNum": "121",
-                "sections": ["500"],
-                "honors": False,
-                "web": False,
-            },
-        ]
+        course = {
+            "subject": "CSCE",
+            "courseNum": "121",
+            "sections": ["500"],
+            "honors": False,
+            "web": False,
+        }
 
-        expected = [
-            CourseFilter(subject="CSCE", course_num="121", section_nums=["500"],
-                         honors=False, web=False)
-        ]
+        expected = CourseFilter(subject="CSCE", course_num="121", section_nums=["500"],
+                                honors=False, web=False)
 
         # Act
-        result = _parse_course_filter(courses)
+        result = _parse_course_filter(course)
 
         # Assert
         self.assertEqual(result, expected)
 
-    def test_parse_unavailable_times_is_correct(self):
+    def test_parse_unavailable_time_is_correct(self):
         """ Tests that _parse_unavailable_times works on a typical input """
 
         # Arrange
-        availabilities = [
-            {
-                "startTime": "0800",
-                "endTime": "1000",
-                "day": 0,
-            },
-        ]
+        availability = {
+            "startTime": "0800",
+            "endTime": "1000",
+            "day": 0,
+        }
 
-        expected = [
-            UnavailableTime(time(8, 00), time(10, 00), 0)
-        ]
+        expected = UnavailableTime(time(8, 00), time(10, 00), 0)
 
         # Act
-        result = _parse_unavailable_times(availabilities)
+        result = _parse_unavailable_time(availability)
 
         # Assert
         self.assertEqual(result, expected)

--- a/autoscheduler/scheduler/tests/api_tests.py
+++ b/autoscheduler/scheduler/tests/api_tests.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 from datetime import time
 from rest_framework.test import APITestCase, APIClient
 from scheduler.views import (_parse_course_filter, _parse_unavailable_times,
-                             _serialize_schedule)
+                             _serialize_schedules)
 from scheduler.utils import UnavailableTime, CourseFilter
 from scraper.models import Section, Instructor
 from scraper.serializers import SectionSerializer
@@ -73,7 +73,7 @@ class SchedulingAPITests(APITestCase):
         # Assert
         self.assertEqual(result, expected)
 
-    def test_serialize_schedule_is_correct(self):
+    def test_serialize_schedules_is_correct(self):
         """ Tests that _serialize_schedule works on a typical input """
 
         # Arrange
@@ -84,7 +84,7 @@ class SchedulingAPITests(APITestCase):
         ]
 
         # Act
-        result = _serialize_schedule(schedule)
+        result = _serialize_schedules(schedule)
 
         # Assert
         self.assertEqual(result, expected)

--- a/autoscheduler/scheduler/tests/api_tests.py
+++ b/autoscheduler/scheduler/tests/api_tests.py
@@ -1,0 +1,132 @@
+from unittest.mock import patch
+from datetime import time
+from rest_framework.test import APITestCase, APIClient
+from scheduler.views import (_parse_course_filter, _parse_unavailable_times,
+                             _serialize_schedule)
+from scheduler.utils import UnavailableTime, CourseFilter
+from scraper.models import Section, Instructor
+from scraper.serializers import SectionSerializer
+
+class SchedulingAPITests(APITestCase):
+    """ Tests for the functionality in scheduling.views """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = APIClient()
+
+        instructor = Instructor(id="name")
+        instructor.save()
+        cls.sections = [
+            Section(id=1, crn=1, subject='CSCE', course_num='121', section_num='501',
+                    term_code='201931', min_credits=0, honors=False, web=False,
+                    current_enrollment=0, max_enrollment=0, instructor=instructor),
+            Section(id=2, crn=2, subject='CSCE', course_num='221', section_num='501',
+                    term_code='201931', min_credits=0, honors=False, web=False,
+                    current_enrollment=0, max_enrollment=0, instructor=instructor),
+        ]
+        Section.objects.bulk_create(cls.sections)
+
+    def test_parse_course_filter_is_correct(self):
+        """ Tests that _parse_counter_filter works on a typical input """
+
+        # Arrange
+        courses = [
+            {
+                "subject": "CSCE",
+                "courseNum": "121",
+                "sections": ["500"],
+                "honors": False,
+                "web": False,
+            },
+        ]
+
+        expected = [
+            CourseFilter(subject="CSCE", course_num="121", section_nums=["500"],
+                         honors=False, web=False)
+        ]
+
+        # Act
+        result = _parse_course_filter(courses)
+
+        # Assert
+        self.assertEqual(result, expected)
+
+    def test_parse_unavailable_times_is_correct(self):
+        """ Tests that _parse_unavailable_times works on a typical input """
+
+        # Arrange
+        availabilities = [
+            {
+                "startTime": "0800",
+                "endTime": "1000",
+                "day": 0,
+            },
+        ]
+
+        expected = [
+            UnavailableTime(time(8, 00), time(10, 00), 0)
+        ]
+
+        # Act
+        result = _parse_unavailable_times(availabilities)
+
+        # Assert
+        self.assertEqual(result, expected)
+
+    def test_serialize_schedule_is_correct(self):
+        """ Tests that _serialize_schedule works on a typical input """
+
+        # Arrange
+        schedule = [("1", "2")]
+
+        expected = [
+            [SectionSerializer(section).data for section in self.sections]
+        ]
+
+        # Act
+        result = _serialize_schedule(schedule)
+
+        # Assert
+        self.assertEqual(result, expected)
+
+    # Replaces the create_schedules import that's imported in scheduler.views
+    @patch('scheduler.views.create_schedules')
+    def test_route_scheduling_generate_is_correct(self, create_schedules_mock):
+        """ Tests that /scheduling/generate evalutes correctly """
+
+        # Arrange
+        # Mock create schedules so we don't have to make the meetings for the sections
+        create_schedules_mock.return_value = [("1", "2")]
+
+        request_body = {
+            "term": "201931",
+            "courses": [
+                {
+                    "subject": "CSCE",
+                    "courseNum": 221,
+                    "sections": [],
+                    "honors": False,
+                    "web": False,
+                },
+                {
+                    "subject": "CSCE",
+                    "courseNum": 121,
+                    "sections": [],
+                    "honors": False,
+                    "web": False,
+                },
+            ],
+            "availabilities": [],
+            "includeFull": True,
+        }
+
+        expected = [
+            [SectionSerializer(section).data for section in self.sections]
+        ]
+
+        # Act
+        result = self.client.post('/scheduler/generate', request_body, format='json')
+        result = result.json()
+
+        # Assert
+        self.assertEqual(result, expected)

--- a/autoscheduler/scheduler/tests/api_tests.py
+++ b/autoscheduler/scheduler/tests/api_tests.py
@@ -77,7 +77,7 @@ class SchedulingAPITests(APITestCase):
         """ Tests that _serialize_schedule works on a typical input """
 
         # Arrange
-        schedule = [("1", "2")]
+        schedule = [(1, 2)]
 
         expected = [
             [SectionSerializer(section).data for section in self.sections]
@@ -96,7 +96,7 @@ class SchedulingAPITests(APITestCase):
 
         # Arrange
         # Mock create schedules so we don't have to make the meetings for the sections
-        create_schedules_mock.return_value = [("1", "2")]
+        create_schedules_mock.return_value = [(1, 2)]
 
         request_body = {
             "term": "201931",

--- a/autoscheduler/scheduler/urls.py
+++ b/autoscheduler/scheduler/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from scheduler.views import ScheduleView
+
+urlpatterns = [
+    path('generate', ScheduleView.as_view()),
+]

--- a/autoscheduler/scheduler/utils.py
+++ b/autoscheduler/scheduler/utils.py
@@ -51,6 +51,10 @@ class UnavailableTime:
         self.end_time = end_time
         self.meeting_days = set((day,))
 
+    def __eq__(self, other):
+        return (self.start_time == other.start_time and self.end_time == other.end_time
+                and self.meeting_days == other.meeting_days)
+
 class CourseFilter(NamedTuple):
     """ Contains the course-specific information needed to query the database for a course
         and filter its sections to the ones that match the user's selections

--- a/autoscheduler/scheduler/views.py
+++ b/autoscheduler/scheduler/views.py
@@ -64,7 +64,7 @@ def _serialize_schedules(schedules: List[Tuple[str]]) -> List[List]:
     sections_dict = {section.id: section for section in models.iterator()}
 
     def sections_for_schedule(schedule):
-        sections = (sections_dict[int(section)] for section in schedule)
+        sections = (sections_dict[section] for section in schedule)
 
         return SectionSerializer(sections, many=True).data
 

--- a/autoscheduler/scheduler/views.py
+++ b/autoscheduler/scheduler/views.py
@@ -65,7 +65,7 @@ def _serialize_schedule(schedules: List[Tuple[str]]) -> List[List]:
 
     output = []
     for schedule in schedules:
-        schedule_out = [SectionSerializer(sections_dict[section_id]).data
+        schedule_out = [SectionSerializer(sections_dict[int(section_id)]).data
                         for _, section_id in enumerate(schedule)]
 
         output.append(schedule_out)

--- a/autoscheduler/scheduler/views.py
+++ b/autoscheduler/scheduler/views.py
@@ -1,4 +1,96 @@
-# Once we start adding routes, uncomment this line
-# from django.shortcuts import render
+import json
+from typing import List, Tuple
+from rest_framework.views import APIView
+from rest_framework.response import Response
 
-# Create your views here.
+from scheduler.create_schedules import create_schedules
+from scheduler.utils import UnavailableTime, CourseFilter
+from scraper.management.commands.scrape_courses import convert_meeting_time
+from scraper.serializers import SectionSerializer
+from scraper.models import Section
+
+def _parse_course_filter(courses) -> List[CourseFilter]:
+    """ Parses the given courses to retrieve and converts them to CourseFilter objects
+        to be used in create_schedules
+    """
+
+    output = []
+
+    for course in courses:
+        subject = str(course["subject"])
+        course_num = str(course["courseNum"])
+
+        sections = course["sections"]
+
+        honors = course["honors"]
+        web = course["web"]
+
+        output.append(CourseFilter(subject=subject, course_num=course_num,
+                                   section_nums=sections, honors=honors, web=web))
+    return output
+
+def _parse_unavailable_times(availabilities) -> List[UnavailableTime]:
+    """ Parses the availabilities input and converts them to UnavailableTime objects
+        to be used in create_schedules
+    """
+
+    unavailable_times = []
+    for avail in availabilities:
+        start_time = convert_meeting_time(avail["startTime"])
+        end_time = convert_meeting_time(avail["endTime"])
+        day = int(avail["day"])
+
+        unavailable_times.append(UnavailableTime(start_time, end_time, day))
+
+    return unavailable_times
+
+def _serialize_schedule(schedules: List[Tuple[str]]) -> List[List]:
+    """ Converts the given schedules, retrieves the corresponding sections,
+        then serializes and returns them
+
+    Args:
+        schedules: The schedules returned from create_schedules
+
+    Returns
+        The list of given schedules with the corresponding serialized sections
+    """
+
+    # Retrieve the section models in bulk so we only do one DB query
+    # Put the section ids in a set to remove duplicates
+    section_set = set((section_id for schedule in schedules for section_id in schedule))
+    models = Section.objects.filter(id__in=section_set)
+
+    # Maps each section's id to their corresponding section model
+    sections_dict = {section.id: section for section in models.iterator()}
+
+    output = []
+    for schedule in schedules:
+        schedule_out = [SectionSerializer(sections_dict[section_id]).data
+                        for _, section_id in enumerate(schedule)]
+
+        output.append(schedule_out)
+
+    return output
+
+class ScheduleView(APIView):
+    """ Handles requests to the generate schedules algorithm  """
+
+    def post(self, request):
+        """ Receives a POST request containg the schedule-generating parameters
+            and returns a list of generate schedules
+        """
+
+        query = json.loads(request.body)
+
+        # List[Tuple[str, str]]
+        courses = _parse_course_filter(query["courses"])
+        unavailable_times = _parse_unavailable_times(query["availabilities"])
+
+        term = query["term"]
+        include_full = query["includeFull"]
+
+        num_schedules = 5
+        schedules = create_schedules(courses, term, unavailable_times, include_full,
+                                     num_schedules)
+
+        return Response(_serialize_schedule(schedules))

--- a/autoscheduler/scraper/serializers.py
+++ b/autoscheduler/scraper/serializers.py
@@ -1,6 +1,6 @@
 from datetime import time
 from rest_framework import serializers
-from scraper.models import Course, Section, Meeting, Department
+from scraper.models import Course, Section, Meeting, Department, Grades
 
 def format_time(time_obj: time) -> str:
     """ Formats a time object to a string HH:MM, for use with section serializer """
@@ -16,11 +16,12 @@ class SectionSerializer(serializers.ModelSerializer):
     """ Serializes a section into an object with information needed by /api/sections """
     instructor_name = serializers.SerializerMethodField()
     meetings = serializers.SerializerMethodField()
+    grades = serializers.SerializerMethodField()
 
     class Meta:
         model = Section
         fields = ['id', 'crn', 'instructor_name', 'honors', 'meetings',
-                  'section_num', 'web']
+                  'section_num', 'web', 'grades']
 
     def get_instructor_name(self, obj): # pylint: disable=no-self-use
         """ Get the name (id) of this section's instructor.
@@ -40,6 +41,11 @@ class SectionSerializer(serializers.ModelSerializer):
             'end_time': format_time(meeting.end_time),
             'type': meeting.meeting_type,
         } for meeting in meetings]
+
+    def get_grades(self, obj): # pylint: disable=no-self-use
+        """ Gets the past grade distributions for this prof + course """
+        return Grades.objects.instructor_performance(obj.subject, obj.course_num,
+                                                     obj.instructor)
 
 def season_num_to_string(season_num):
     """ Converts int representing season in 'term' field to a string to

--- a/autoscheduler/scraper/tests/api_tests.py
+++ b/autoscheduler/scraper/tests/api_tests.py
@@ -259,6 +259,8 @@ class APITests(APITestCase): #pylint: disable=too-many-public-methods
             ],
             'section_num': '501',
             'web': False,
+            'grades': {key: None for key in ['A', 'B', 'C', 'D', 'F', 'I',
+                                             'S', 'U', 'Q', 'X', 'gpa']}
         }
 
         # Act
@@ -302,6 +304,8 @@ class APITests(APITestCase): #pylint: disable=too-many-public-methods
                 ],
                 'section_num': '501',
                 'web': False,
+                'grades': {key: None for key in ['A', 'B', 'C', 'D', 'F', 'I',
+                                                 'S', 'U', 'Q', 'X', 'gpa']}
             },
             {
                 'id': 2,
@@ -326,6 +330,10 @@ class APITests(APITestCase): #pylint: disable=too-many-public-methods
                 ],
                 'section_num': '502',
                 'web': False,
+                'grades': {
+                    'gpa': 1, 'A': 0, 'B': 0, 'C': 0, 'D': 0, 'F': 0, 'I': 0, 'S': 0,
+                    'U': 0, 'Q': 0, 'X': 0,
+                }
             },
         ]
         data = {'dept': 'CSCE', 'course_num': 310, 'term': '201931'}


### PR DESCRIPTION
Implements the scheduling api at /scheduler/generate.

We can't include the `api` in the route since it redirects to scraper.urls, but we can modify it if we want to.

Closes #165 