### PR TITLE
Corrected CourseCardRedux tests

### DIFF
--- a/autoscheduler/frontend/src/tests/redux/CourseCardRedux.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/CourseCardRedux.test.ts
@@ -246,9 +246,11 @@ describe('Course Cards Redux', () => {
           maxEnrollment: 1,
           instructor: new Instructor({ name: 'Instructor Name' }),
           grades: null as any,
+          web: false,
+          honors: false,
         });
 
-        const expected = [
+        const meetings = [
           new Meeting({
             id: 11,
             building: '',
@@ -262,8 +264,10 @@ describe('Course Cards Redux', () => {
           }),
         ];
 
+        const expected = [{ section, meetings, selected: false }];
+
         // act
-        const output = parseMeetings(input);
+        const output = parseSections(input);
 
         // assert
         expect(output).toEqual(expected);


### PR DESCRIPTION
Since I didn't rebase with master for #232 before merging, it ended up failing the tests as I added `parseMeetings` tests in it, but Ryan changed it to `parseSection` and I didn't reflect those changes in my branch.