### PR TITLE
Misc Actions/CI changes

### DIFF
--- a/.github/dangerfile.ts
+++ b/.github/dangerfile.ts
@@ -14,9 +14,9 @@ const touchedFiles = danger.git.modified_files.concat(danger.git.created_files);
 function checkForBigPR(offset = 0) {
   const bigPRThreshold = 500;
   const changedLines = pr.additions + pr.deletions - offset;
-  if (changedLines - offset > bigPRThreshold) {
-    warn(':exclamation: Big PR! You might want to split this up into separate commits in '
-          + 'order to maximize the effectiveness of code review');
+  if (changedLines > bigPRThreshold) {
+    warn(`:exclamation: Big PR(${changedLines})! You might want to split this up into`
+          + ' separate commits in order to maximize the effectiveness of code review');
   }
 }
 

--- a/.github/dangerfile.ts
+++ b/.github/dangerfile.ts
@@ -89,20 +89,3 @@ if (hasBackendChanges && !hasBackendTestChanges) {
   warn('There are backend changes, but not tests. That\'s ok as long are you\'re'
         + ' refactoring existing code.');
 }
-
-// Add a failure if there are backend changes on a frontend branch
-if (pr.head.label.includes('frontend/') && backendTouchedFiles.length > 0) {
-  // Add a warning if there's touched files in the backend
-  fail(':exclamation: No Python/Django related files should be touched on a frontend-'
-        + 'related branch');
-}
-
-frontendTouchedFiles = touchedFiles.filter(
-  (f) => f.endsWith('.js') || f.endsWith('.ts') || f.endsWith('.tsx') || f.endsWith('.'),
-);
-
-// Add a failure if there are frontend changes on a backend branch
-if (pr.head.label.startsWith('backend/') && frontendTouchedFiles.length > 0) {
-  fail(':exclamation: No Python/Django related files should be touched on a backend-'
-        + 'related branch');
-}

--- a/.github/workflows/backend-workflow.yml
+++ b/.github/workflows/backend-workflow.yml
@@ -1,8 +1,5 @@
 name: Backend CI
-on: 
-  push:
-    branches-ignore:
-      - 'frontend/**' # Don't run on any frontend branches
+on: push
 
 jobs:
   test-backend:

--- a/.github/workflows/frontend-workflow.yml
+++ b/.github/workflows/frontend-workflow.yml
@@ -1,8 +1,5 @@
 name: Frontend CI
-on:
-  push:
-    branches-ignore:
-      - 'backend/**' # Don't run on any backend branches
+on: push
 
 jobs:
   test-frontend:


### PR DESCRIPTION
- Makes the frontend & backend steps run on all pushes/not ignore `backend/` and `frontend/` branches respectively.
- Removed the check in danger that gave an warning when you touch frontend related files on `backend/*` branches and vice-versa