### PR TITLE
Made deploy workflow only run on pushes to master

### DIFF
--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -1,8 +1,7 @@
 name: GCP Deploy
-on: push
-#on:
-#  push:
-#    master
+on:
+  push:
+    master
 
 jobs:
   deploy-app-engine:


### PR DESCRIPTION
Meant to do this in the GCP deploy PR but I got a bit to eager and merged it before hand