### PR TITLE
Refactored parseMeetings to parseSections

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.tsx
@@ -3,7 +3,6 @@ import { Typography, FormLabel } from '@material-ui/core';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../../../../../redux/reducer';
 import * as styles from './BasicSelect.css';
-import { SectionSelected } from '../../../../../../types/CourseCardOptions';
 import BasicOptionRow from './BasicOptionRow';
 
 interface BasicSelectProps {
@@ -12,9 +11,10 @@ interface BasicSelectProps {
 
 const BasicSelect: React.FC<BasicSelectProps> = ({ id }) => {
   const course = useSelector<RootState, string>((state) => state.courseCards[id].course || '');
-  const sections = useSelector<RootState, SectionSelected[]>(
-    (state) => state.courseCards[id].sections,
+  const hasHonors = useSelector<RootState, boolean>(
+    (state) => state.courseCards[id].hasHonors || false,
   );
+  const hasWeb = useSelector<RootState, boolean>((state) => state.courseCards[id].hasWeb || false);
 
   // shows placeholder text if no course is selected
   if (!course) {
@@ -25,12 +25,8 @@ const BasicSelect: React.FC<BasicSelectProps> = ({ id }) => {
     );
   }
 
-  // determine whether or not there are honors or web sections
-  const hasHonorsSections = sections.some((secData) => secData.section.honors);
-  const hasWebSections = sections.some((secData) => secData.section.web);
-
   // show placeholder message if there are no special sections to filter
-  if (!hasHonorsSections && !hasWebSections) {
+  if (!hasHonors && !hasWeb) {
     return (
       <Typography className={styles.grayText}>
         There are no honors or online courses for this class
@@ -43,10 +39,10 @@ const BasicSelect: React.FC<BasicSelectProps> = ({ id }) => {
       <FormLabel>Options</FormLabel>
       <table className={styles.tableContainer}>
         <tbody>
-          {hasHonorsSections
+          {hasHonors
             ? <BasicOptionRow id={id} value="honors" />
             : null}
-          {hasWebSections
+          {hasWeb
             ? <BasicOptionRow id={id} value="web" />
             : null}
         </tbody>

--- a/autoscheduler/frontend/src/tests/redux/CourseCardRedux.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/CourseCardRedux.test.ts
@@ -1,4 +1,4 @@
-import { parseMeetings } from '../../redux/actions/courseCards';
+import { parseSections } from '../../redux/actions/courseCards';
 import Meeting, { MeetingType } from '../../types/Meeting';
 import Section from '../../types/Section';
 import Instructor from '../../types/Instructor';
@@ -6,7 +6,7 @@ import Instructor from '../../types/Instructor';
 // The input from the backend use snake_case, so disable camelcase errors for this file
 /* eslint-disable @typescript-eslint/camelcase */
 describe('Course Cards Redux', () => {
-  describe('parseMeeting', () => {
+  describe('parseSections', () => {
     describe('parses correctly', () => {
       test('on a normal input', () => {
         // arrange
@@ -49,22 +49,21 @@ describe('Course Cards Redux', () => {
           instructor: new Instructor({ name: 'Instructor Name' }),
         });
 
-        const expected = [
-          new Meeting({
-            id: 11,
-            building: '',
-            meetingDays: [true, false, false, false, false, false, false],
-            startTimeHours: 8,
-            startTimeMinutes: 0,
-            endTimeHours: 8,
-            endTimeMinutes: 50,
-            meetingType: MeetingType.LEC,
-            section,
-          }),
-        ];
+        const meetings = [new Meeting({
+          id: 11,
+          building: '',
+          meetingDays: [true, false, false, false, false, false, false],
+          startTimeHours: 8,
+          startTimeMinutes: 0,
+          endTimeHours: 8,
+          endTimeMinutes: 50,
+          meetingType: MeetingType.LEC,
+          section,
+        })];
+        const expected = [{ section, meetings, selected: false }];
 
         // act
-        const output = parseMeetings(input);
+        const output = parseSections(input);
 
         // assert
         expect(output).toEqual(expected);
@@ -110,7 +109,7 @@ describe('Course Cards Redux', () => {
           instructor: new Instructor({ name: 'Instructor Name' }),
         });
 
-        const expected = [
+        const meetings = [
           new Meeting({
             id: 11,
             building: '',
@@ -124,8 +123,10 @@ describe('Course Cards Redux', () => {
           }),
         ];
 
+        const expected = [{ section, meetings, selected: false }];
+
         // act
-        const output = parseMeetings(input);
+        const output = parseSections(input);
 
         // assert
         expect(output).toEqual(expected);
@@ -172,7 +173,7 @@ describe('Course Cards Redux', () => {
           instructor: new Instructor({ name: 'Instructor Name' }),
         });
 
-        const expected = [
+        const meetings = [
           new Meeting({
             id: 11,
             building: '',
@@ -186,8 +187,10 @@ describe('Course Cards Redux', () => {
           }),
         ];
 
+        const expected = [{ section, meetings, selected: false }];
+
         // act
-        const output = parseMeetings(input);
+        const output = parseSections(input);
 
         // assert
         expect(output).toEqual(expected);

--- a/autoscheduler/frontend/src/types/CourseCardOptions.ts
+++ b/autoscheduler/frontend/src/types/CourseCardOptions.ts
@@ -21,6 +21,8 @@ export interface CourseCardOptions {
   customizationLevel?: CustomizationLevel;
   web?: string;
   honors?: string;
+  hasHonors?: boolean;
+  hasWeb? : boolean;
   sections?: SectionSelected[];
 }
 


### PR DESCRIPTION
Optimizes the way that `SectionSelected` objects are created by parsing them directly from the section data we get from the API. I also added `hasHonors` and `hasWeb` as parts of the course card state, so that they only have to be calculated when sections are parsed again.

I realized that it's far more effort than it's worth to remove the `SectionSelected` class (as it would create a circular dependency between `Section` and `Meeting` and even if I make `Meeting` just take section nums/ids instead of a section object, it would involve a huge amount of refactoring), so I didn't change it at all.

Closes #241.