### PR TITLE
Frontend/meeting overflow

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/Schedule.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/Schedule.tsx
@@ -134,9 +134,9 @@ const Schedule: React.FC = () => {
     const clientRect = evt.currentTarget.getBoundingClientRect();
     const parentRect = evt.currentTarget.parentElement.getBoundingClientRect();
     if (evt.clientY < clientRect.top) {
-      time2 = 8 * 60 + 0;
+      time2 = FIRST_HOUR * 60 + 0;
     } else if (evt.clientY > clientRect.bottom) {
-      time2 = 21 * 60 + 0;
+      time2 = LAST_HOUR * 60 + 0;
     } else if (
       // these conditions ensure that the time disappears if the mouse leaves to the side
       evt.clientX >= parentRect.left
@@ -164,7 +164,7 @@ const Schedule: React.FC = () => {
   /**
    * As the mouse moves, this function updates `hoveredDay`, `hoveredTime`, and `mouseY` to update
    * the position of the `<HoveredTime />` component, or alternatively, if the mouse has moved
-   * before 8 AM or after 9 PM, then the `<HoveredTime />` is hidden. Then, if the mouse is pressed
+   * before 8 AM or after 10 PM, then the `<HoveredTime />` is hidden. Then, if the mouse is pressed
    * down, this function will also create/update an availability corresponding to where the user
    * is dragging
    * @param evt

--- a/autoscheduler/frontend/src/tests/testSchedules.ts
+++ b/autoscheduler/frontend/src/tests/testSchedules.ts
@@ -63,11 +63,11 @@ const testMeeting = new Meeting({
   id: 123456,
   building: 'HRBB',
   meetingDays: DAYS_TR,
-  startTimeHours: 10,
-  startTimeMinutes: 20,
-  endTimeHours: 11,
-  endTimeMinutes: 10,
-  meetingType: MeetingType.LEC,
+  startTimeHours: 19,
+  startTimeMinutes: 30,
+  endTimeHours: 22,
+  endTimeMinutes: 0,
+  meetingType: MeetingType.EXAM,
   section: testSection1,
 });
 

--- a/autoscheduler/frontend/src/tests/types/Availability.test.ts
+++ b/autoscheduler/frontend/src/tests/types/Availability.test.ts
@@ -3,6 +3,7 @@ import Availability, { roundUpAvailability, AvailabilityArgs, AvailabilityType }
 import autoSchedulerReducer from '../../redux/reducer';
 import { addAvailability } from '../../redux/actions/availability';
 import DayOfWeek from '../../types/DayOfWeek';
+import { LAST_HOUR } from '../../timeUtil';
 
 /**
  * Converts a pair of hours and minutes into a number of minutes past midnight
@@ -40,19 +41,19 @@ describe('roundUpAvailability()', () => {
       expect(store.getState().availability).toEqual(expectedResult);
     });
 
-    test('if the user starts after 20:30 and drags down', () => {
+    test('if the user starts within 30 minutes of the last hour and drags down', () => {
       // arrange
       const store = createStore(autoSchedulerReducer);
       const avArgs: AvailabilityArgs = {
         ...dummyArgs,
-        time1: makeTime(20, 40),
-        time2: makeTime(20, 50),
+        time1: makeTime(LAST_HOUR - 1, 40),
+        time2: makeTime(LAST_HOUR - 1, 50),
       };
       const expectedResult: Availability[] = [{
         ...dummyArgs,
-        startTimeHours: 20,
+        startTimeHours: LAST_HOUR - 1,
         startTimeMinutes: 30,
-        endTimeHours: 21,
+        endTimeHours: LAST_HOUR,
         endTimeMinutes: 0,
       }];
 

--- a/autoscheduler/frontend/src/tests/ui/Availability.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/Availability.test.tsx
@@ -98,7 +98,7 @@ describe('Availability UI', () => {
         .toHaveAttribute('aria-valuetext', expectedEnd);
     });
 
-    test('with an end time of 9 PM and a size of 30 mins if dragged below the bottom', () => {
+    test('with an end time of 10 PM and a size of 30 mins if dragged below the bottom', () => {
       // arrange
       const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
       const {
@@ -118,8 +118,8 @@ describe('Availability UI', () => {
         clientY: 1200,
         clientX: 100,
       };
-      const expectedStart = '20:30';
-      const expectedEnd = '21:00';
+      const expectedStart = '21:30';
+      const expectedEnd = '22:00';
       const dayZero = document.getElementsByClassName(styles.calendarDay)[0];
       jest.spyOn(dayZero, 'clientHeight', 'get')
         .mockImplementation(() => 1000);
@@ -161,8 +161,8 @@ describe('Availability UI', () => {
       );
       const startEventProps = timeToEvent(LAST_HOUR - 1, 40, 100);
       const endEventProps = timeToEvent(LAST_HOUR - 1, 50, 100);
-      const expectedStart = '20:30';
-      const expectedEnd = '21:00';
+      const expectedStart = '21:30';
+      const expectedEnd = '22:00';
       const dayZero = document.getElementsByClassName(styles.calendarDay)[0];
       jest.spyOn(dayZero, 'clientHeight', 'get')
         .mockImplementation(() => 1000);

--- a/autoscheduler/frontend/src/timeUtil.ts
+++ b/autoscheduler/frontend/src/timeUtil.ts
@@ -1,5 +1,5 @@
 export const FIRST_HOUR = 8;
-export const LAST_HOUR = 21;
+export const LAST_HOUR = 22;
 /**
  * Given the hours and minutes of a time, returns a formatted string representation of
  * that time. By default, this uses 12-hour format, but an extra argument can be specified

--- a/autoscheduler/frontend/src/types/Availability.ts
+++ b/autoscheduler/frontend/src/types/Availability.ts
@@ -59,14 +59,15 @@ export function argsToAvailability(avArgs: AvailabilityArgs): Availability {
 
 /**
    * Using time1 and time2 from the given availability, returns arguments for
-   * an availability that is at least 30 minutes long and ends before 9 PM
+   * an availability that is at least 30 minutes long and ends before LAST_HOUR
+   * (currently 10 PM)
    */
 export function roundUpAvailability(avl: AvailabilityArgs): AvailabilityArgs[] {
   const blockSize = Math.abs(avl.time2 - avl.time1);
   if (blockSize < 30) {
     if (avl.time2 < (LAST_HOUR - 1) * 60 + 30 || avl.time1 > avl.time2) {
       if (avl.time1 > FIRST_HOUR * 60 + 30 || avl.time1 < avl.time2) {
-        // if the availability is solidly between 8:30 and 20:30, just round up
+        // if the availability is solidly between 8:30 and 21:30, just round up
         // also works if the un-dragged time is earlier than the dragged one
         return [{
           ...avl,
@@ -75,7 +76,7 @@ export function roundUpAvailability(avl: AvailabilityArgs): AvailabilityArgs[] {
         }];
       }
 
-      // if availability is close to the eddges, force it to 8 to 8:30 in 2 steps
+      // if availability is close to the edges, force it to 8 to 8:30 in 2 steps
       return [{
         ...avl,
         time2: FIRST_HOUR * 60,

--- a/autoscheduler/frontend/src/types/Availability.ts
+++ b/autoscheduler/frontend/src/types/Availability.ts
@@ -1,4 +1,5 @@
 import DayOfWeek from './DayOfWeek';
+import { LAST_HOUR, FIRST_HOUR } from '../timeUtil';
 
 export enum AvailabilityType {
   NONE, BUSY
@@ -63,8 +64,8 @@ export function argsToAvailability(avArgs: AvailabilityArgs): Availability {
 export function roundUpAvailability(avl: AvailabilityArgs): AvailabilityArgs[] {
   const blockSize = Math.abs(avl.time2 - avl.time1);
   if (blockSize < 30) {
-    if (avl.time2 < 20 * 60 + 30 || avl.time1 > avl.time2) {
-      if (avl.time1 > 8 * 60 + 30 || avl.time1 < avl.time2) {
+    if (avl.time2 < (LAST_HOUR - 1) * 60 + 30 || avl.time1 > avl.time2) {
+      if (avl.time1 > FIRST_HOUR * 60 + 30 || avl.time1 < avl.time2) {
         // if the availability is solidly between 8:30 and 20:30, just round up
         // also works if the un-dragged time is earlier than the dragged one
         return [{
@@ -77,21 +78,21 @@ export function roundUpAvailability(avl: AvailabilityArgs): AvailabilityArgs[] {
       // if availability is close to the eddges, force it to 8 to 8:30 in 2 steps
       return [{
         ...avl,
-        time2: 8 * 60,
+        time2: FIRST_HOUR * 60,
       }, {
         ...avl,
-        time1: 8 * 60,
-        time2: 8 * 60 + 30,
+        time1: FIRST_HOUR * 60,
+        time2: FIRST_HOUR * 60 + 30,
       }];
     }
-    // new time blocks cannot be later than 9 PM / 2100
+    // new time blocks cannot be later than 10 PM / 2200
     return [{
       ...avl,
-      time2: 21 * 60,
+      time2: LAST_HOUR * 60,
     }, {
       ...avl,
-      time1: 21 * 60,
-      time2: 20 * 60 + 30,
+      time1: LAST_HOUR * 60,
+      time2: (LAST_HOUR - 1) * 60 + 30,
     }];
   }
 


### PR DESCRIPTION
## Description
Because MATH 152 exams can go until 9:30, this PR seeks to lengthen the calendar so that the last hour is not 9 PM but 10 PM

## How to test
The end time for SUBJ 234-500 lab has temporarily been set to 22:00. It should not render below the bottom of the schedule.

## Rationale
More widespread use of the `LAST_HOUR` variable should help, but a few strings have been left as `'10 PM'` in tests to make tests easier to read

## Screenshots
Before:
![chrome_8bQYFBi3mE.png](https://images.zenhubusercontent.com/5da358de33f74500019c3b7f/88b763e8-c290-450e-966b-0e2d21e5083d)
After:
![image](https://user-images.githubusercontent.com/10082177/83360955-c4083100-a34a-11ea-976c-68cb3e445eda.png)

## Related tasks
Closes #265 