### PR TITLE
Show ONLINE for online meetings in SectionSelect

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
@@ -46,7 +46,8 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
 
   const getMeetingTimeText = (mtg: Meeting): string => {
     if (mtg.startTimeHours === 0) {
-      return 'ONLINE';
+      // If the time is 00:00 but it's not honors, then showing nothing for the meeting time
+      return mtg.section.web ? 'ONLINE' : '';
     }
 
     // Returns it in the format 12:00 - 1:00

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
@@ -44,6 +44,16 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
     return meeting.meetingDays.reduce((acc, curr, idx) => (curr ? acc + DAYS_OF_WEEK[idx] : acc), '');
   };
 
+  const getMeetingTimeText = (mtg: Meeting): string => {
+    if (mtg.startTimeHours === 0) {
+      return 'ONLINE';
+    }
+
+    // Returns it in the format 12:00 - 1:00
+    return `${formatTime(mtg.startTimeHours, mtg.startTimeMinutes)}
+      - ${formatTime(mtg.endTimeHours, mtg.endTimeMinutes)}`;
+  };
+
   const renderMeeting = (mtg: Meeting, showSectionNum: boolean): JSX.Element => (
     <Typography className={styles.denseListItem} key={mtg.id}>
       <span className={styles.sectionNum} style={{ visibility: showSectionNum ? 'visible' : 'hidden' }}>
@@ -56,8 +66,7 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
         {formatMeetingDays(mtg)}
       </span>
       <span className={styles.meetingDetailsText}>
-        {`${formatTime(mtg.startTimeHours, mtg.startTimeMinutes)}
-        - ${formatTime(mtg.endTimeHours, mtg.endTimeMinutes)}`}
+        {getMeetingTimeText(mtg)}
       </span>
     </Typography>
   );

--- a/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
@@ -511,7 +511,7 @@ describe('Course Select Card UI', () => {
   });
   describe('SectionSelect', () => {
     describe('shows ONLINE', () => {
-      test('for 00:00 meeting times', () => {
+      test('for 00:00 meeting times & online section', () => {
         // arrange
         const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
 
@@ -563,6 +563,62 @@ describe('Course Select Card UI', () => {
 
         // assert
         expect(getByText('ONLINE')).toBeTruthy();
+      });
+    });
+
+    describe('does not show ONLINE', () => {
+      test('for 00:00 meeting times that are not online sections', () => {
+        // arrange
+        const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
+
+        const {
+          queryByText,
+        } = render(
+          <Provider store={store}><SectionSelect id={0} /></Provider>,
+        );
+
+        const testSection = new Section({
+          id: 0,
+          crn: 0,
+          subject: 'CSCE',
+          courseNum: '121',
+          sectionNum: '200',
+          minCredits: 3,
+          maxCredits: null,
+          currentEnrollment: 0,
+          maxEnrollment: 0,
+          instructor: new Instructor({
+            name: 'Test',
+          }),
+          honors: false,
+          web: false,
+          grades: null,
+        });
+        const testMeeting = new Meeting({
+          id: 1,
+          building: '',
+          meetingDays: new Array(7).fill(true),
+          startTimeHours: 0,
+          startTimeMinutes: 0,
+          endTimeHours: 0,
+          endTimeMinutes: 0,
+          meetingType: MeetingType.LEC,
+          section: testSection,
+        });
+
+        const sectionSelected = {
+          section: testSection,
+          meetings: [testMeeting],
+          selected: false,
+        };
+
+        // Add the SectionSelected type to the store so it shows up in the SectionSelect component
+        store.dispatch<any>(updateCourseCard(0, {
+          sections: [sectionSelected],
+        }, '201931'));
+
+        // assert
+        expect(queryByText('ONLINE')).not.toBeInTheDocument();
       });
     });
   });

--- a/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
@@ -15,6 +15,11 @@ import CourseSelectCard from '../../components/SchedulingPage/CourseSelectColumn
 import autoSchedulerReducer from '../../redux/reducer';
 import testFetch from '../testData';
 import setTerm from '../../redux/actions/term';
+import SectionSelect from '../../components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect';
+import Section from '../../types/Section';
+import Instructor from '../../types/Instructor';
+import Meeting, { MeetingType } from '../../types/Meeting';
+import { updateCourseCard } from '../../redux/actions/courseCards';
 
 const dummySectionArgs = {
   id: 123456,
@@ -502,6 +507,63 @@ describe('Course Select Card UI', () => {
       // assert
       const placeholder = 'There are no available sections for this term';
       expect(queryByText(placeholder)).not.toBeInTheDocument();
+    });
+  });
+  describe('SectionSelect', () => {
+    describe('shows ONLINE', () => {
+      test('for 00:00 meeting times', () => {
+        // arrange
+        const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
+
+        const {
+          getByText,
+        } = render(
+          <Provider store={store}><SectionSelect id={0} /></Provider>,
+        );
+
+        const testSection = new Section({
+          id: 0,
+          crn: 0,
+          subject: 'CSCE',
+          courseNum: '121',
+          sectionNum: '200',
+          minCredits: 3,
+          maxCredits: null,
+          currentEnrollment: 0,
+          maxEnrollment: 0,
+          instructor: new Instructor({
+            name: 'Test',
+          }),
+          honors: false,
+          web: true,
+          grades: null,
+        });
+        const testMeeting = new Meeting({
+          id: 1,
+          building: '',
+          meetingDays: new Array(7).fill(true),
+          startTimeHours: 0,
+          startTimeMinutes: 0,
+          endTimeHours: 0,
+          endTimeMinutes: 0,
+          meetingType: MeetingType.LEC,
+          section: testSection,
+        });
+
+        const sectionSelected = {
+          section: testSection,
+          meetings: [testMeeting],
+          selected: false,
+        };
+
+        // Add the SectionSelected type to the store so it shows up in the SectionSelect component
+        store.dispatch<any>(updateCourseCard(0, {
+          sections: [sectionSelected],
+        }, '201931'));
+
+        // assert
+        expect(getByText('ONLINE')).toBeTruthy();
+      });
     });
   });
 });


### PR DESCRIPTION
This adds the showing of ONLINE for meeting times that are `00:00`. I used the assumption that if the startTime for a meeting is 0, then it's safe to assume that the rest of them are also 0, meaning that it's an online meeting time.

Closes #184 