### PR TITLE
Added mini schedule to schedule preview

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/Schedule.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/Schedule.tsx
@@ -31,7 +31,7 @@ const Schedule: React.FC = () => {
     (state) => state.selectedAvailability,
   );
   const dispatch = useDispatch();
-  const getMeetingColor = useMeetingColor();
+  const meetingColors = useMeetingColor();
 
   /* state */
   const [startDay, setStartDay] = React.useState(null);
@@ -280,7 +280,7 @@ const Schedule: React.FC = () => {
       return (
         <MeetingCard
           meeting={meeting}
-          bgColor={getMeetingColor(schedule, meeting.section.id)}
+          bgColor={meetingColors.get(meeting.section.subject + meeting.section.courseNum)}
           key={meeting.id}
           firstHour={FIRST_HOUR}
           lastHour={LAST_HOUR}
@@ -290,7 +290,7 @@ const Schedule: React.FC = () => {
     return [DayOfWeek.MON, DayOfWeek.TUE, DayOfWeek.WED, DayOfWeek.THU, DayOfWeek.FRI].map(
       (idx) => getMeetingsForDay(idx).map((mtg) => renderMeeting(mtg)),
     );
-  }, [getMeetingColor, schedule]);
+  }, [meetingColors, schedule]);
   const availabilitiesForDays = React.useMemo(() => {
     // build each day based on availabilityList
     function getAvailabilityForDay(day: number): Availability[] {

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/Schedule.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/Schedule.tsx
@@ -11,7 +11,7 @@ import AvailabilityCard from './AvailabilityCard/AvailabilityCard';
 import HoveredTime from './HoveredTime/HoveredTime';
 import { FIRST_HOUR, LAST_HOUR, formatTime } from '../../../timeUtil';
 import DayOfWeek from '../../../types/DayOfWeek';
-import colors from './meetingColors';
+import useMeetingColor from './meetingColors';
 
 const emptySchedule: Meeting[] = [];
 
@@ -31,6 +31,7 @@ const Schedule: React.FC = () => {
     (state) => state.selectedAvailability,
   );
   const dispatch = useDispatch();
+  const getMeetingColor = useMeetingColor();
 
   /* state */
   const [startDay, setStartDay] = React.useState(null);
@@ -269,7 +270,6 @@ const Schedule: React.FC = () => {
 
   // let's see if useMemo reduces our render time
   const meetingsForDays = React.useMemo(() => {
-    const uniqueSections = [...new Set(schedule.map((mtg: Meeting) => mtg.section.id))];
     // build each day based on schedule
     function getMeetingsForDay(day: number): Meeting[] {
       // meetingDays = UMTWRFS
@@ -280,7 +280,7 @@ const Schedule: React.FC = () => {
       return (
         <MeetingCard
           meeting={meeting}
-          bgColor={colors[uniqueSections.indexOf(meeting.section.id) % colors.length]}
+          bgColor={getMeetingColor(schedule, meeting.section.id)}
           key={meeting.id}
           firstHour={FIRST_HOUR}
           lastHour={LAST_HOUR}
@@ -290,7 +290,7 @@ const Schedule: React.FC = () => {
     return [DayOfWeek.MON, DayOfWeek.TUE, DayOfWeek.WED, DayOfWeek.THU, DayOfWeek.FRI].map(
       (idx) => getMeetingsForDay(idx).map((mtg) => renderMeeting(mtg)),
     );
-  }, [schedule]);
+  }, [getMeetingColor, schedule]);
   const availabilitiesForDays = React.useMemo(() => {
     // build each day based on availabilityList
     function getAvailabilityForDay(day: number): Availability[] {

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/meetingColors.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/meetingColors.ts
@@ -23,11 +23,4 @@ export default function useMeetingColor(): Map<string, string> {
     sectionToColor.set(courseName, colors[idx % colors.length]);
   });
   return sectionToColor;
-
-  /* return (schedule: Meeting[], sectionId: number): string => {
-    const uniqueSections = [...new Set(schedule.map((mtg: Meeting) => mtg.section.id))];
-    return meetingColors[
-      uniqueSections.indexOf(sectionId) % meetingColors.length
-    ];
-  }; */
 }

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/meetingColors.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/meetingColors.ts
@@ -1,5 +1,4 @@
 import { useSelector } from 'react-redux';
-import Meeting from '../../../types/Meeting';
 import { RootState } from '../../../redux/reducer';
 
 export const colors = [
@@ -18,7 +17,6 @@ export default function useMeetingColor(): Map<string, string> {
       [],
     ),
   ));
-  console.log(allSectionIds);
 
   const sectionToColor = new Map<string, string>();
   [...allSectionIds.keys()].forEach((courseName, idx) => {

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/meetingColors.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/meetingColors.ts
@@ -1,6 +1,15 @@
-const meetingColors = [
+import Meeting from '../../../types/Meeting';
+
+export const meetingColors = [
   '#500000', '#733333', '#966666', '#b99999',
   '#871b1e', '#9a1d26', '#c2777d', '#9f494b', '#b76778',
 ];
 
-export default meetingColors;
+export default function useMeetingColor(): Function {
+  return (schedule: Meeting[], sectionId: number): string => {
+    const uniqueSections = [...new Set(schedule.map((mtg: Meeting) => mtg.section.id))];
+    return meetingColors[
+      uniqueSections.indexOf(sectionId) % meetingColors.length
+    ];
+  };
+}

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/meetingColors.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/meetingColors.ts
@@ -1,15 +1,35 @@
+import { useSelector } from 'react-redux';
 import Meeting from '../../../types/Meeting';
+import { RootState } from '../../../redux/reducer';
 
-export const meetingColors = [
+export const colors = [
   '#500000', '#733333', '#966666', '#b99999',
   '#871b1e', '#9a1d26', '#c2777d', '#9f494b', '#b76778',
 ];
 
-export default function useMeetingColor(): Function {
-  return (schedule: Meeting[], sectionId: number): string => {
+export default function useMeetingColor(): Map<string, string> {
+  const allSectionIds = new Set(useSelector<RootState, string[]>(
+    (state) => state.schedules.reduce<string[]>(
+      (arr, schedule) => arr.concat(
+        schedule.map(
+          (meeting) => meeting.section.subject + meeting.section.courseNum,
+        ),
+      ),
+      [],
+    ),
+  ));
+  console.log(allSectionIds);
+
+  const sectionToColor = new Map<string, string>();
+  [...allSectionIds.keys()].forEach((courseName, idx) => {
+    sectionToColor.set(courseName, colors[idx % colors.length]);
+  });
+  return sectionToColor;
+
+  /* return (schedule: Meeting[], sectionId: number): string => {
     const uniqueSections = [...new Set(schedule.map((mtg: Meeting) => mtg.section.id))];
     return meetingColors[
       uniqueSections.indexOf(sectionId) % meetingColors.length
     ];
-  };
+  }; */
 }

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ColorBox.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ColorBox.tsx
@@ -6,9 +6,7 @@ interface ColorBoxProps {
 }
 
 const ColorBox: React.FC<ColorBoxProps> = ({ color }) => (
-  <span className={styles.colorBox}>
-    <span style={{ backgroundColor: color }} />
-  </span>
+  <span className={styles.colorBox} style={{ backgroundColor: color }} />
 );
 
 export default ColorBox;

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ColorBox.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ColorBox.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import * as styles from './SchedulePreview.css';
+
+interface ColorBoxProps {
+  color: string;
+}
+
+const ColorBox: React.FC<ColorBoxProps> = ({ color }) => (
+  <span className={styles.colorBox}>
+    <span style={{ backgroundColor: color }} />
+  </span>
+);
+
+export default ColorBox;

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule.tsx
@@ -1,0 +1,94 @@
+import * as React from 'react';
+import Meeting from '../../../types/Meeting';
+import { LAST_HOUR, FIRST_HOUR } from '../../../timeUtil';
+import DayOfWeek from '../../../types/DayOfWeek';
+import * as styles from '../Schedule/Schedule.css';
+import colors from '../Schedule/meetingColors';
+
+interface MiniScheduleProps {
+  schedule: Meeting[];
+}
+
+const MiniSchedule: React.FC<MiniScheduleProps> = ({ schedule }) => {
+  // these must be unique because of how they're used below
+  const DAYS_OF_WEEK = ['M', 'T', 'W', 'R', 'F'];
+
+  // build rows from first and last hour
+  const HOURS_OF_DAY = [];
+  for (let h = FIRST_HOUR; h <= LAST_HOUR; h++) { HOURS_OF_DAY.push(h); }
+  const hourBars = HOURS_OF_DAY.map((hour) => (
+    <div className={styles.calendarRow} key={hour}>
+      <div className={styles.hourMarker} />
+    </div>
+  ));
+
+  // let's see if useMemo reduces our render time
+  const meetingsForDays = React.useMemo(() => {
+    const uniqueSections = [...new Set(schedule.map((mtg: Meeting) => mtg.section.id))];
+    // build each day based on schedule
+    function getMeetingsForDay(day: number): Meeting[] {
+      // meetingDays = UMTWRFS
+      // day = MTWRF
+      return schedule.filter((meeting) => meeting.meetingDays[day]);
+    }
+    function renderMeeting(meeting: Meeting): JSX.Element {
+      const {
+        endTimeHours, endTimeMinutes, startTimeHours, startTimeMinutes,
+      } = meeting;
+      const elapsedTime = endTimeHours * 60 + endTimeMinutes
+        - startTimeHours * 60 - startTimeMinutes;
+      const computedStyle: React.CSSProperties = {
+        position: 'absolute',
+        width: '100%',
+        height: `calc(${elapsedTime / (LAST_HOUR - FIRST_HOUR) / 60 * 100}%)`,
+        top: `${(startTimeHours * 60 + startTimeMinutes - FIRST_HOUR * 60) / (LAST_HOUR - FIRST_HOUR) / 60 * 100}%`,
+        backgroundColor: colors[uniqueSections.indexOf(meeting.section.id) % colors.length],
+      };
+      return (
+        <div
+          key={meeting.id}
+          style={computedStyle}
+        />
+      );
+    }
+    return [DayOfWeek.MON, DayOfWeek.TUE, DayOfWeek.WED, DayOfWeek.THU, DayOfWeek.FRI].map(
+      (idx) => getMeetingsForDay(idx).map((mtg) => renderMeeting(mtg)),
+    );
+  }, [schedule]);
+
+  const FULL_WEEK_DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
+  const scheduleDays = DAYS_OF_WEEK.map((day, idx) => (
+    <div
+      className={styles.calendarDay}
+      key={day}
+      role="gridcell"
+      tabIndex={0}
+      aria-label={FULL_WEEK_DAYS[idx]}
+    >
+      { meetingsForDays[idx] }
+    </div>
+  ));
+
+  return (
+    <div style={{
+      width: '100%', alignSelf: 'stretch', minHeight: 120, margin: 8,
+    }}
+    >
+      <div style={{
+        borderTopLeftRadius: 4,
+        borderTopRightRadius: 4,
+        height: 8,
+        backgroundColor: '#500000',
+      }}
+      />
+      <div className={styles.calendarBody} style={{ height: '100%', backgroundColor: 'white' }}>
+        {hourBars}
+        <div className={styles.meetingsContainer} style={{ width: '100%', marginLeft: 0 }}>
+          {scheduleDays}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MiniSchedule;

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule.tsx
@@ -18,7 +18,7 @@ const MiniSchedule: React.FC<MiniScheduleProps> = ({ schedule }) => {
   for (let h = FIRST_HOUR; h <= LAST_HOUR; h++) { HOURS_OF_DAY.push(h); }
   const hourBars = HOURS_OF_DAY.map((hour) => (
     <div className={styles.calendarRow} key={hour}>
-      <div className={styles.hourMarker} />
+      <div className={styles.hourMarker} style={{ top: 0 }} />
     </div>
   ));
 
@@ -79,7 +79,7 @@ const MiniSchedule: React.FC<MiniScheduleProps> = ({ schedule }) => {
       />
       <div className={styles.calendarBody} style={{ height: '100%', backgroundColor: 'white' }}>
         {hourBars}
-        <div className={styles.meetingsContainer} style={{ width: '100%', marginLeft: 0 }}>
+        <div className={styles.meetingsContainer} style={{ width: '100%', marginLeft: 0, marginTop: 0 }}>
           {scheduleDays}
         </div>
       </div>

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule.tsx
@@ -56,14 +56,10 @@ const MiniSchedule: React.FC<MiniScheduleProps> = ({ schedule }) => {
     );
   }, [schedule]);
 
-  const FULL_WEEK_DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
   const scheduleDays = DAYS_OF_WEEK.map((day, idx) => (
     <div
       className={styles.calendarDay}
       key={day}
-      role="gridcell"
-      tabIndex={0}
-      aria-label={FULL_WEEK_DAYS[idx]}
     >
       { meetingsForDays[idx] }
     </div>

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule/MiniSchedule.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule/MiniSchedule.css
@@ -1,0 +1,42 @@
+.hour-marker {
+    flex-grow: 1;
+    border-bottom: 1px solid darkgray;
+    height: 0;
+    align-self: stretch;
+    position: relative;
+    top: 0;
+}
+
+.calendar-body {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    background-color: white;
+    height: 100%;
+}
+
+.meetings-container {
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    top: 0px;
+    left: 0px;
+    margin-left: 0px;
+    margin-top: 0px;
+    display: flex;
+    flex-direction: row;
+}
+
+.header {
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+    height: 8px;
+    background-color: #500000;
+}
+
+.container {
+    width: 100%;
+    align-self: stretch;
+    min-height: 120px;
+    margin: 8px 0px 8px 16px;
+}

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule/MiniSchedule.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule/MiniSchedule.css
@@ -12,7 +12,7 @@
     display: flex;
     flex-direction: column;
     background-color: white;
-    height: 100%;
+    height: calc(100% - 16px);
 }
 
 .meetings-container {
@@ -35,8 +35,19 @@
 }
 
 .mini-schedule-container {
+    position: absolute;
+    top: 0;
+    left: 0;
     width: 100%;
+    height: 100%;
     align-self: stretch;
     min-height: 120px;
+}
+
+.aspect-ratio-box {
+    position: relative;
+    height: 0px;
+    padding-top: calc(50% - 16px);
+    width: calc(50% - 16px);
     margin: 8px 0px 8px 16px;
 }

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule/MiniSchedule.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule/MiniSchedule.css
@@ -49,5 +49,4 @@
     height: 0px;
     padding-top: calc(50% - 16px);
     width: calc(33% - 16px);
-    margin: 8px 0px 8px 16px;
 }

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule/MiniSchedule.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule/MiniSchedule.css
@@ -48,6 +48,6 @@
     position: relative;
     height: 0px;
     padding-top: calc(50% - 16px);
-    width: calc(50% - 16px);
+    width: calc(33% - 16px);
     margin: 8px 0px 8px 16px;
 }

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule/MiniSchedule.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule/MiniSchedule.css
@@ -30,11 +30,11 @@
 .header {
     border-top-left-radius: 4px;
     border-top-right-radius: 4px;
-    height: 8px;
-    background-color: #500000;
+    height: 10px;
+    background: linear-gradient(#500000 0px, #500000 9px, #ffffff 9px, #ffffff 10px);
 }
 
-.container {
+.mini-schedule-container {
     width: 100%;
     align-self: stretch;
     min-height: 120px;

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule/MiniSchedule.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule/MiniSchedule.css.d.ts
@@ -1,5 +1,7 @@
 declare namespace MiniScheduleCssModule {
   export interface IMiniScheduleCss {
+    "aspect-ratio-box": string;
+    aspectRatioBox: string;
     "calendar-body": string;
     calendarBody: string;
     header: string;

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule/MiniSchedule.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule/MiniSchedule.css.d.ts
@@ -2,12 +2,13 @@ declare namespace MiniScheduleCssModule {
   export interface IMiniScheduleCss {
     "calendar-body": string;
     calendarBody: string;
-    container: string;
     header: string;
     "hour-marker": string;
     hourMarker: string;
     "meetings-container": string;
     meetingsContainer: string;
+    "mini-schedule-container": string;
+    miniScheduleContainer: string;
   }
 }
 

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule/MiniSchedule.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule/MiniSchedule.css.d.ts
@@ -1,0 +1,19 @@
+declare namespace MiniScheduleCssModule {
+  export interface IMiniScheduleCss {
+    "calendar-body": string;
+    calendarBody: string;
+    container: string;
+    header: string;
+    "hour-marker": string;
+    hourMarker: string;
+    "meetings-container": string;
+    meetingsContainer: string;
+  }
+}
+
+declare const MiniScheduleCssModule: MiniScheduleCssModule.IMiniScheduleCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: MiniScheduleCssModule.IMiniScheduleCss;
+};
+
+export = MiniScheduleCssModule;

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule/MiniSchedule.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule/MiniSchedule.tsx
@@ -72,12 +72,14 @@ const MiniSchedule: React.FC<MiniScheduleProps> = ({ schedule }) => {
   ));
 
   return (
-    <div className={styles.miniScheduleContainer}>
-      <div className={styles.header} />
-      <div className={styles.calendarBody}>
-        {hourBars}
-        <div className={styles.meetingsContainer}>
-          {scheduleDays}
+    <div className={styles.aspectRatioBox}>
+      <div className={styles.miniScheduleContainer}>
+        <div className={styles.header} />
+        <div className={styles.calendarBody}>
+          {hourBars}
+          <div className={styles.meetingsContainer}>
+            {scheduleDays}
+          </div>
         </div>
       </div>
     </div>

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule/MiniSchedule.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule/MiniSchedule.tsx
@@ -23,7 +23,10 @@ const MiniSchedule: React.FC<MiniScheduleProps> = ({ schedule }) => {
     </div>
   ));
 
-  // let's see if useMemo reduces our render time
+  /**
+   * An array of arrays, in which each outer array represents a calendar day and each
+   * inner array represents the meetings for that day
+   */
   const meetingsForDays = React.useMemo(() => {
     const uniqueSections = [...new Set(schedule.map((mtg: Meeting) => mtg.section.id))];
     // build each day based on schedule
@@ -40,7 +43,9 @@ const MiniSchedule: React.FC<MiniScheduleProps> = ({ schedule }) => {
         - startTimeHours * 60 - startTimeMinutes;
       const computedStyle: React.CSSProperties = {
         position: 'absolute',
-        width: '100%',
+        width: 'calc(100% - 4px)',
+        marginLeft: 2,
+        marginRight: 2,
         height: `calc(${elapsedTime / (LAST_HOUR - FIRST_HOUR) / 60 * 100}%)`,
         top: `${(startTimeHours * 60 + startTimeMinutes - FIRST_HOUR * 60) / (LAST_HOUR - FIRST_HOUR) / 60 * 100}%`,
         backgroundColor: colors[uniqueSections.indexOf(meeting.section.id) % colors.length],
@@ -67,7 +72,7 @@ const MiniSchedule: React.FC<MiniScheduleProps> = ({ schedule }) => {
   ));
 
   return (
-    <div className={styles.container}>
+    <div className={styles.miniScheduleContainer}>
       <div className={styles.header} />
       <div className={styles.calendarBody}>
         {hourBars}

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule/MiniSchedule.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule/MiniSchedule.tsx
@@ -4,7 +4,7 @@ import { LAST_HOUR, FIRST_HOUR } from '../../../../timeUtil';
 import DayOfWeek from '../../../../types/DayOfWeek';
 import * as parentStyles from '../../Schedule/Schedule.css';
 import * as styles from './MiniSchedule.css';
-import colors from '../../Schedule/meetingColors';
+import useMeetingColor from '../../Schedule/meetingColors';
 
 interface MiniScheduleProps {
   schedule: Meeting[];
@@ -25,12 +25,12 @@ const hourBars = HOURS_OF_DAY.map((hour) => (
 ));
 
 const MiniSchedule: React.FC<MiniScheduleProps> = ({ schedule }) => {
+  const getMeetingColor = useMeetingColor();
   /**
    * An array of arrays, in which each outer array represents a calendar day and each
    * inner array represents the meetings for that day
    */
   const meetingsForDays = React.useMemo(() => {
-    const uniqueSections = [...new Set(schedule.map((mtg: Meeting) => mtg.section.id))];
     // build each day based on schedule
     function getMeetingsForDay(day: number): Meeting[] {
       // meetingDays = UMTWRFS
@@ -50,7 +50,7 @@ const MiniSchedule: React.FC<MiniScheduleProps> = ({ schedule }) => {
         marginRight: 1,
         height: `calc(${elapsedTime / (LAST_HOUR - FIRST_HOUR) / 60 * 100}%)`,
         top: `${(startTimeHours * 60 + startTimeMinutes - FIRST_HOUR * 60) / (LAST_HOUR - FIRST_HOUR) / 60 * 100}%`,
-        backgroundColor: colors[uniqueSections.indexOf(meeting.section.id) % colors.length],
+        backgroundColor: getMeetingColor(schedule, meeting.section.id),
       };
       return (
         <div
@@ -62,7 +62,7 @@ const MiniSchedule: React.FC<MiniScheduleProps> = ({ schedule }) => {
     return DAYS_OF_WEEK.map(
       (idx) => getMeetingsForDay(idx).map((mtg) => renderMeeting(mtg)),
     );
-  }, [schedule]);
+  }, [getMeetingColor, schedule]);
 
   const scheduleDays = DAYS_OF_WEEK.map((day, idx) => (
     <div

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule/MiniSchedule.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule/MiniSchedule.tsx
@@ -10,19 +10,21 @@ interface MiniScheduleProps {
   schedule: Meeting[];
 }
 
+/** Calculate a few constants that won't change * */
+
+// these must be unique because of how they're used below
+const DAYS_OF_WEEK = [DayOfWeek.MON, DayOfWeek.TUE, DayOfWeek.WED, DayOfWeek.THU, DayOfWeek.FRI];
+
+// build rows from first and last hour
+const HOURS_OF_DAY = [];
+for (let h = FIRST_HOUR; h <= LAST_HOUR; h++) { HOURS_OF_DAY.push(h); }
+const hourBars = HOURS_OF_DAY.map((hour) => (
+  <div className={parentStyles.calendarRow} key={hour}>
+    <div className={styles.hourMarker} style={{ top: 0 }} />
+  </div>
+));
+
 const MiniSchedule: React.FC<MiniScheduleProps> = ({ schedule }) => {
-  // these must be unique because of how they're used below
-  const DAYS_OF_WEEK = ['M', 'T', 'W', 'R', 'F'];
-
-  // build rows from first and last hour
-  const HOURS_OF_DAY = [];
-  for (let h = FIRST_HOUR; h <= LAST_HOUR; h++) { HOURS_OF_DAY.push(h); }
-  const hourBars = HOURS_OF_DAY.map((hour) => (
-    <div className={parentStyles.calendarRow} key={hour}>
-      <div className={styles.hourMarker} style={{ top: 0 }} />
-    </div>
-  ));
-
   /**
    * An array of arrays, in which each outer array represents a calendar day and each
    * inner array represents the meetings for that day
@@ -44,8 +46,8 @@ const MiniSchedule: React.FC<MiniScheduleProps> = ({ schedule }) => {
       const computedStyle: React.CSSProperties = {
         position: 'absolute',
         width: 'calc(100% - 4px)',
-        marginLeft: 2,
-        marginRight: 2,
+        marginLeft: 1,
+        marginRight: 1,
         height: `calc(${elapsedTime / (LAST_HOUR - FIRST_HOUR) / 60 * 100}%)`,
         top: `${(startTimeHours * 60 + startTimeMinutes - FIRST_HOUR * 60) / (LAST_HOUR - FIRST_HOUR) / 60 * 100}%`,
         backgroundColor: colors[uniqueSections.indexOf(meeting.section.id) % colors.length],
@@ -57,7 +59,7 @@ const MiniSchedule: React.FC<MiniScheduleProps> = ({ schedule }) => {
         />
       );
     }
-    return [DayOfWeek.MON, DayOfWeek.TUE, DayOfWeek.WED, DayOfWeek.THU, DayOfWeek.FRI].map(
+    return DAYS_OF_WEEK.map(
       (idx) => getMeetingsForDay(idx).map((mtg) => renderMeeting(mtg)),
     );
   }, [schedule]);

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule/MiniSchedule.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule/MiniSchedule.tsx
@@ -25,7 +25,7 @@ const hourBars = HOURS_OF_DAY.map((hour) => (
 ));
 
 const MiniSchedule: React.FC<MiniScheduleProps> = ({ schedule }) => {
-  const getMeetingColor = useMeetingColor();
+  const meetingColors = useMeetingColor();
   /**
    * An array of arrays, in which each outer array represents a calendar day and each
    * inner array represents the meetings for that day
@@ -50,7 +50,7 @@ const MiniSchedule: React.FC<MiniScheduleProps> = ({ schedule }) => {
         marginRight: 1,
         height: `calc(${elapsedTime / (LAST_HOUR - FIRST_HOUR) / 60 * 100}%)`,
         top: `${(startTimeHours * 60 + startTimeMinutes - FIRST_HOUR * 60) / (LAST_HOUR - FIRST_HOUR) / 60 * 100}%`,
-        backgroundColor: getMeetingColor(schedule, meeting.section.id),
+        backgroundColor: meetingColors.get(meeting.section.subject + meeting.section.courseNum),
       };
       return (
         <div
@@ -62,7 +62,7 @@ const MiniSchedule: React.FC<MiniScheduleProps> = ({ schedule }) => {
     return DAYS_OF_WEEK.map(
       (idx) => getMeetingsForDay(idx).map((mtg) => renderMeeting(mtg)),
     );
-  }, [getMeetingColor, schedule]);
+  }, [meetingColors, schedule]);
 
   const scheduleDays = DAYS_OF_WEEK.map((day, idx) => (
     <div

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule/MiniSchedule.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/MiniSchedule/MiniSchedule.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import Meeting from '../../../types/Meeting';
-import { LAST_HOUR, FIRST_HOUR } from '../../../timeUtil';
-import DayOfWeek from '../../../types/DayOfWeek';
-import * as styles from '../Schedule/Schedule.css';
-import colors from '../Schedule/meetingColors';
+import Meeting from '../../../../types/Meeting';
+import { LAST_HOUR, FIRST_HOUR } from '../../../../timeUtil';
+import DayOfWeek from '../../../../types/DayOfWeek';
+import * as parentStyles from '../../Schedule/Schedule.css';
+import * as styles from './MiniSchedule.css';
+import colors from '../../Schedule/meetingColors';
 
 interface MiniScheduleProps {
   schedule: Meeting[];
@@ -17,7 +18,7 @@ const MiniSchedule: React.FC<MiniScheduleProps> = ({ schedule }) => {
   const HOURS_OF_DAY = [];
   for (let h = FIRST_HOUR; h <= LAST_HOUR; h++) { HOURS_OF_DAY.push(h); }
   const hourBars = HOURS_OF_DAY.map((hour) => (
-    <div className={styles.calendarRow} key={hour}>
+    <div className={parentStyles.calendarRow} key={hour}>
       <div className={styles.hourMarker} style={{ top: 0 }} />
     </div>
   ));
@@ -58,7 +59,7 @@ const MiniSchedule: React.FC<MiniScheduleProps> = ({ schedule }) => {
 
   const scheduleDays = DAYS_OF_WEEK.map((day, idx) => (
     <div
-      className={styles.calendarDay}
+      className={parentStyles.calendarDay}
       key={day}
     >
       { meetingsForDays[idx] }
@@ -66,20 +67,11 @@ const MiniSchedule: React.FC<MiniScheduleProps> = ({ schedule }) => {
   ));
 
   return (
-    <div style={{
-      width: '100%', alignSelf: 'stretch', minHeight: 120, margin: 8,
-    }}
-    >
-      <div style={{
-        borderTopLeftRadius: 4,
-        borderTopRightRadius: 4,
-        height: 8,
-        backgroundColor: '#500000',
-      }}
-      />
-      <div className={styles.calendarBody} style={{ height: '100%', backgroundColor: 'white' }}>
+    <div className={styles.container}>
+      <div className={styles.header} />
+      <div className={styles.calendarBody}>
         {hourBars}
-        <div className={styles.meetingsContainer} style={{ width: '100%', marginLeft: 0, marginTop: 0 }}>
+        <div className={styles.meetingsContainer}>
           {scheduleDays}
         </div>
       </div>

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css
@@ -26,3 +26,18 @@
     display: flex;
     flex-direction: row;
 }
+
+.color-box {
+    display: inline-block;
+    border: 1px solid black;
+    margin-right: 4px;
+    padding: 2px;
+    width: 1rem;
+    height: 1rem;
+}
+
+.color-box span {
+    display: inline-block;
+    width: 100%;
+    height: 100%;
+}

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css
@@ -1,5 +1,13 @@
 .gpa {
     display: inline-block;
+    color: rgba(0, 0, 0, 0.54);
+}
+
+.schedule-title {
+    display: flex;
+    flex-direction: column;
+    line-height: 1rem;
+    margin-bottom: 4px;
 }
 
 #card-header {
@@ -27,17 +35,22 @@
     flex-direction: row;
 }
 
+.section-label-row {
+    display: flex;
+}
+
 .color-box {
     display: inline-block;
     border: 1px solid black;
     margin-right: 4px;
-    padding: 2px;
-    width: 1rem;
-    height: 1rem;
+    padding: 1px;
+    width: 14px;
+    height: 14px;
 }
 
 .color-box span {
     display: inline-block;
     width: 100%;
     height: 100%;
+    margin-bottom: 1px; 
 }

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css
@@ -36,6 +36,7 @@
 
 .section-label-row {
     display: flex;
+    align-items: center;
 }
 
 .color-box {
@@ -43,7 +44,6 @@
     outline: 1px solid black;
     border: 1px solid white;
     margin-right: 4px;
-    margin-top: calc((1rem - 12px) / 2);
     width: 12px;
     height: 12px;
 }

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css
@@ -1,5 +1,4 @@
 .gpa {
-    display: inline-block;
     color: rgba(0, 0, 0, 0.54);
 }
 

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css
@@ -21,3 +21,8 @@
 .no-schedules {
     text-align: center;
 }
+
+.list-item-with-preview {
+    display: flex;
+    flex-direction: row;
+}

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css
@@ -1,5 +1,5 @@
 .gpa {
-    float: right;
+    display: inline-block;
 }
 
 #card-header {

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css
@@ -40,16 +40,10 @@
 
 .color-box {
     display: inline-block;
-    border: 1px solid black;
+    outline: 1px solid black;
+    border: 1px solid white;
     margin-right: 4px;
-    padding: 1px;
-    width: 14px;
-    height: 14px;
-}
-
-.color-box span {
-    display: inline-block;
-    width: 100%;
-    height: 100%;
-    margin-bottom: 1px; 
+    margin-top: calc((1rem - 12px) / 2);
+    width: 12px;
+    height: 12px;
 }

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css.d.ts
@@ -12,6 +12,10 @@ declare namespace SchedulePreviewCssModule {
     listItemWithPreview: string;
     "no-schedules": string;
     noSchedules: string;
+    "schedule-title": string;
+    scheduleTitle: string;
+    "section-label-row": string;
+    sectionLabelRow: string;
   }
 }
 

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css.d.ts
@@ -6,6 +6,8 @@ declare namespace SchedulePreviewCssModule {
     configureCard: string;
     gpa: string;
     list: string;
+    "list-item-with-preview": string;
+    listItemWithPreview: string;
     "no-schedules": string;
     noSchedules: string;
   }

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css.d.ts
@@ -2,6 +2,8 @@ declare namespace SchedulePreviewCssModule {
   export interface ISchedulePreviewCss {
     "card-header": string;
     cardHeader: string;
+    "color-box": string;
+    colorBox: string;
     "configure-card": string;
     configureCard: string;
     gpa: string;

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
@@ -42,7 +42,7 @@ const SchedulePreview: React.FC = () => {
   const schedules = useSelector<RootState, Meeting[][]>((state) => state.schedules);
   const selectedSchedule = useSelector<RootState, number>((state) => state.selectedSchedule);
   const dispatch = useDispatch();
-  const getMeetingColor = useMeetingColor();
+  const meetingColors = useMeetingColor();
 
   const renderSchedule = (schedule: Meeting[], idx: number): JSX.Element => (
     <ListItem
@@ -72,7 +72,7 @@ const SchedulePreview: React.FC = () => {
             return acc;
           }, []).map((sec: Section) => (
             <span key={sec.id} className={styles.sectionLabelRow}>
-              <ColorBox color={getMeetingColor(schedule, sec.id)} />
+              <ColorBox color={meetingColors.get(sec.subject + sec.courseNum)} />
               {`${sec.subject} ${sec.courseNum}-${sec.sectionNum}`}
               <br />
             </span>

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
@@ -57,7 +57,7 @@ const SchedulePreview: React.FC = () => {
         primary={(
           <span className={styles.scheduleTitle}>
             <span>{`Schedule ${idx + 1}`}</span>
-            <Typography variant="subtitle2" component="span">
+            <Typography variant="subtitle2" component="span" className={styles.gpa}>
               {getAverageGPATextForSchedule(schedule)}
             </Typography>
           </span>

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
@@ -54,6 +54,7 @@ const SchedulePreview: React.FC = () => {
         primary={(
           <span>
             <span>{`Schedule ${idx + 1}`}</span>
+            <br />
             <span className={styles.gpa}>
               {getAverageGPATextForSchedule(schedule)}
             </span>

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
@@ -11,7 +11,7 @@ import Section from '../../../types/Section';
 import * as styles from './SchedulePreview.css';
 import MiniSchedule from './MiniSchedule/MiniSchedule';
 import ColorBox from './ColorBox';
-import meetingColors from '../Schedule/meetingColors';
+import useMeetingColor from '../Schedule/meetingColors';
 
 // Exported so we can test it
 export function getAverageGPATextForSchedule(schedule: Meeting[]): string {
@@ -42,6 +42,7 @@ const SchedulePreview: React.FC = () => {
   const schedules = useSelector<RootState, Meeting[][]>((state) => state.schedules);
   const selectedSchedule = useSelector<RootState, number>((state) => state.selectedSchedule);
   const dispatch = useDispatch();
+  const getMeetingColor = useMeetingColor();
 
   const renderSchedule = (schedule: Meeting[], idx: number): JSX.Element => (
     <ListItem
@@ -70,9 +71,9 @@ const SchedulePreview: React.FC = () => {
               return acc.concat(curr.section);
             }
             return acc;
-          }, []).map((sec: Section, secIdx: number) => (
+          }, []).map((sec: Section) => (
             <span key={sec.id}>
-              <ColorBox color={meetingColors[secIdx]} />
+              <ColorBox color={getMeetingColor(schedule, sec.id)} />
               {`${sec.subject} ${sec.courseNum}-${sec.sectionNum}`}
               <br />
             </span>

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
@@ -9,7 +9,7 @@ import selectSchedule from '../../../redux/actions/selectedSchedule';
 import Meeting from '../../../types/Meeting';
 import Section from '../../../types/Section';
 import * as styles from './SchedulePreview.css';
-import MiniSchedule from './MiniSchedule';
+import MiniSchedule from './MiniSchedule/MiniSchedule';
 
 // Exported so we can test it
 export function getAverageGPATextForSchedule(schedule: Meeting[]): string {

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
@@ -10,6 +10,8 @@ import Meeting from '../../../types/Meeting';
 import Section from '../../../types/Section';
 import * as styles from './SchedulePreview.css';
 import MiniSchedule from './MiniSchedule/MiniSchedule';
+import ColorBox from './ColorBox';
+import meetingColors from '../Schedule/meetingColors';
 
 // Exported so we can test it
 export function getAverageGPATextForSchedule(schedule: Meeting[]): string {
@@ -68,8 +70,9 @@ const SchedulePreview: React.FC = () => {
               return acc.concat(curr.section);
             }
             return acc;
-          }, []).map((sec: Section) => (
+          }, []).map((sec: Section, secIdx: number) => (
             <span key={sec.id}>
+              <ColorBox color={meetingColors[secIdx]} />
               {`${sec.subject} ${sec.courseNum}-${sec.sectionNum}`}
               <br />
             </span>

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import {
-  ListItem, List, ListItemText,
+  ListItem, List, ListItemText, Typography,
 } from '@material-ui/core';
 import GenericCard from '../../GenericCard/GenericCard';
 import { RootState } from '../../../redux/reducer';
@@ -55,12 +55,11 @@ const SchedulePreview: React.FC = () => {
     >
       <ListItemText
         primary={(
-          <span>
+          <span className={styles.scheduleTitle}>
             <span>{`Schedule ${idx + 1}`}</span>
-            <br />
-            <span className={styles.gpa}>
+            <Typography variant="subtitle2" component="span">
               {getAverageGPATextForSchedule(schedule)}
-            </span>
+            </Typography>
           </span>
         )}
         secondary={
@@ -72,7 +71,7 @@ const SchedulePreview: React.FC = () => {
             }
             return acc;
           }, []).map((sec: Section) => (
-            <span key={sec.id}>
+            <span key={sec.id} className={styles.sectionLabelRow}>
               <ColorBox color={getMeetingColor(schedule, sec.id)} />
               {`${sec.subject} ${sec.courseNum}-${sec.sectionNum}`}
               <br />

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
@@ -9,6 +9,7 @@ import selectSchedule from '../../../redux/actions/selectedSchedule';
 import Meeting from '../../../types/Meeting';
 import Section from '../../../types/Section';
 import * as styles from './SchedulePreview.css';
+import MiniSchedule from './MiniSchedule';
 
 // Exported so we can test it
 export function getAverageGPATextForSchedule(schedule: Meeting[]): string {
@@ -47,6 +48,7 @@ const SchedulePreview: React.FC = () => {
       key={idx}
       onClick={(): void => { dispatch(selectSchedule(idx)); }}
       selected={selectedSchedule === idx}
+      classes={{ root: styles.listItemWithPreview }}
     >
       <ListItemText
         primary={(
@@ -73,6 +75,7 @@ const SchedulePreview: React.FC = () => {
           ))
         }
       />
+      <MiniSchedule schedule={schedule} />
     </ListItem>
   );
 

--- a/autoscheduler/frontend/src/tests/ui/Schedule.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/Schedule.test.tsx
@@ -11,7 +11,7 @@ import Instructor from '../../types/Instructor';
 import Schedule from '../../components/SchedulingPage/Schedule/Schedule';
 import autoSchedulerReducer from '../../redux/reducer';
 import { testSchedule3 } from '../testSchedules';
-import colors from '../../components/SchedulingPage/Schedule/meetingColors';
+import { meetingColors as colors } from '../../components/SchedulingPage/Schedule/meetingColors';
 
 const testSection = new Section({
   id: 123456,

--- a/autoscheduler/frontend/src/tests/ui/Schedule.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/Schedule.test.tsx
@@ -11,7 +11,7 @@ import Instructor from '../../types/Instructor';
 import Schedule from '../../components/SchedulingPage/Schedule/Schedule';
 import autoSchedulerReducer from '../../redux/reducer';
 import { testSchedule3 } from '../testSchedules';
-import { meetingColors as colors } from '../../components/SchedulingPage/Schedule/meetingColors';
+import { colors } from '../../components/SchedulingPage/Schedule/meetingColors';
 
 const testSection = new Section({
   id: 123456,


### PR DESCRIPTION
Added a mini-schedule to the schedule preview component to summarize generated schedules. Couple of design decisions I made: I didn't like how rounded borders looked, so I used rectangles. I also currently have a minimum height but no maximum height. It might be better to standardize the heights for all of them, regardless of how big the `<ListItem />` is. Also, let me know if the spacing feels off.
![image](https://user-images.githubusercontent.com/10082177/82758591-03fc7080-9dad-11ea-8c12-cec35fbc61db.png)

Closes #183 