### PR TITLE
Connected generate schedules

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
@@ -80,15 +80,9 @@ const ConfigureCard: React.FC = () => {
       }),
     }).then(
       (res) => res.json(),
-    ).then((data: any[][]) => {
-      const ret: Meeting[][] = [];
-
-      data.forEach((schedule) => {
-        ret.push(parseAllMeetings(schedule));
-      });
-
-      return ret;
-    }).then((schedules: Meeting[][]) => {
+    ).then((generatedSchedules: any[][]) => generatedSchedules.map(
+      (schedule) => parseAllMeetings(schedule),
+    )).then((schedules: Meeting[][]) => {
       dispatch(replaceSchedules(schedules));
       dispatch(selectSchedule(0));
       setLoading(false);

--- a/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
@@ -9,7 +9,7 @@ import * as styles from './ConfigureCard.css';
 import { replaceSchedules } from '../../../redux/actions/schedules';
 import selectSchedule from '../../../redux/actions/selectedSchedule';
 import Meeting from '../../../types/Meeting';
-import { parseMeetings } from '../../../redux/actions/courseCards';
+import { parseAllMeetings } from '../../../redux/actions/courseCards';
 // DEBUG
 import { RootState } from '../../../redux/reducer';
 import { CourseCardArray, CustomizationLevel } from '../../../types/CourseCardOptions';
@@ -24,7 +24,7 @@ const ConfigureCard: React.FC = () => {
   const [includeFull, setIncludeFull] = React.useState(false);
   const [loading, setLoading] = React.useState(false);
   const courseCards = useSelector<RootState, CourseCardArray>((state) => state.courseCards);
-  const term = useSelector<RootState, number>((state) => state.term);
+  const term = useSelector<RootState, string>((state) => state.term);
   const avsList = useSelector<RootState, Availability[]>((state) => state.availability);
   const dispatch = useDispatch();
 
@@ -50,12 +50,16 @@ const ConfigureCard: React.FC = () => {
         const [subject, courseNum] = courseCard.course.split(' ');
         const isBasic = courseCard.customizationLevel === CustomizationLevel.BASIC;
 
+        // The default option for honors and web when the Section customization level is selected
+        const filterDefault = 'no_preference';
+
         courses.push({
           subject,
           courseNum,
           sections: isBasic ? [] : selectedSections, // Only send if "Section" customization level
-          honors: isBasic ? courseCard.honors ?? null : null, // Only send if "Basic" level
-          web: isBasic ? courseCard.web ?? null : null,
+          // Only send if "Basic" level
+          honors: isBasic ? courseCard.honors ?? filterDefault : filterDefault,
+          web: isBasic ? courseCard.web ?? filterDefault : filterDefault,
         });
       }
     }
@@ -80,7 +84,7 @@ const ConfigureCard: React.FC = () => {
       const ret: Meeting[][] = [];
 
       data.forEach((schedule) => {
-        ret.push(parseMeetings(schedule));
+        ret.push(parseAllMeetings(schedule));
       });
 
       return ret;

--- a/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
@@ -35,11 +35,20 @@ const ConfigureCard: React.FC = () => {
     const courses = [];
     for (let i = 0; i < courseCards.numCardsCreated; i++) {
       if (courseCards[i] && courseCards[i].course) {
+        const selectedSections: string[] = []; // the section nums of the selected sections
+
+        // Iterate through the sections and only choose the ones that are selected
+        courseCards[i].sections.forEach((sectionSel) => {
+          if (sectionSel.selected) {
+            selectedSections.push(sectionSel.section.sectionNum);
+          }
+        });
+
         const [subject, courseNum] = courseCards[i].course.split(' ');
         courses.push({
           subject,
           courseNum,
-          sections: courseCards[i].sections,
+          sections: selectedSections,
           honors: courseCards[i].honors,
           web: courseCards[i].web,
         });

--- a/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
@@ -65,8 +65,8 @@ const ConfigureCard: React.FC = () => {
     }
     // make availabilities object
     const availabilities = avsList.map((avl) => ({
-      startTime: formatTime(avl.startTimeHours, avl.startTimeMinutes).replace(':', ''),
-      endTime: formatTime(avl.endTimeHours, avl.endTimeMinutes).replace(':', ''),
+      startTime: formatTime(avl.startTimeHours, avl.startTimeMinutes, true, true).replace(':', ''),
+      endTime: formatTime(avl.endTimeHours, avl.endTimeMinutes, true, true).replace(':', ''),
       day: avl.dayOfWeek,
     }));
 

--- a/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
@@ -12,7 +12,7 @@ import Meeting from '../../../types/Meeting';
 import { parseMeetings } from '../../../redux/actions/courseCards';
 // DEBUG
 import { RootState } from '../../../redux/reducer';
-import { CourseCardArray } from '../../../types/CourseCardOptions';
+import { CourseCardArray, CustomizationLevel } from '../../../types/CourseCardOptions';
 import Availability from '../../../types/Availability';
 import { formatTime } from '../../../timeUtil';
 
@@ -36,22 +36,26 @@ const ConfigureCard: React.FC = () => {
     const courses = [];
     for (let i = 0; i < courseCards.numCardsCreated; i++) {
       if (courseCards[i] && courseCards[i].course) {
+        const courseCard = courseCards[i];
+
         const selectedSections: string[] = []; // the section nums of the selected sections
 
         // Iterate through the sections and only choose the ones that are selected
-        courseCards[i].sections.forEach((sectionSel) => {
+        courseCard.sections.forEach((sectionSel) => {
           if (sectionSel.selected) {
             selectedSections.push(sectionSel.section.sectionNum);
           }
         });
 
-        const [subject, courseNum] = courseCards[i].course.split(' ');
+        const [subject, courseNum] = courseCard.course.split(' ');
+        const isBasic = courseCard.customizationLevel === CustomizationLevel.BASIC;
+
         courses.push({
           subject,
           courseNum,
-          sections: selectedSections,
-          honors: courseCards[i].honors,
-          web: courseCards[i].web,
+          sections: isBasic ? [] : selectedSections, // Only send if "Section" customization level
+          honors: isBasic ? courseCard.honors ?? null : null, // Only send if "Basic" level
+          web: isBasic ? courseCard.web ?? null : null,
         });
       }
     }

--- a/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
@@ -24,6 +24,7 @@ const ConfigureCard: React.FC = () => {
   const [includeFull, setIncludeFull] = React.useState(false);
   const [loading, setLoading] = React.useState(false);
   const courseCards = useSelector<RootState, CourseCardArray>((state) => state.courseCards);
+  const term = useSelector<RootState, number>((state) => state.term);
   const avsList = useSelector<RootState, Availability[]>((state) => state.availability);
   const dispatch = useDispatch();
 
@@ -64,7 +65,7 @@ const ConfigureCard: React.FC = () => {
     fetch('scheduler/generate', {
       method: 'POST',
       body: JSON.stringify({
-        term: '202011',
+        term,
         includeFull,
         courses,
         availabilities,
@@ -84,7 +85,7 @@ const ConfigureCard: React.FC = () => {
       dispatch(selectSchedule(0));
       setLoading(false);
     });
-  }, [avsList, courseCards, dispatch, includeFull]);
+  }, [avsList, courseCards, dispatch, includeFull, term]);
 
   return (
     <GenericCard

--- a/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
@@ -9,8 +9,8 @@ import * as styles from './ConfigureCard.css';
 import { replaceSchedules } from '../../../redux/actions/schedules';
 import selectSchedule from '../../../redux/actions/selectedSchedule';
 import Meeting from '../../../types/Meeting';
+import { parseMeetings } from '../../../redux/actions/courseCards';
 // DEBUG
-import fetch from './generateSchedulesMock';
 import { RootState } from '../../../redux/reducer';
 import { CourseCardArray } from '../../../types/CourseCardOptions';
 import Availability from '../../../types/Availability';
@@ -52,7 +52,7 @@ const ConfigureCard: React.FC = () => {
       day: avl.dayOfWeek,
     }));
 
-    fetch('/api/scheduling/generate', {
+    fetch('scheduler/generate', {
       method: 'POST',
       body: JSON.stringify({
         term: '202011',
@@ -60,13 +60,21 @@ const ConfigureCard: React.FC = () => {
         courses,
         availabilities,
       }),
-    }).then((res) => res.json()).then(
-      (schedules: Meeting[][]) => {
-        dispatch(replaceSchedules(schedules));
-        dispatch(selectSchedule(0));
-        setLoading(false);
-      },
-    );
+    }).then(
+      (res) => res.json(),
+    ).then((data: any[][]) => {
+      const ret: Meeting[][] = [];
+
+      data.forEach((schedule) => {
+        ret.push(parseMeetings(schedule));
+      });
+
+      return ret;
+    }).then((schedules: Meeting[][]) => {
+      dispatch(replaceSchedules(schedules));
+      dispatch(selectSchedule(0));
+      setLoading(false);
+    });
   }, [avsList, courseCards, dispatch, includeFull]);
 
   return (

--- a/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
@@ -38,14 +38,8 @@ const ConfigureCard: React.FC = () => {
       if (courseCards[i] && courseCards[i].course) {
         const courseCard = courseCards[i];
 
-        const selectedSections: string[] = []; // the section nums of the selected sections
-
         // Iterate through the sections and only choose the ones that are selected
-        courseCard.sections.forEach((sectionSel) => {
-          if (sectionSel.selected) {
-            selectedSections.push(sectionSel.section.sectionNum);
-          }
-        });
+        const selectedSections = courseCard.sections.filter((sectionSel) => sectionSel.selected);
 
         const [subject, courseNum] = courseCard.course.split(' ');
         const isBasic = courseCard.customizationLevel === CustomizationLevel.BASIC;
@@ -58,8 +52,8 @@ const ConfigureCard: React.FC = () => {
           courseNum,
           sections: isBasic ? [] : selectedSections, // Only send if "Section" customization level
           // Only send if "Basic" level
-          honors: isBasic ? courseCard.honors ?? filterDefault : filterDefault,
-          web: isBasic ? courseCard.web ?? filterDefault : filterDefault,
+          honors: isBasic ? (courseCard.honors ?? filterDefault) : filterDefault,
+          web: isBasic ? (courseCard.web ?? filterDefault) : filterDefault,
         });
       }
     }

--- a/autoscheduler/frontend/src/package-lock.json
+++ b/autoscheduler/frontend/src/package-lock.json
@@ -3384,9 +3384,9 @@
       "dev": true
     },
     "cacache": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
-      "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
+      "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
       "dev": true,
       "requires": {
         "bluebird": "^3.5.5",
@@ -3510,9 +3510,9 @@
       }
     },
     "chownr": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true
     },
     "chrome-trace-event": {
@@ -5053,9 +5053,9 @@
       }
     },
     "figgy-pudding": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-      "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
+      "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
       "dev": true
     },
     "figures": {
@@ -9549,9 +9549,9 @@
       }
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
     "kleur": {
@@ -9883,9 +9883,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mississippi": {
       "version": "3.0.0",
@@ -9927,20 +9927,12 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        }
+        "minimist": "^1.2.5"
       }
     },
     "move-concurrently": {
@@ -10533,9 +10525,9 @@
       "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
     },
     "portfinder": {
-      "version": "1.0.25",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.25.tgz",
-      "integrity": "sha512-6ElJnHBbxVA1XSLgBp7G1FiCkQdlqGzuF7DswL5tcea+E8UpuvPU7beVAjjRwCioTS9ZluNbu+ZyRvgTsmqEBg==",
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.26.tgz",
+      "integrity": "sha512-Xi7mKxJHHMI3rIUrnm/jjUgwhbYMkp/XKEcZX3aG4BrumLpq3nmoQMX+ClYnDZnZ/New7IatC1no5RX0zo1vXQ==",
       "dev": true,
       "requires": {
         "async": "^2.6.2",
@@ -13320,8 +13312,7 @@
     },
     "yargs-parser": {
       "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "resolved": "",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/autoscheduler/frontend/src/redux/actions/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/actions/courseCards.ts
@@ -37,56 +37,98 @@ function updateCourseCardSync(index: number, courseCard: CourseCardOptions): Upd
 }
 
 /**
+ * Helper function that converts the given serialized section from the backend and converts it
+ * into a Section type
+ * @param sectionData The serialized section returned from the backend, i.e. from /api/sections
+ */
+function parseSection(sectionData: any): Section {
+  return new Section({
+    id: Number(sectionData.id),
+    crn: Number(sectionData.crn),
+    subject: sectionData.subject,
+    courseNum: sectionData.course_num,
+    sectionNum: sectionData.section_num,
+    minCredits: Number(sectionData.min_credits),
+    maxCredits: Number(sectionData.max_credits) || null,
+    currentEnrollment: Number(sectionData.current_enrollment),
+    maxEnrollment: Number(sectionData.max_enrollment),
+    honors: sectionData.honors,
+    web: sectionData.web,
+    instructor: new Instructor({ name: sectionData.instructor_name }),
+    grades: sectionData.grades == null ? null : new Grades(sectionData.grades),
+  });
+}
+
+/**
+ * Helper function that iterates through all of the meetings in single section given by the backend
+ * and converts them into a Meeting's type array
+ * @param sectionData The serialized section returned from the backend, i.e. from /api/sections
+ * @param section The parsed Section type from this sectionData
+ */
+function parseMeetings(sectionData: any, section: Section): Meeting[] {
+  const meetings: Meeting[] = [];
+
+  sectionData.meetings.forEach((meetingData: any) => {
+    let start: string[] = ['0', '0'];
+    let end: string[] = ['0', '0'];
+
+    if (meetingData.start_time != null && meetingData.start_time.length > 0) {
+      start = meetingData.start_time.split(':');
+      end = meetingData.end_time.split(':');
+    }
+
+    const meeting = new Meeting({
+      id: Number(meetingData.id),
+      building: '',
+      meetingDays: meetingData.days,
+      startTimeHours: Number(start[0]),
+      startTimeMinutes: Number(start[1]),
+      endTimeHours: Number(end[0]),
+      endTimeMinutes: Number(end[1]),
+      // Converts string to MeetingType enum
+      meetingType: MeetingType[meetingData.type as keyof typeof MeetingType],
+      section,
+    });
+
+    meetings.push(meeting);
+  });
+
+  return meetings;
+}
+
+/**
+ * Helper function that iterates through all of the individual sections that are given by
+ * /scheduler/generate, parses their meetings, then combines them into a singular Meeting array
+ * Used in ConfigureCard for parsing the return from /scheduler/generate
+ * @param arr The array of sections returne from the backend
+ */
+export function parseAllMeetings(arr: any[]): Meeting[] {
+  const ret: Meeting[] = [];
+
+  arr.forEach((sectionData) => {
+    const section = parseSection(sectionData);
+
+    const meetings = parseMeetings(sectionData, section);
+
+    ret.push(...meetings);
+  });
+
+  return ret;
+}
+
+/**
  *  Helper function to parse the serialized Section model from the backend convert it into an
  *  array of Sections
  *  @param arr The array of sections returned from the backend, such as from api/sections
  */
-export function parseSections(arr: any[]): SectionSelected[] {
+export function parseSections(arr: any[]): SectionSelected[] { // Rename to parseSectionSelected?
   const sections: SectionSelected[] = [];
 
   arr.forEach((sectionData) => {
-    const meetings: Meeting[] = [];
+    const section = parseSection(sectionData);
 
-    const section = new Section({
-      id: Number(sectionData.id),
-      crn: Number(sectionData.crn),
-      subject: sectionData.subject,
-      courseNum: sectionData.course_num,
-      sectionNum: sectionData.section_num,
-      minCredits: Number(sectionData.min_credits),
-      maxCredits: Number(sectionData.max_credits) || null,
-      currentEnrollment: Number(sectionData.current_enrollment),
-      maxEnrollment: Number(sectionData.max_enrollment),
-      honors: sectionData.honors,
-      web: sectionData.web,
-      instructor: new Instructor({ name: sectionData.instructor_name }),
-      grades: sectionData.grades == null ? null : new Grades(sectionData.grades),
-    });
+    const meetings = parseMeetings(sectionData, section);
 
-    sectionData.meetings.forEach((meetingData: any) => {
-      let start: string[] = ['0', '0'];
-      let end: string[] = ['0', '0'];
-
-      if (meetingData.start_time != null && meetingData.start_time.length > 0) {
-        start = meetingData.start_time.split(':');
-        end = meetingData.end_time.split(':');
-      }
-
-      const meeting = new Meeting({
-        id: Number(meetingData.id),
-        building: '',
-        meetingDays: meetingData.days,
-        startTimeHours: Number(start[0]),
-        startTimeMinutes: Number(start[1]),
-        endTimeHours: Number(end[0]),
-        endTimeMinutes: Number(end[1]),
-        // Converts string to MeetingType enum
-        meetingType: MeetingType[meetingData.type as keyof typeof MeetingType],
-        section,
-      });
-
-      meetings.push(meeting);
-    });
     sections.push({ section, meetings, selected: false });
   });
 

--- a/autoscheduler/frontend/src/redux/actions/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/actions/courseCards.ts
@@ -121,7 +121,7 @@ export function parseAllMeetings(arr: any[]): Meeting[] {
  *  array of Sections
  *  @param arr The array of sections returned from the backend, such as from api/sections
  */
-export function parseSections(arr: any[]): SectionSelected[] { // Rename to parseSectionSelected?
+export function parseSectionSelected(arr: any[]): SectionSelected[] {
   const sections: SectionSelected[] = [];
 
   arr.forEach((sectionData) => {
@@ -152,7 +152,7 @@ function updateCourseCardAsync(
         (res) => res.json(),
       )
       .then(
-        (arr: any[]) => parseSections(arr),
+        (arr: any[]) => parseSectionSelected(arr),
       )
       .then(
         (arr: SectionSelected[]) => arr.sort(

--- a/autoscheduler/frontend/src/redux/actions/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/actions/courseCards.ts
@@ -66,9 +66,7 @@ function parseSection(sectionData: any): Section {
  * @param section The parsed Section type from this sectionData
  */
 function parseMeetings(sectionData: any, section: Section): Meeting[] {
-  const meetings: Meeting[] = [];
-
-  sectionData.meetings.forEach((meetingData: any) => {
+  return sectionData.meetings.map((meetingData: any) => {
     let start: string[] = ['0', '0'];
     let end: string[] = ['0', '0'];
 
@@ -90,10 +88,8 @@ function parseMeetings(sectionData: any, section: Section): Meeting[] {
       section,
     });
 
-    meetings.push(meeting);
+    return meeting;
   });
-
-  return meetings;
 }
 
 /**
@@ -122,17 +118,13 @@ export function parseAllMeetings(arr: any[]): Meeting[] {
  *  @param arr The array of sections returned from the backend, such as from api/sections
  */
 export function parseSectionSelected(arr: any[]): SectionSelected[] {
-  const sections: SectionSelected[] = [];
-
-  arr.forEach((sectionData) => {
+  return arr.map((sectionData) => {
     const section = parseSection(sectionData);
 
     const meetings = parseMeetings(sectionData, section);
 
-    sections.push({ section, meetings, selected: false });
+    return { section, meetings, selected: false };
   });
-
-  return sections;
 }
 
 /**

--- a/autoscheduler/frontend/src/tests/redux/CourseCardRedux.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/CourseCardRedux.test.ts
@@ -1,4 +1,4 @@
-import { parseSections } from '../../redux/actions/courseCards';
+import { parseSectionSelected } from '../../redux/actions/courseCards';
 import Meeting, { MeetingType } from '../../types/Meeting';
 import Section from '../../types/Section';
 import Instructor from '../../types/Instructor';
@@ -70,7 +70,7 @@ describe('Course Cards Redux', () => {
         const expected = [{ section, meetings, selected: false }];
 
         // act
-        const output = parseSections(input);
+        const output = parseSectionSelected(input);
 
         // assert
         expect(output).toEqual(expected);
@@ -134,7 +134,7 @@ describe('Course Cards Redux', () => {
         const expected = [{ section, meetings, selected: false }];
 
         // act
-        const output = parseSections(input);
+        const output = parseSectionSelected(input);
 
         // assert
         expect(output).toEqual(expected);
@@ -199,7 +199,7 @@ describe('Course Cards Redux', () => {
         const expected = [{ section, meetings, selected: false }];
 
         // act
-        const output = parseSections(input);
+        const output = parseSectionSelected(input);
 
         // assert
         expect(output).toEqual(expected);
@@ -267,7 +267,7 @@ describe('Course Cards Redux', () => {
         const expected = [{ section, meetings, selected: false }];
 
         // act
-        const output = parseSections(input);
+        const output = parseSectionSelected(input);
 
         // assert
         expect(output).toEqual(expected);

--- a/autoscheduler/frontend/src/tests/testData.ts
+++ b/autoscheduler/frontend/src/tests/testData.ts
@@ -161,6 +161,8 @@ export async function mockFetchSchedulerGenerate(): Promise<Response> {
       end: '08:50',
       type: 'LEC',
     }],
+    honors: false,
+    web: false,
   };
 
   // common values for testSection2 & 3
@@ -172,6 +174,8 @@ export async function mockFetchSchedulerGenerate(): Promise<Response> {
     current_enrollment: 0,
     max_enrollment: 0,
     instructor_name: 'Aakash Tyagi',
+    honors: false,
+    web: false,
   };
 
   const testSection2 = {

--- a/autoscheduler/frontend/src/tests/testData.ts
+++ b/autoscheduler/frontend/src/tests/testData.ts
@@ -140,3 +140,73 @@ export default async function testFetch(route: string): Promise<Response> {
     },
   ]));
 }
+
+export async function mockFetchSchedulerGenerate(): Promise<Response> {
+  const testSection1 = {
+    id: 123456,
+    crn: 123456,
+    subject: 'DEPT',
+    course_num: '123',
+    section_num: '200',
+    min_credits: 0,
+    max_credits: 0,
+    current_enrollment: 0,
+    max_enrollment: 0,
+    instructor_name: 'Aakash Tyagi',
+    meetings: [{
+      id: 1234560,
+      building: 'HRBB',
+      days: [true, false, true, false, true, false, false], // MWF
+      start: '08:00',
+      end: '08:50',
+      type: 'LEC',
+    }],
+  };
+
+  // common values for testSection2 & 3
+  const csce121 = {
+    subject: 'CSCE',
+    course_num: '121',
+    min_credits: 0,
+    max_credits: 0,
+    current_enrollment: 0,
+    max_enrollment: 0,
+    instructor_name: 'Aakash Tyagi',
+  };
+
+  const testSection2 = {
+    ...csce121,
+    section_num: '501',
+    id: 123458,
+    crn: 123458,
+    meetings: [
+      {
+        id: 1234580,
+        building: 'HRBB',
+        days: [false, true, false, true, false, false, false], // TR
+        start: '08:00',
+        end: '08:50',
+        type: 'LEC',
+      },
+    ],
+  };
+  const testSection3 = {
+    ...csce121,
+    section_num: '200',
+    id: 123457,
+    crn: 123457,
+    meetings: [{
+      id: 1234570,
+      building: 'ZACH',
+      days: [false, true, false, true, false, false, false], // TR
+      start: '11:10',
+      end: '12:25',
+      type: 'LEC',
+    }],
+  };
+
+  return new Response(JSON.stringify([
+    [testSection1, testSection2],
+    [testSection1, testSection3],
+  ]));
+}

--- a/autoscheduler/frontend/src/tests/ui/ConfigureCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/ConfigureCard.test.tsx
@@ -83,8 +83,8 @@ describe('ConfigureCard component', () => {
 
       store.dispatch<any>(updateCourseCard(0, {
         customizationLevel: CustomizationLevel.SECTION,
-        honors: true,
-        web: true,
+        honors: 'exclude',
+        web: 'exclude',
       }));
 
       // Doesn't need to return anything valid
@@ -113,8 +113,8 @@ describe('ConfigureCard component', () => {
 
       store.dispatch<any>(updateCourseCard(0, {
         customizationLevel: CustomizationLevel.BASIC,
-        honors: true,
-        web: true,
+        honors: 'exclude',
+        web: 'exclude',
         // Add a selected section so its added to selectedSections internally
         sections: [{
           section: null,

--- a/autoscheduler/frontend/src/tests/ui/ConfigureCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/ConfigureCard.test.tsx
@@ -1,9 +1,14 @@
+import fetchMock, { enableFetchMocks } from 'jest-fetch-mock';
+
+enableFetchMocks();
+
+/* eslint-disable import/first */ // enableFetchMocks must be called before others are imported
+
 import * as React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { createStore } from 'redux';
 import { Provider } from 'react-redux';
 import ConfigureCard from '../../components/SchedulingPage/ConfigureCard/ConfigureCard';
-import fetch from '../../components/SchedulingPage/ConfigureCard/generateSchedulesMock';
 import autoSchedulerReducer from '../../redux/reducer';
 
 jest.mock('../../components/SchedulingPage/ConfigureCard/generateSchedulesMock', () => ({
@@ -13,7 +18,20 @@ jest.mock('../../components/SchedulingPage/ConfigureCard/generateSchedulesMock',
 
 describe('ConfigureCard component', () => {
   describe('makes an API call', () => {
-    test('when the user clicks Fetch Schedules', async () => {
+    test('when the user clicks Fetch Schedules', () => {
+      let fetchCount = 0;
+
+      fetchMock.mockImplementation((route: string): Promise<Response> => {
+        if (route.match(/scheduler\/generate/)) {
+          fetchCount += 1;
+
+          // Don't need to return anything valid for this test
+          return Promise.resolve(new Response(JSON.stringify([])));
+        }
+
+        return Promise.resolve(new Response('404 Not Found'));
+      });
+
       // arrange
       const store = createStore(autoSchedulerReducer);
       const { getByText } = render(
@@ -26,7 +44,7 @@ describe('ConfigureCard component', () => {
       fireEvent.click(getByText('Generate Schedules'));
 
       // assert
-      expect(fetch).toBeCalledTimes(1);
+      expect(fetchCount).toEqual(1);
     });
   });
 

--- a/autoscheduler/frontend/src/tests/ui/ConfigureCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/ConfigureCard.test.tsx
@@ -14,11 +14,6 @@ import autoSchedulerReducer from '../../redux/reducer';
 import { updateCourseCard } from '../../redux/actions/courseCards';
 import { CustomizationLevel } from '../../types/CourseCardOptions';
 
-jest.mock('../../components/SchedulingPage/ConfigureCard/generateSchedulesMock', () => ({
-  __esModule: true,
-  default: jest.fn(() => new Promise(() => {})),
-}));
-
 describe('ConfigureCard component', () => {
   beforeEach(fetchMock.mockReset);
 
@@ -62,6 +57,11 @@ describe('ConfigureCard component', () => {
           <ConfigureCard />
         </Provider>,
       );
+
+      fetchMock.mockImplementation((): Promise<Response> => new Promise(
+        (resolve) => setTimeout(resolve, 500, JSON.stringify([])),
+      ));
+
       // act
       fireEvent.click(getByText('Generate Schedules'));
       const loadingSpinner = await findByRole('progressbar');

--- a/autoscheduler/frontend/src/tests/ui/SchedulingPage.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SchedulingPage.test.tsx
@@ -1,3 +1,8 @@
+import fetchMock, { enableFetchMocks } from 'jest-fetch-mock';
+
+enableFetchMocks();
+
+/* eslint-disable import/first */ // enableFetchMocks must be called before others are imported
 import * as React from 'react';
 import { createStore } from 'redux';
 import { Provider } from 'react-redux';
@@ -6,6 +11,7 @@ import {
 } from '@testing-library/react';
 import autoSchedulerReducer from '../../redux/reducer';
 import SchedulingPage from '../../components/SchedulingPage/SchedulingPage';
+import { mockFetchSchedulerGenerate } from '../testData';
 
 describe('Scheduling Page UI', () => {
   describe('indicates that there are no schedules', () => {
@@ -34,6 +40,9 @@ describe('Scheduling Page UI', () => {
         </Provider>,
       );
 
+      // Mock scheduler/generate
+      fetchMock.mockImplementationOnce(mockFetchSchedulerGenerate);
+
       // act
       fireEvent.click(getByText('Generate Schedules'));
       await waitFor(() => {});
@@ -43,6 +52,7 @@ describe('Scheduling Page UI', () => {
       expect(queryByText('Schedule 1')).toBeTruthy();
     });
   });
+
   describe('changes the meetings shown in the Schedule', () => {
     test('when the user clicks on a different schedule in the Schedule Preview', async () => {
       // arrange
@@ -55,6 +65,9 @@ describe('Scheduling Page UI', () => {
         </Provider>,
       );
 
+      // Mock scheduler/generate/
+      fetchMock.mockImplementationOnce(mockFetchSchedulerGenerate);
+
       // act
       fireEvent.click(getByRole('button', { name: 'Generate Schedules' }));
       const schedule2 = await findByText('Schedule 2');
@@ -64,11 +77,11 @@ describe('Scheduling Page UI', () => {
       const calendarDay = getByLabelText('Tuesday');
 
       // assert
-      // Schedule 1 has BIOL 319 in it
-      // Schedule 2 has BIOL 351 instead
+      // Schedule 1 has section 501 in it
+      // Schedule 2 has section 200 instead
       // we check Tuesday to avoid selecting the equivalent text in SchedulePreview
-      expect(queryContainerByText(calendarDay, /BIOL 319.*/)).toBeFalsy();
-      expect(queryContainerByText(calendarDay, /BIOL 351.*/)).toBeTruthy();
+      expect(queryContainerByText(calendarDay, /CSCE 121-501.*/)).toBeFalsy();
+      expect(queryContainerByText(calendarDay, /CSCE 121-200.*/)).toBeTruthy();
     });
   });
 });

--- a/autoscheduler/frontend/src/timeUtil.ts
+++ b/autoscheduler/frontend/src/timeUtil.ts
@@ -8,7 +8,13 @@ export const LAST_HOUR = 21;
  * @param m minutes
  * @param use24Hour if true, applies 24-hour format instead of the default 12-hour format
  */
-export function formatTime(h: number, m: number, use24Hour = false): string {
-  return `${use24Hour ? h : (h - 1) % 12 + 1}:${
+export function formatTime(h: number, m: number, use24Hour = false, padZeroes = false): string {
+  const ret = `${use24Hour ? h : (h - 1) % 12 + 1}:${
     new Intl.NumberFormat('en-US', { minimumIntegerDigits: 2 }).format(m)}`;
+
+  if (padZeroes && ret.length < 4) {
+    return `0${ret}`;
+  }
+
+  return ret;
 }

--- a/autoscheduler/frontend/src/timeUtil.ts
+++ b/autoscheduler/frontend/src/timeUtil.ts
@@ -9,12 +9,9 @@ export const LAST_HOUR = 21;
  * @param use24Hour if true, applies 24-hour format instead of the default 12-hour format
  */
 export function formatTime(h: number, m: number, use24Hour = false, padZeroes = false): string {
-  const ret = `${use24Hour ? h : (h - 1) % 12 + 1}:${
-    new Intl.NumberFormat('en-US', { minimumIntegerDigits: 2 }).format(m)}`;
+  const formattedHours = use24Hour ? h : (h - 1) % 12 + 1;
 
-  if (padZeroes && ret.length < 4) {
-    return `0${ret}`;
-  }
+  const padZero = new Intl.NumberFormat('en-US', { minimumIntegerDigits: 2 });
 
-  return ret;
+  return `${padZeroes ? padZero.format(formattedHours) : formattedHours}:${padZero.format(m)}`;
 }

--- a/autoscheduler/scheduler/views.py
+++ b/autoscheduler/scheduler/views.py
@@ -72,7 +72,6 @@ class ScheduleView(APIView):
         """
 
         query = json.loads(request.body)
-        print(query)
 
         # List[Tuple[str, str]]
         courses = [_parse_course_filter(course) for course in query["courses"]]

--- a/autoscheduler/scheduler/views.py
+++ b/autoscheduler/scheduler/views.py
@@ -18,10 +18,10 @@ def _parse_course_filter(course) -> CourseFilter:
     subject = course["subject"]
     course_num = course["courseNum"]
 
-    sections = course["sections"]
+    sections = course.get("sections", [])
 
-    honors = BasicFilter(course["honors"])
-    web = BasicFilter(course["web"])
+    honors = BasicFilter(course.get("honors"))
+    web = BasicFilter(course.get("web"))
 
     return CourseFilter(subject=subject, course_num=course_num, section_nums=sections,
                         honors=honors, web=web)
@@ -72,6 +72,7 @@ class ScheduleView(APIView):
         """
 
         query = json.loads(request.body)
+        print(query)
 
         # List[Tuple[str, str]]
         courses = [_parse_course_filter(course) for course in query["courses"]]


### PR DESCRIPTION
Connects the `Generate schedules` button to /scheduler/generate.

Currently I handle the BASIC/SECTIONS customization level by if the SECTIONS option is selected, then the options for the honors/web only are set to the default. And if the BASIC option is selected, then the sections aren't sent. We might want to modify this for sessions so we *always* have the data in order to save it, and we can instead just send the current customization level for each section, and `create_schedules` can then choose which one it wants to ignore. Should be a relatively easy fix.

Also think we might want to add some tests for this that I missed, as the availabilities time converting was messed up and I didn't catch it for awhile, so lmk if you have any ideas for tests to add.

I also had to change the course cards actions which sort of (not really) reverts the changes Ryan made in #244 since I actually do need the original `parseMeetings` functionality for this, but I did my best extracting-out the common functionality of it all.

Closes #193 