### PR TITLE
Made scraping bulk_create in slices

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -50,7 +50,7 @@ callbacks=cb_,_cb
 notes=FIXME,XXX,TODO
 
 # Good variable names which should always be accepted, separated by a comma.
-good-names=i,j,k,ex,Run,_
+good-names=i,j,k,ex,Run,_,it,n
 
 [DESIGN]
 # Maximum number of arguments for function / method.

--- a/autoscheduler/scraper/management/commands/scrape_courses.py
+++ b/autoscheduler/scraper/management/commands/scrape_courses.py
@@ -10,7 +10,7 @@ from scraper.banner_requests import BannerRequests
 from scraper.models import Course, Instructor, Section, Meeting, Department
 from scraper.models.course import generate_course_id
 from scraper.models.section import generate_meeting_id
-from scraper.management.commands.utils.scraper_utils import get_all_terms
+from scraper.management.commands.utils.scraper_utils import get_all_terms, slice_every
 
 # Set of the courses' ID's
 def convert_meeting_time(string_time: str) -> datetime.time:
@@ -240,22 +240,26 @@ class Command(base.BaseCommand):
                 meetings.extend(meetings_list)
 
         start = time.time()
-        Instructor.objects.bulk_create(instructors, ignore_conflicts=True)
+        for slc in slice_every(instructors, 50_000):
+            Instructor.objects.bulk_create(slc, ignore_conflicts=True)
         finish = time.time()
         print(f"Saved {len(instructors)} instructors in {(finish-start):.2f} seconds")
 
         start = time.time()
-        Section.objects.bulk_create(sections, ignore_conflicts=True)
+        for slc in slice_every(sections, 50_000):
+            Section.objects.bulk_create(slc, ignore_conflicts=True)
         finish = time.time()
         print(f"Saved {len(sections)} sections in {(finish-start):.2f} seconds")
 
         start = time.time()
-        Meeting.objects.bulk_create(meetings, ignore_conflicts=True)
+        for slc in slice_every(meetings, 50_000):
+            Meeting.objects.bulk_create(slc, ignore_conflicts=True)
         finish = time.time()
         print(f"Saved {len(meetings)} meetings in {(finish-start):.2f} seconds")
 
         start = time.time()
-        Course.objects.bulk_create(courses, ignore_conflicts=True)
+        for slc in slice_every(courses, 50_000):
+            Course.objects.bulk_create(slc, ignore_conflicts=True)
         finish = time.time()
         print(f"Saved {len(courses)} courses in {(finish-start):.2f} seconds")
 

--- a/autoscheduler/scraper/management/commands/scrape_grades.py
+++ b/autoscheduler/scraper/management/commands/scrape_grades.py
@@ -13,6 +13,7 @@ from django.core.management import base
 
 from scraper.models import Grades, Section
 from scraper.management.commands.utils import pdf_parser
+from scraper.management.commands.utils.scraper_utils import slice_every
 
 ROOT_URL = "http://web-as.tamu.edu/gradereport"
 PDF_URL = ROOT_URL + "/PDFREPORTS/{}/grd{}{}.pdf"
@@ -266,7 +267,8 @@ class Command(base.BaseCommand):
         # Save all of the models
         save_start = time.time()
         # ignore_conflicts is only so we can run this multiple times locally
-        Grades.objects.bulk_create(scraped_grades, ignore_conflicts=True)
+        for slc in slice_every(scraped_grades, 50_000):
+            Grades.objects.bulk_create(slc, ignore_conflicts=True)
         save_end = time.time()
         elapsed_time = save_end - save_start
         print(f"Saving {len(scraped_grades)} grades took {elapsed_time:.2f} sec")

--- a/autoscheduler/scraper/management/commands/utils/scraper_utils.py
+++ b/autoscheduler/scraper/management/commands/utils/scraper_utils.py
@@ -1,6 +1,6 @@
 from datetime import datetime
-from typing import List
-from itertools import product
+from typing import Iterable, List
+from itertools import chain, islice, product
 
 def get_all_terms(year: int = -1) -> List[str]:
     """ Generates all of the terms, from 2013 until now
@@ -21,3 +21,18 @@ def get_all_terms(year: int = -1) -> List[str]:
 
     return [f"{year}{semester}{location}"
             for year, semester, location in product(years, semesters, locations)]
+
+
+def slice_every(iterable: Iterable, n: int) -> Iterable[Iterable]:
+    """ Divides an iterable into slices of length n. Make sure you consume each slice
+        before trying to evaluate the next.
+    Args:
+        iterable: Any iterable
+        n: Size of each slice
+    Yields:
+        len(iterable)/n iterators of length n corresponding to all items in the iterable.
+    """
+    it = iter(iterable)
+    for first in it:
+        rest = islice(it, n-1)
+        yield chain([first], rest)


### PR DESCRIPTION
Since using `bulk_create` directly on our data isn't possible in Cloud SQL given how many objects we scrape (240k sections, 320k meetings, 80k courses, 98k grades), I made a function to split our lists into slices, and pass these slices into `scrape_courses` and `scrape_grades`. I decided not to change how `scrape_depts` works since there less than 6000 departments across all terms, but we can easily change this if we want. I tested that this works by running `scrape_depts` then `scrape_courses` and `scrape_grades` and saving the models to a new database in GCP, then checking that the correct number of records exist in the database for each model.

If you're curious, here are the runtimes of `scrape_courses` on GCP with slices of 10,000 objects:
![image](https://user-images.githubusercontent.com/28655462/80312830-277fcb80-87ad-11ea-9d10-20d8d89a3eef.png)
And with slices of size 50,000:
![image](https://user-images.githubusercontent.com/28655462/80312848-3a929b80-87ad-11ea-9e9d-f6166e0a8dcc.png)

Closes #212.