### PR TITLE
Meeting times are no longer covered up by adjacent meetings

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/ScheduleCard/ScheduleCard.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/ScheduleCard/ScheduleCard.css
@@ -14,6 +14,10 @@
     z-index: 3;
 }
 
+.schedule-card:hover {
+    z-index: 4;
+}
+
 .start-time, .end-time {
     color: black;
     background-color: white;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/10082177/79873385-a8eded00-83ac-11ea-80ee-51d84e142e05.png)
After:
![image](https://user-images.githubusercontent.com/10082177/82498130-10cf4a80-9ab5-11ea-80da-0ca89593442a.png)

I don't know if this is something that Jest can test, since it pretty much requires looking at the screen. I also wasn't sure if JSDom would mock Z-indices, but I could try comparing those if y'all think it would be worth it.

Closes #219 