### PR TITLE
Parse instructor fix

### DIFF
--- a/autoscheduler/scraper/management/commands/scrape_courses.py
+++ b/autoscheduler/scraper/management/commands/scrape_courses.py
@@ -120,7 +120,7 @@ def parse_instructor(course_data, instructors_set) -> Instructor:
 
         if name not in instructors_set:
             instructors_set.add(name)
-            return instructor_model
+        return instructor_model
 
     return None
 

--- a/autoscheduler/scraper/management/commands/scrape_courses.py
+++ b/autoscheduler/scraper/management/commands/scrape_courses.py
@@ -98,7 +98,7 @@ def parse_meeting(meetings_data, section: Section, meeting_count: int) -> Meetin
                             meeting_type=class_type, section=section)
     return meeting_model
 
-def parse_instructor(course_data, instructors_set) -> Instructor:
+def parse_instructor(course_data) -> Instructor:
     """ Parses the instructor data and saves it as a Instructor model.
         Called from parse_course.
     """
@@ -116,11 +116,7 @@ def parse_instructor(course_data, instructors_set) -> Instructor:
 
         email = faculty_data['emailAddress']
 
-        instructor_model = Instructor(id=name, email_address=email)
-
-        if name not in instructors_set:
-            instructors_set.add(name)
-        return instructor_model
+        return Instructor(id=name, email_address=email)
 
     return None
 
@@ -147,8 +143,14 @@ def parse_course(course_data: List,
     credit_hours = course_data['creditHourLow']
 
     # Parse the instructor, then send the returned Instructor model to parse_section
-    instructor_model = parse_instructor(course_data, instructors_set)
+    instructor_model = parse_instructor(course_data)
     section_data = parse_section(course_data, instructor_model)
+
+    if instructor_model is not None and instructor_model not in instructors_set:
+        instructors_set.add(instructor_model)
+    else:
+        # Set it to None so that it doesn't get added to the list of instructors to save
+        instructor_model = None
 
     # Save course only if it hasn't already been created
     if course_id not in courses_set:

--- a/autoscheduler/scraper/tests/commands/scrape_courses_tests.py
+++ b/autoscheduler/scraper/tests/commands/scrape_courses_tests.py
@@ -132,6 +132,24 @@ class ScrapeCoursesTests(django.test.TestCase):
         # will throw an error, thus failing the test
         Instructor.objects.get(id=instructor_id, email_address=email)
 
+    def test_parse_instructor_does_return_instructor_when_already_seen(self):
+        """ Tests that parse instructor returns the same instructor twice when they're
+            seen in different sections, rather than returning None for the second one
+        """
+
+        # Arrange
+        instructor_set = set()
+        # Both sections have John M. Moore as the professor
+        # Parse the professor for the first time, which adds it to the instructor_set
+        instructor1 = parse_instructor(self.csce_section_json, instructor_set)
+
+        # Act
+        instructor2 = parse_instructor(self.csce_web_section_json, instructor_set)
+
+        # Assert
+        self.assertEqual(instructor1, instructor2)
+        self.assertIsNotNone(instructor2)
+
     def test_parse_course_does_save_model(self):
         """ Tests if parse_course saves the course to the database correctly """
 

--- a/autoscheduler/scraper/tests/commands/scrape_courses_tests.py
+++ b/autoscheduler/scraper/tests/commands/scrape_courses_tests.py
@@ -124,7 +124,7 @@ class ScrapeCoursesTests(django.test.TestCase):
         email = "jmichael@email.tamu.edu"
 
         # Act
-        instructor = parse_instructor(self.csce_section_json, set())
+        instructor = parse_instructor(self.csce_section_json)
         instructor.save()
 
         # Assert
@@ -138,13 +138,12 @@ class ScrapeCoursesTests(django.test.TestCase):
         """
 
         # Arrange
-        instructor_set = set()
         # Both sections have John M. Moore as the professor
         # Parse the professor for the first time, which adds it to the instructor_set
-        instructor1 = parse_instructor(self.csce_section_json, instructor_set)
+        instructor1 = parse_instructor(self.csce_section_json)
 
         # Act
-        instructor2 = parse_instructor(self.csce_web_section_json, instructor_set)
+        instructor2 = parse_instructor(self.csce_web_section_json)
 
         # Assert
         self.assertEqual(instructor1, instructor2)


### PR DESCRIPTION
Small bug, but `parse_instructor` would return `None` anytime an instructor was already visited, which resulted in lot of sections having `None` instructors when they shouldn't (i.e. for `201531`). This fixes that bug and adds a test for it. 