### PR TITLE
Removed unnecessary f-string from scrape_grades

### DIFF
--- a/autoscheduler/scraper/management/commands/scrape_grades.py
+++ b/autoscheduler/scraper/management/commands/scrape_grades.py
@@ -172,7 +172,7 @@ def scrape_pdf(grade_dists: List[pdf_parser.GradeData], term: str) -> List[Grade
     scraped_grades = list(create_grades(grade_dists, sections_dict, counts))
 
     if not counts:
-        print(f"No grades scraped")
+        print("No grades scraped")
 
     for dept, count in counts.items():
         print(f"{dept}: Scraped {count} grades")


### PR DESCRIPTION
Adel's recently merged #188 PR (9b4ca31) failed linting even though it wasn't before for some reason, so this fixes that. 

I have no idea why this isn't giving a linting error in #224 but w/e