### PR TITLE
Added grades to Section type

### DIFF
--- a/autoscheduler/frontend/src/redux/actions/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/actions/courseCards.ts
@@ -8,6 +8,7 @@ import { RootState } from '../reducer';
 import Meeting, { MeetingType } from '../../types/Meeting';
 import Section from '../../types/Section';
 import Instructor from '../../types/Instructor';
+import Grades from '../../types/Grades';
 
 export function addCourseCard(): AddCourseAction {
   return {
@@ -55,6 +56,7 @@ export function parseMeetings(arr: any[]): Meeting[] {
       currentEnrollment: Number(sectionData.current_enrollment),
       maxEnrollment: Number(sectionData.max_enrollment),
       instructor: new Instructor({ name: sectionData.instructor_name }),
+      grades: sectionData.grades == null ? null : new Grades(sectionData.grades),
     });
 
     sectionData.meetings.forEach((meetingData: any) => {

--- a/autoscheduler/frontend/src/redux/testData.ts
+++ b/autoscheduler/frontend/src/redux/testData.ts
@@ -17,6 +17,7 @@ export default async function fetch(route: string): Promise<Response> {
     instructor: new Instructor({
       name: 'Aakash Tyagi',
     }),
+    grades: null,
   });
   const testSection2 = new Section({
     id: 123458,
@@ -31,6 +32,7 @@ export default async function fetch(route: string): Promise<Response> {
     instructor: new Instructor({
       name: 'Aakash Tyagi',
     }),
+    grades: null,
   });
   const testSection3 = new Section({
     id: 123457,
@@ -45,6 +47,7 @@ export default async function fetch(route: string): Promise<Response> {
     instructor: new Instructor({
       name: 'Somebody Else',
     }),
+    grades: null,
   });
   const testSection4 = new Section({
     id: 830262,
@@ -59,6 +62,7 @@ export default async function fetch(route: string): Promise<Response> {
     instructor: new Instructor({
       name: 'Dr. Pepper',
     }),
+    grades: null,
   });
 
   // test that different sections do different things

--- a/autoscheduler/frontend/src/tests/redux/CourseCardRedux.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/CourseCardRedux.test.ts
@@ -45,6 +45,7 @@ describe('Course Cards Redux', () => {
           currentEnrollment: 0,
           maxEnrollment: 1,
           instructor: new Instructor({ name: 'Instructor Name' }),
+          grades: null,
         });
 
         const expected = [
@@ -104,6 +105,7 @@ describe('Course Cards Redux', () => {
           currentEnrollment: 0,
           maxEnrollment: 1,
           instructor: new Instructor({ name: 'Instructor Name' }),
+          grades: null,
         });
 
         const expected = [
@@ -164,6 +166,7 @@ describe('Course Cards Redux', () => {
           currentEnrollment: 0,
           maxEnrollment: 1,
           instructor: new Instructor({ name: 'Instructor Name' }),
+          grades: null,
         });
 
         const expected = [

--- a/autoscheduler/frontend/src/tests/redux/CourseCardRedux.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/CourseCardRedux.test.ts
@@ -2,6 +2,7 @@ import { parseMeetings } from '../../redux/actions/courseCards';
 import Meeting, { MeetingType } from '../../types/Meeting';
 import Section from '../../types/Section';
 import Instructor from '../../types/Instructor';
+import Grades from '../../types/Grades';
 
 // The input from the backend use snake_case, so disable camelcase errors for this file
 /* eslint-disable @typescript-eslint/camelcase */
@@ -10,6 +11,10 @@ describe('Course Cards Redux', () => {
     describe('parses correctly', () => {
       test('on a normal input', () => {
         // arrange
+        const grades = {
+          gpa: 4.0, A: 1, B: 0, C: 0, D: 0, F: 0, I: 0, S: 0, Q: 0, X: 0,
+        };
+
         const input = [{
           id: 1,
           crn: 1,
@@ -32,6 +37,7 @@ describe('Course Cards Redux', () => {
               type: 'LEC',
             },
           ],
+          grades,
         }];
 
         const section = new Section({
@@ -45,7 +51,7 @@ describe('Course Cards Redux', () => {
           currentEnrollment: 0,
           maxEnrollment: 1,
           instructor: new Instructor({ name: 'Instructor Name' }),
-          grades: null,
+          grades: new Grades(grades),
         });
 
         const expected = [
@@ -178,6 +184,70 @@ describe('Course Cards Redux', () => {
             startTimeMinutes: 0,
             endTimeHours: 0,
             endTimeMinutes: 0,
+            meetingType: MeetingType.LEC,
+            section,
+          }),
+        ];
+
+        // act
+        const output = parseMeetings(input);
+
+        // assert
+        expect(output).toEqual(expected);
+      });
+    });
+
+    describe('Grades is null', () => {
+      test('When its given as null', () => {
+        // arrange
+        const input = [{
+          id: 1,
+          crn: 1,
+          subject: 'CSCE',
+          course_num: '121',
+          section_num: '500',
+          min_credits: 3,
+          max_credits: 3,
+          current_enrollment: 0,
+          max_enrollment: 1,
+          instructor_name: 'Instructor Name',
+          web: false,
+          honors: false,
+          meetings: [
+            {
+              id: 11,
+              days: [true, false, false, false, false, false, false],
+              start_time: '08:00',
+              end_time: '08:50',
+              type: 'LEC',
+            },
+          ],
+          grades: null as any,
+        }];
+
+        const section = new Section({
+          id: 1,
+          crn: 1,
+          subject: 'CSCE',
+          courseNum: '121',
+          sectionNum: '500',
+          minCredits: 3,
+          maxCredits: 3,
+          currentEnrollment: 0,
+          maxEnrollment: 1,
+          instructor: new Instructor({ name: 'Instructor Name' }),
+          grades: null as any,
+        });
+
+        const expected = [
+          new Meeting({
+            id: 11,
+            building: '',
+            meetingDays: [true, false, false, false, false, false, false],
+            startTimeHours: 8,
+            startTimeMinutes: 0,
+            endTimeHours: 8,
+            endTimeMinutes: 50,
             meetingType: MeetingType.LEC,
             section,
           }),

--- a/autoscheduler/frontend/src/tests/redux/Redux.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/Redux.test.ts
@@ -22,6 +22,7 @@ const testSection = new Section({
   instructor: new Instructor({
     name: 'Aakash Tyagi',
   }),
+  grades: null,
 });
 
 const testMeeting1 = new Meeting({

--- a/autoscheduler/frontend/src/tests/redux/Schedule.test.tsx
+++ b/autoscheduler/frontend/src/tests/redux/Schedule.test.tsx
@@ -18,6 +18,7 @@ const testSectionA = new Section({
   instructor: new Instructor({
     name: 'Aakash Tyagi',
   }),
+  grades: null,
 });
 
 const testSectionB = new Section({
@@ -33,6 +34,7 @@ const testSectionB = new Section({
   instructor: new Instructor({
     name: 'Bad Bunny',
   }),
+  grades: null,
 });
 
 const testSectionC = new Section({
@@ -48,6 +50,7 @@ const testSectionC = new Section({
   instructor: new Instructor({
     name: 'Creed Cratton',
   }),
+  grades: null,
 });
 
 const testMeeting1 = new Meeting({

--- a/autoscheduler/frontend/src/tests/testSchedules.ts
+++ b/autoscheduler/frontend/src/tests/testSchedules.ts
@@ -18,6 +18,7 @@ const testSection1 = new Section({
   instructor: new Instructor({
     name: 'Aakash Tyagi',
   }),
+  grades: null,
 });
 
 const testSection2 = new Section({
@@ -33,6 +34,7 @@ const testSection2 = new Section({
   instructor: new Instructor({
     name: 'James Pennington',
   }),
+  grades: null,
 });
 
 const testSection3 = new Section({
@@ -48,6 +50,7 @@ const testSection3 = new Section({
   instructor: new Instructor({
     name: 'William Cohn',
   }),
+  grades: null,
 });
 
 const testMeeting = new Meeting({
@@ -109,6 +112,7 @@ const testSectionA = new Section({
   currentEnrollment: 0,
   maxEnrollment: 1,
   instructor: new Instructor({ name: 'Deborah Seagle' }),
+  grades: null,
 });
 
 const testMeeting5 = new Meeting({
@@ -145,6 +149,7 @@ const testSectionB = new Section({
   currentEnrollment: 0,
   maxEnrollment: 24,
   instructor: new Instructor({ name: 'Donald Trump' }),
+  grades: null,
 });
 
 const testMeeting7 = new Meeting({
@@ -170,6 +175,7 @@ const testSectionC = new Section({
   currentEnrollment: 0,
   maxEnrollment: 24,
   instructor: new Instructor({ name: 'Harley Quinn' }),
+  grades: null,
 });
 
 const testMeeting8 = new Meeting({
@@ -195,6 +201,7 @@ const testSectionD = new Section({
   currentEnrollment: 0,
   maxEnrollment: 24,
   instructor: new Instructor({ name: 'Naruto Uchiha' }),
+  grades: null,
 });
 
 const testMeeting9 = new Meeting({
@@ -220,6 +227,7 @@ const testSectionE = new Section({
   currentEnrollment: 0,
   maxEnrollment: 24,
   instructor: new Instructor({ name: 'Shawn Lupoli' }),
+  grades: null,
 });
 
 const testMeeting10 = new Meeting({
@@ -245,6 +253,7 @@ const testSectionF = new Section({
   currentEnrollment: 0,
   maxEnrollment: 24,
   instructor: new Instructor({ name: 'Albert Einstein' }),
+  grades: null,
 });
 
 const testMeeting11 = new Meeting({
@@ -270,6 +279,7 @@ const testSectionG = new Section({
   currentEnrollment: 0,
   maxEnrollment: 24,
   instructor: new Instructor({ name: 'Leonardo DiCaprio' }),
+  grades: null,
 });
 
 const testMeeting12 = new Meeting({
@@ -295,6 +305,7 @@ const testSectionH = new Section({
   currentEnrollment: 0,
   maxEnrollment: 24,
   instructor: new Instructor({ name: 'Morgan Freeman' }),
+  grades: null,
 });
 
 const testMeeting13 = new Meeting({

--- a/autoscheduler/frontend/src/tests/types/Grades.test.ts
+++ b/autoscheduler/frontend/src/tests/types/Grades.test.ts
@@ -1,0 +1,29 @@
+import Grades from '../../types/Grades';
+import { Indexable, fetchMock } from '../util';
+
+const correctArgs: Indexable = {
+  gpa: 0.0, A: 0, B: 0, C: 0, D: 0, F: 0, I: 0, S: 0, Q: 0, X: 0,
+};
+
+const createGrades = jest.fn((args) => new Grades(fetchMock(args)));
+
+describe('Grades type', () => {
+  describe('throws an error', () => {
+    const nonNullableProps = ['gpa', 'A', 'B', 'C', 'D', 'F', 'I', 'S', 'Q', 'X'];
+    test.each(nonNullableProps)('when any of the properties are null %s', (prop) => {
+      // arrange
+      const badArgs = { ...correctArgs };
+      badArgs[prop] = null;
+
+      // act/assert
+      expect(() => createGrades(badArgs)).toThrow();
+    });
+  });
+
+  describe('does not throw an error', () => {
+    test('when all of the props are not-null', () => {
+      // arrange/act/assert
+      expect(() => createGrades(correctArgs)).not.toThrow();
+    });
+  });
+});

--- a/autoscheduler/frontend/src/tests/types/Meeting.test.ts
+++ b/autoscheduler/frontend/src/tests/types/Meeting.test.ts
@@ -26,6 +26,7 @@ const correctArgs: Indexable = {
     instructor: new Instructor({
       name: 'Aakash Tyagi',
     }),
+    grades: null,
   }),
 };
 const createMeeting = jest.fn((args) => new Meeting(fetchMock(args)));

--- a/autoscheduler/frontend/src/tests/ui/MeetingCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/MeetingCard.test.tsx
@@ -23,6 +23,7 @@ const testSection = new Section({
   instructor: new Instructor({
     name: 'Aakash Tyagi',
   }),
+  grades: null,
 });
 
 const testMeeting = new Meeting({

--- a/autoscheduler/frontend/src/tests/ui/Schedule.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/Schedule.test.tsx
@@ -26,6 +26,7 @@ const testSection = new Section({
   instructor: new Instructor({
     name: 'Aakash Tyagi',
   }),
+  grades: null,
 });
 
 const testMeeting1 = new Meeting({

--- a/autoscheduler/frontend/src/types/Grades.ts
+++ b/autoscheduler/frontend/src/types/Grades.ts
@@ -23,6 +23,18 @@ export default class Grades {
   Q: number;
   X: number;
   constructor(init: GradesInit) {
+    // None of the properties can be null
+    if (init.gpa == null) { throw Error(`Grades.gpa is invalid: ${init.gpa}`); }
+    if (init.A == null) { throw Error(`Grades.A is invalid: ${init.A}`); }
+    if (init.B == null) { throw Error(`Grades.B is invalid: ${init.B}`); }
+    if (init.C == null) { throw Error(`Grades.C is invalid: ${init.C}`); }
+    if (init.D == null) { throw Error(`Grades.D is invalid: ${init.D}`); }
+    if (init.F == null) { throw Error(`Grades.F is invalid: ${init.F}`); }
+    if (init.I == null) { throw Error(`Grades.I is invalid: ${init.I}`); }
+    if (init.S == null) { throw Error(`Grades.S is invalid: ${init.S}`); }
+    if (init.Q == null) { throw Error(`Grades.Q is invalid: ${init.Q}`); }
+    if (init.X == null) { throw Error(`Grades.X is invalid: ${init.X}`); }
+
     Object.assign(this, init);
   }
 }

--- a/autoscheduler/frontend/src/types/Section.ts
+++ b/autoscheduler/frontend/src/types/Section.ts
@@ -1,4 +1,5 @@
 import Instructor from './Instructor';
+import Grades from './Grades';
 
 export default class Section {
   id: number;
@@ -11,6 +12,7 @@ export default class Section {
   currentEnrollment: number;
   maxEnrollment: number;
   instructor: Instructor;
+  grades: Grades;
 
   constructor(src: {
       id: number;
@@ -23,6 +25,7 @@ export default class Section {
       currentEnrollment: number;
       maxEnrollment: number;
       instructor: Instructor;
+      grades: Grades;
     }) {
     if (!Number.isInteger(src.id)) { throw Error(`Section.id is invalid: ${src.id}`); }
     if (!Number.isInteger(src.crn)) { throw Error(`Meeting.crn is invalid: ${src.crn}`); }

--- a/autoscheduler/scraper/serializers.py
+++ b/autoscheduler/scraper/serializers.py
@@ -48,8 +48,13 @@ class SectionSerializer(serializers.ModelSerializer):
 
     def get_grades(self, obj): # pylint: disable=no-self-use
         """ Gets the past grade distributions for this prof + course """
-        return Grades.objects.instructor_performance(obj.subject, obj.course_num,
-                                                     obj.instructor)
+        grades = Grades.objects.instructor_performance(obj.subject, obj.course_num,
+                                                       obj.instructor)
+        # If GPA is none, then there weren't any grades for this course & professor
+        if grades.get("gpa") is None:
+            return None
+
+        return grades
 
 def season_num_to_string(season_num):
     """ Converts int representing season in 'term' field to a string to

--- a/autoscheduler/scraper/tests/api_tests.py
+++ b/autoscheduler/scraper/tests/api_tests.py
@@ -265,8 +265,7 @@ class APITests(APITestCase): #pylint: disable=too-many-public-methods
             ],
             'section_num': '501',
             'web': False,
-            'grades': {key: None for key in ['A', 'B', 'C', 'D', 'F', 'I',
-                                             'S', 'U', 'Q', 'X', 'gpa']}
+            'grades': None,
         }
 
         # Act
@@ -316,8 +315,7 @@ class APITests(APITestCase): #pylint: disable=too-many-public-methods
                 ],
                 'section_num': '501',
                 'web': False,
-                'grades': {key: None for key in ['A', 'B', 'C', 'D', 'F', 'I',
-                                                 'S', 'U', 'Q', 'X', 'gpa']}
+                'grades': None,
             },
             {
                 'id': 2,


### PR DESCRIPTION
I added the grades field to the Section type, as we'll need it for the schedule GPA calculating in #193 (and I didn't want to do it in that PR), as well as for the grade distributions (#163).

I also made the `SectionSerializer` return `None` instead of `Grades` models where all of the fields were null in the cases that a prof has no previous grades out for a course, as it makes it much easier to handle on the frontend. 