### PR TITLE
Changed scrape_grades to use multiprocessing

### DIFF
--- a/autoscheduler/scraper/management/commands/scrape_grades.py
+++ b/autoscheduler/scraper/management/commands/scrape_grades.py
@@ -219,12 +219,11 @@ def retrieve_pdf(year_semester: str, college: str):
 
     return None
 
-
-def perform_searches(years: List[int], colleges: List[str]):
+def perform_searches(years: List[int], colleges: List[str], max_worker_procs=None):
     """ Gathers all of the retrieve_pdf tasks for each year/semester/college combination
         Then collects the returned list of grade models and returns them. Uses a pool of
         N worker processes, with each process running one retrieve_pdf task at a time,
-        where N=number of CPU cores (including hyperthreaded/virtual cores)
+        where N=number of CPU cores by default (including hyperthreaded/virtual cores)
 
         Returns:
             A list of Grades models
@@ -232,7 +231,7 @@ def perform_searches(years: List[int], colleges: List[str]):
 
     semesters = [SPRING, SUMMER, FALL]
 
-    if max_worker_procs == -1:
+    if not max_worker_procs:
         # Multiprocessing seems to work best when this is equal to number of CPU cores
         max_worker_procs = os.cpu_count()
 
@@ -264,6 +263,11 @@ class Command(base.BaseCommand):
                             help="The year you want to scrape grades for, such as 2019")
         parser.add_argument('--college', '-c', type=str,
                             help="The college you want to scrape grades for, such as EN")
+        parser.add_argument('--procs', '-p', type=int,
+                            help=("The number of worker processes to run this with. "
+                                  "The optimal amount if the number of CPU cores, "
+                                  "but you may want to reduce this if it is taking up "
+                                  "too much CPU performance"))
 
     def handle(self, *args, **options):
         start = time.time()
@@ -278,7 +282,7 @@ class Command(base.BaseCommand):
         colleges = ([options['college']] if options['college']
                     else _get_colleges(page_soup))
 
-        scraped_grades = perform_searches(years, colleges)
+        scraped_grades = perform_searches(years, colleges, options.get('procs'))
 
         # Have to import here due to Django "App not found" error due to multiprocessing
         from scraper.models import Grades

--- a/autoscheduler/scraper/management/commands/scrape_grades.py
+++ b/autoscheduler/scraper/management/commands/scrape_grades.py
@@ -1,18 +1,19 @@
 import time
 import os
-import asyncio
-import ssl
+from concurrent.futures import ProcessPoolExecutor
 from typing import List
 from pathlib import Path
 from collections import defaultdict
+from itertools import chain
 import requests
 import bs4
-from aiohttp import ClientSession
 
 from django.core.management import base
-
-from scraper.models import Grades, Section
 from scraper.management.commands.utils import pdf_parser
+
+# Needed since we have to import the specific models in the functions they're used in
+# due to multiprocessing
+# pylint: disable=import-outside-toplevel
 
 ROOT_URL = "http://web-as.tamu.edu/gradereport"
 PDF_URL = ROOT_URL + "/PDFREPORTS/{}/grd{}{}.pdf"
@@ -86,7 +87,7 @@ def save_pdf(data: bytes, save_path: str, year_semester: str, college: str):
         print(f"Downloaded {year_semester}-{college}")
         return save_path
 
-async def download_pdf(year_semester: int, college: str, session: ClientSession) -> str:
+def download_pdf(year_semester: int, college: str) -> str:
     """ Downloads a pdf for the given college and year
 
         Args:
@@ -107,13 +108,19 @@ async def download_pdf(year_semester: int, college: str, session: ClientSession)
         print(f"Using cached {year_semester} {college}")
         return path
 
-    ssl_context = ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH)
-    async with session.get(url, ssl_context=ssl_context) as response:
-        data = await response.read()
+    max_retries = 10
+    for i in range(max_retries):
+        try:
+            data = requests.get(url).content
 
-        return save_pdf(data, path, year_semester, college)
+            return save_pdf(data, path, year_semester, college)
+        except requests.exceptions.ConnectionError:
+            print((f"\nCONNECTION ERROR: nRetrying with {year_semester} {college}:"
+                   f" Retry {i}\n\n"))
 
-def scrape_pdf(grade_dists: List[pdf_parser.GradeData], term: str) -> List[Grades]:
+    return None # Retrying failed
+
+def scrape_pdf(grade_dists: List[pdf_parser.GradeData], term: str):
     """ Calls parse_pdf on the given pdf and adds all of the grade distributions
         as models to the GRADES array for later saving
 
@@ -127,6 +134,13 @@ def scrape_pdf(grade_dists: List[pdf_parser.GradeData], term: str) -> List[Grade
 
     if not grade_dists:
         return []
+
+    # Setup Django for each worker process
+    import django
+    django.setup()
+
+    # We can't import the models for this entire file as Django throws "App not setup" err
+    from scraper.models import Section, Grades
 
     # The count of how many of each department was scraped, used for debug printing
     # str : int
@@ -176,53 +190,57 @@ def scrape_pdf(grade_dists: List[pdf_parser.GradeData], term: str) -> List[Grade
 
     for dept, count in counts.items():
         print(f"{dept}: Scraped {count} grades")
-    print() # Add a new line to separate the outputs
 
     return scraped_grades
 
-async def perform_searches(years: List[int], colleges: List[str]) -> List[Grades]:
+def retrieve_pdf(year_semester: str, college: str):
+    """ Downloads the grade report pdf, parses & scrapes it and returns the list of
+        scraped grades
+
+        Returns:
+            A list of Grades models
+    """
+
+    pdf_path = download_pdf(year_semester, college)
+
+    if pdf_path is not None:
+        # Parse the pdf then scrape the returned grade distributions
+        print(f"Parsing PDF for {year_semester} {college}")
+
+        grade_dists = pdf_parser.parse_pdf(pdf_path)
+
+        # Convert the year_semester term to include the location
+        term = generate_term_with_location(year_semester, college)
+
+        scraped_grades = scrape_pdf(grade_dists, term)
+
+        print(f"Done for {year_semester} {college}\n")
+        return scraped_grades
+
+    return None
+
+
+def perform_searches(years: List[int], colleges: List[str]):
     """ Gathers all of the retrieve_pdf tasks for each year/semester/college combination
+        Then collects the returned list of grade models and returns them. Uses a pool of
+        N worker processes, with each process running one retrieve_pdf task at a time,
+        where N=number of CPU cores (including hyperthreaded/virtual cores)
 
-        Then collects the returned list of grade models and returns them
+        Returns:
+            A list of Grades models
      """
-
-    loop = asyncio.get_running_loop()
-
-    async def retrieve_pdf(year_semester: str, college: str):
-        """ Creates a aiohttp session, downloads the grade report pdf, parses & scrapes it
-            and returns the list of scraped grades
-        """
-
-        async with ClientSession(loop=loop) as session:
-            pdf_path = await download_pdf(year_semester, college, session)
-
-            if pdf_path is not None:
-                # Parse the pdf then scrape the returned grade distributions
-                print(f"Parsing PDF for {year_semester} {college}")
-
-                grade_dists = pdf_parser.parse_pdf(pdf_path)
-
-                # Convert the year_semester term to include the location
-                term = generate_term_with_location(year_semester, college)
-
-                scraped_grades = scrape_pdf(grade_dists, term)
-
-                return scraped_grades
-
-            return None
 
     semesters = [SPRING, SUMMER, FALL]
 
-    # Gather all of the retrieve functions into an array
-    tasks = [retrieve_pdf(f"{year}{semester}", college)
-             for year in years for semester in semesters for college in colleges]
+    if max_worker_procs == -1:
+        # Multiprocessing seems to work best when this is equal to number of CPU cores
+        max_worker_procs = os.cpu_count()
 
-    grades = [] # list of Grades models
-    for scraped_grades in await asyncio.gather(*tasks, loop=loop):
-        if scraped_grades:
-            grades.extend(scraped_grades)
+    with ProcessPoolExecutor(max_workers=max_worker_procs) as executor:
+        results = [executor.submit(retrieve_pdf, f"{year}{semester}", college)
+                   for year in years for college in colleges for semester in semesters]
 
-    return grades
+    return list(chain.from_iterable(filter(None, (res.result() for res in results))))
 
 def fetch_page_data() -> bs4.BeautifulSoup:
     """ Retrieves the ROOT_URL HTML data and converts it to BeautifulSoup
@@ -260,8 +278,10 @@ class Command(base.BaseCommand):
         colleges = ([options['college']] if options['college']
                     else _get_colleges(page_soup))
 
-        loop = asyncio.get_event_loop()
-        scraped_grades = loop.run_until_complete(perform_searches(years, colleges))
+        scraped_grades = perform_searches(years, colleges)
+
+        # Have to import here due to Django "App not found" error due to multiprocessing
+        from scraper.models import Grades
 
         # Save all of the models
         save_start = time.time()


### PR DESCRIPTION
Since scrape_grades previously took 15-20 minutes to run, I modified it to use multiple processes so that the PDF retrieving & parsing actually runs in parallel. 

Be aware that if you run it without using a `-p` argument with less than the number of cores you have, your computer will be slow af since it's probably at 100% CPU usage.

These were my runtimes scraping all of the grades on an i5-9600k @ 3.7 Ghz (overclocks to ~4.2 GHz) w/ 6 cores. Command ran was `python manage.py scrape_grades -p N`, where N = __# of processes__
| # of processes | Time taken | Speedup (Time for 1 proc / Time for n proc) | Efficiency (speed up / # proc) |
| -------------|-------------|-------|-----|
| 1 | 15.05 min | 1 | 1 |
| 2 | 8.11 min | 1.85 | 0.92 |
| 4 | 4.30 min |  3.5 | 0.87 |
| __6__ | 3.25 min | __4.63__ | 0.77 |
| 8 | 3.58 min | 4.21 | 0.52 |
| 16 | 3.48 min | 4.32 | 0.27 |
| 24 | 3.65 min | 4.12 | 0.17 |
| 32 | 3.50 min | 4.30 | 0.13 |

Also, `os.cpu_count()` returns 6 for me

Closes #215 