### PR TITLE
Sort api/course/search results by dept and course_num

### DIFF
--- a/autoscheduler/scraper/views.py
+++ b/autoscheduler/scraper/views.py
@@ -65,7 +65,7 @@ class RetrieveCourseSearchView(generics.ListAPIView):
         search = search.replace("%20", "").replace(" ", "").upper()
         term = self.request.query_params.get('term')
         return Course.objects.filter(
-            id__startswith=search, term=term)
+            id__startswith=search, term=term).order_by('dept', 'course_num')
 
     def list(self, request): # pylint: disable=arguments-differ
         """ Overrides default behavior of list method so terms are ouput in


### PR DESCRIPTION
Pretty simple PR, currently our search results look like this:
```json
{
    "results": [
        "ACCT 621",
        "ACCT 210",
        "AERO 212",
        "ACCT 622",
        "ACCT 624",
        "ACCT 640",
        "ACCT 230",
        "AERO 214",
        "ACCT 327",
        "AERO 401",
        "ACCT 648",
        "AERO 222",
        "ACCT 650",
        "ACCT 328",
        "ACCT 665",
        "ACCT 329",
        "ACCT 408",
        "ACCT 427",
        "ACCT 447",
        "AERO 402",
        "ACCT 450",
```
They're not being sorted, so it just returns them in the order they are in the table. By sorting, the results look like this:
```json
{
    "results": [
        "ACCT 209",
        "ACCT 210",
        "ACCT 229",
        "ACCT 230",
        "ACCT 327",
        "ACCT 328",
        "ACCT 329",
        "ACCT 403",
        "ACCT 405",
        "ACCT 407",
        "ACCT 408",
        "ACCT 410",
        "ACCT 421",
        "ACCT 427",
        "ACCT 447",
        "ACCT 450",
        "ACCT 484",
        "ACCT 491",
        "ACCT 603",
        "ACCT 607",
        "ACCT 610",
        "ACCT 611",
        "ACCT 612",
        "ACCT 621",
        "ACCT 622",
        "ACCT 624",
        "ACCT 625",
        "ACCT 628",
        "ACCT 640",
        "ACCT 647",
        "ACCT 648",
        "ACCT 650",
        "ACCT 651",
        "ACCT 665",
        "ACCT 684",
        "ACCT 689",
        "ACCT 691",
        "ACCT 705",
        "ACCT 710",
        "AEGD 601",
        "AEGD 606",
```
I requested Adel for review just in case he had any feedback/things to point out, since these results will be used in the course select cards.

Closes #222.