### PR TITLE
Django settings fix for Cloud SQL proxy

### DIFF
--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Collect static files
         run: |
-          export SETTINGS_MODE=prod
+          export SETTINGS_MODE=static
           python manage.py collectstatic --no-input
         working-directory: ./autoscheduler
 

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -8,11 +8,14 @@ jobs:
   deploy-app-engine:
     name: App Engine
     runs-on: ubuntu-latest
-    env:
-      working-drectory: ./autoscheduler
     steps:
       - name: Checkout
         uses: actions/checkout@master
+
+      - name: Write Django secret to file
+        run: echo $DJANGO_SECRET > autoscheduler/autoscheduler/settings/secret.txt
+        env:
+          DJANGO_SECRET: ${{ secrets.DJANGO_SECRET }}
 
       - name: Fill in Postgres credentials
         run: bash fill_credentials.sh ${{ secrets.POSTGRES_USER }} ${{ secrets.POSTGRESS_PASS }}

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# GCP
+cloud_sql_proxy.*
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/autoscheduler/autoscheduler/settings/base.py
+++ b/autoscheduler/autoscheduler/settings/base.py
@@ -3,8 +3,10 @@ from autoscheduler.config import config
 
 # What Google App Engine uses
 _IS_GCP = os.getenv('SERVER_SOFTWARE', '').startswith('gunicorn')
-# Environment variables for when we connect to Google Cloud SQL/collect static files
+# Environment variables for when we collect static files
 _IS_PROD = os.getenv('SETTINGS_MODE') == 'prod'
+# Env variable for connecting to Cloud SQL through cloud_sql_proxy
+_IS_PROXY = os.getenv('SETTINGS_MODE') == 'proxy'
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -79,7 +81,7 @@ if _IS_GCP:
             'PASSWORD': config.get_prop("password"),
         }
     }
-elif _IS_PROD:
+elif _IS_PROXY:
     print("Connecting to Google Cloud SQL (using cloud_sql_proxy)")
     DATABASES = {
         'default': {

--- a/autoscheduler/autoscheduler/settings/base.py
+++ b/autoscheduler/autoscheduler/settings/base.py
@@ -4,7 +4,7 @@ from autoscheduler.config import config
 # What Google App Engine uses
 _IS_GCP = os.getenv('SERVER_SOFTWARE', '').startswith('gunicorn')
 # Environment variables for when we collect static files
-_IS_PROD = os.getenv('SETTINGS_MODE') == 'prod'
+_IS_STATIC = os.getenv('SETTINGS_MODE') == 'static'
 # Env variable for connecting to Cloud SQL through cloud_sql_proxy
 _IS_PROXY = os.getenv('SETTINGS_MODE') == 'proxy'
 
@@ -143,7 +143,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
 
-if _IS_GCP or _IS_PROD:
+if _IS_GCP or _IS_STATIC:
     print("Using GCP/prod for static files")
     STATIC_ROOT = 'static'
     STATIC_URL = 'https://storage.googleapis.com/revregistration.appspot.com'

--- a/autoscheduler/autoscheduler/settings/base.py
+++ b/autoscheduler/autoscheduler/settings/base.py
@@ -15,7 +15,15 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'ogxjva5h%&5c7&e#-2f1&+u5p#zygwffcy!@)k8i37#j_89xe2'
+if _IS_GCP:
+    # For production, load the secret from secret.txt and set it
+    # This is set from the GitHub actions secret DJANGO_SECRET in deploy-workflow.yml
+    _SECRET_PATH = os.path.dirname(__file__) + "/secret.txt"
+
+    with open(_SECRET_PATH) as _SECRET_FILE:
+        SECRET_KEY = _SECRET_FILE.read()[:-1] # Shave off newline
+else:
+    SECRET_KEY = 'ogxjva5h%&5c7&e#-2f1&+u5p#zygwffcy!@)k8i37#j_89xe2'
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = not _IS_GCP


### PR DESCRIPTION
This mainly adds the `SETTINGS_MODE=proxy` option, as the `STATIC_URL` has to be pointing to the actual static files rather than cloud storage. Likewise the only thing that `prod` is actually used for is collecting static files, so I changed that settings mode to `static` instead.

Also `cloud_sql_proxy` to the `.gitignore`
