### PR TITLE
Frontend/concat exams

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
@@ -55,6 +55,22 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
       - ${formatTime(mtg.endTimeHours, mtg.endTimeMinutes)}`;
   };
 
+  /**
+   * Accepts an array of meetings and returns a filtered array without duplicate meetings.
+   * Meetings are considered to be duplicates if they are of the same type, meet on the same days,
+   * and start and end at the same hour. Meetings that are the same by all of these criteria but
+   * differ only in the exact minutes of the meeting will still be considered duplicates
+   * @param arr
+   */
+  const filterDuplicateMeetings = (arr: Meeting[]): Meeting[] => {
+    // add all meetings to a map, then get the values of the map
+    const map = new Map<string, Meeting>();
+    arr.forEach((mtg) => map.set(
+      `${mtg.meetingType}${mtg.meetingDays}${mtg.startTimeHours}${mtg.endTimeHours}`, mtg,
+    ));
+    return [...map.values()];
+  };
+
   const renderMeeting = (mtg: Meeting, showSectionNum: boolean): JSX.Element => (
     <Typography className={styles.denseListItem} key={mtg.id}>
       <span className={styles.sectionNum} style={{ visibility: showSectionNum ? 'visible' : 'hidden' }}>
@@ -101,8 +117,8 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
             />
           </ListItemIcon>
           <ListItemText>
-            {meetings.filter(
-              (mtg) => mtg.section.id === section.id,
+            {filterDuplicateMeetings(
+              meetings.filter((mtg) => mtg.section.id === section.id),
             ).map((mtg, mtgIdx) => renderMeeting(mtg, mtgIdx === 0))}
           </ListItemText>
         </ListItem>

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
@@ -82,12 +82,12 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
     };
 
     // add all meetings to a map, then get the values of the map
-    const map = new Map<string, Meeting>();
+    const uniqueMeetings = new Map<string, Meeting>();
     arr.forEach((mtg) => {
       const key = `${mtg.meetingType}${mtg.startTimeHours}${mtg.startTimeMinutes}`;
-      map.set(key, mergeMeetings(mtg, map.get(key)));
+      uniqueMeetings.set(key, mergeMeetings(mtg, uniqueMeetings.get(key)));
     });
-    return [...map.values()];
+    return [...uniqueMeetings.values()];
   };
 
   const renderMeeting = (mtg: Meeting, showSectionNum: boolean): JSX.Element => (
@@ -119,7 +119,12 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
         : null;
       lastProf = section.instructor.name;
 
-      // get the meetings that match this section
+      // filters and then builds UI elements for the meetings that match this section
+      const meetingRows = filterDuplicateMeetings(
+        meetings.filter((mtg) => mtg.section.id === section.id),
+      ).map((mtg, mtgIdx) => renderMeeting(mtg, mtgIdx === 0));
+
+      // makes a list of the meetings in this section, along with one checkbox for all of them
       const sectionDetails = (
         <ListItem
           onClick={(): void => toggleSelected(secIdx)}
@@ -136,9 +141,7 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
             />
           </ListItemIcon>
           <ListItemText>
-            {filterDuplicateMeetings(
-              meetings.filter((mtg) => mtg.section.id === section.id),
-            ).map((mtg, mtgIdx) => renderMeeting(mtg, mtgIdx === 0))}
+            {meetingRows}
           </ListItemText>
         </ListItem>
       );

--- a/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
@@ -509,6 +509,7 @@ describe('Course Select Card UI', () => {
       expect(queryByText(placeholder)).not.toBeInTheDocument();
     });
   });
+
   describe('SectionSelect', () => {
     describe('shows ONLINE', () => {
       test('for 00:00 meeting times & online section', () => {
@@ -619,6 +620,234 @@ describe('Course Select Card UI', () => {
 
         // assert
         expect(queryByText('ONLINE')).not.toBeInTheDocument();
+      });
+    });
+
+    describe('shows a single meeting time', () => {
+      test('for duplicate exam times', () => {
+      // arrange
+        const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
+
+        const { getAllByText } = render(
+          <Provider store={store}><SectionSelect id={0} /></Provider>,
+        );
+
+        const testSection = new Section({
+          id: 0,
+          crn: 0,
+          subject: 'CSCE',
+          courseNum: '121',
+          sectionNum: '200',
+          minCredits: 3,
+          maxCredits: null,
+          currentEnrollment: 0,
+          maxEnrollment: 0,
+          instructor: new Instructor({
+            name: 'Test',
+          }),
+          honors: false,
+          web: true,
+          grades: null,
+        });
+        const testMeeting = new Meeting({
+          id: 1,
+          building: '',
+          meetingDays: new Array(7).fill(true),
+          startTimeHours: 19,
+          startTimeMinutes: 0,
+          endTimeHours: 20,
+          endTimeMinutes: 0,
+          meetingType: MeetingType.EXAM,
+          section: testSection,
+        });
+
+        const sectionSelected = {
+          section: testSection,
+          meetings: [testMeeting, testMeeting, testMeeting],
+          selected: false,
+        };
+
+        // Add the SectionSelected type to the store so it shows up in the SectionSelect component
+        store.dispatch<any>(updateCourseCard(0, {
+          sections: [sectionSelected],
+        }, '201931'));
+
+        // assert
+        expect(getAllByText('EXAM')).toHaveLength(1);
+      });
+
+      test('for slightly different exam times', () => {
+        // arrange
+        const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
+
+        const { getAllByText } = render(
+          <Provider store={store}><SectionSelect id={0} /></Provider>,
+        );
+
+        const testSection = new Section({
+          id: 0,
+          crn: 0,
+          subject: 'CSCE',
+          courseNum: '121',
+          sectionNum: '200',
+          minCredits: 3,
+          maxCredits: null,
+          currentEnrollment: 0,
+          maxEnrollment: 0,
+          instructor: new Instructor({
+            name: 'Test',
+          }),
+          honors: false,
+          web: true,
+          grades: null,
+        });
+        const testMeeting = new Meeting({
+          id: 1,
+          building: '',
+          meetingDays: new Array(7).fill(true),
+          startTimeHours: 19,
+          startTimeMinutes: 0,
+          endTimeHours: 20,
+          endTimeMinutes: 0,
+          meetingType: MeetingType.EXAM,
+          section: testSection,
+        });
+        const testMeeting2 = {
+          ...testMeeting,
+          endTimeMinutes: 30,
+        };
+
+        const sectionSelected = {
+          section: testSection,
+          meetings: [testMeeting, testMeeting, testMeeting, testMeeting2],
+          selected: false,
+        };
+
+        // Add the SectionSelected type to the store so it shows up in the SectionSelect component
+        store.dispatch<any>(updateCourseCard(0, {
+          sections: [sectionSelected],
+        }, '201931'));
+
+        // assert
+        expect(getAllByText('EXAM')).toHaveLength(1);
+      });
+    });
+
+    describe('shows multiple meeting times', () => {
+      test('for different meeting types at different times', () => {
+        // arrange
+        const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
+
+        const { getAllByText } = render(
+          <Provider store={store}><SectionSelect id={0} /></Provider>,
+        );
+
+        const testSection = new Section({
+          id: 0,
+          crn: 0,
+          subject: 'CSCE',
+          courseNum: '121',
+          sectionNum: '200',
+          minCredits: 3,
+          maxCredits: null,
+          currentEnrollment: 0,
+          maxEnrollment: 0,
+          instructor: new Instructor({
+            name: 'Test',
+          }),
+          honors: false,
+          web: true,
+          grades: null,
+        });
+        const testMeeting1 = new Meeting({
+          id: 1,
+          building: '',
+          meetingDays: new Array(7).fill(true),
+          startTimeHours: 19,
+          startTimeMinutes: 0,
+          endTimeHours: 20,
+          endTimeMinutes: 0,
+          meetingType: MeetingType.EXAM,
+          section: testSection,
+        });
+        const testMeeting2 = {
+          ...testMeeting1,
+          startTimeHours: 9,
+          startTimeMinutes: 0,
+          endTimeHours: 10,
+          endTimeMinutes: 30,
+          meetingType: MeetingType.LEC,
+        };
+
+        const sectionSelected = {
+          section: testSection,
+          meetings: [testMeeting1, testMeeting2],
+          selected: false,
+        };
+
+        // Add the SectionSelected type to the store so it shows up in the SectionSelect component
+        store.dispatch<any>(updateCourseCard(0, {
+          sections: [sectionSelected],
+        }, '201931'));
+
+        // assert
+        expect(getAllByText(/(EXAM)|(LEC)/)).toHaveLength(2);
+      });
+
+      test('for the same meeting time on different days', () => {
+        // arrange
+        const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
+
+        const { getAllByText } = render(
+          <Provider store={store}><SectionSelect id={0} /></Provider>,
+        );
+
+        const testSection = new Section({
+          id: 0,
+          crn: 0,
+          subject: 'CSCE',
+          courseNum: '121',
+          sectionNum: '200',
+          minCredits: 3,
+          maxCredits: null,
+          currentEnrollment: 0,
+          maxEnrollment: 0,
+          instructor: new Instructor({
+            name: 'Test',
+          }),
+          honors: false,
+          web: true,
+          grades: null,
+        });
+        const testMeeting1 = new Meeting({
+          id: 1,
+          building: '',
+          meetingDays: [true, false, false, false, false, false, false],
+          startTimeHours: 19,
+          startTimeMinutes: 0,
+          endTimeHours: 20,
+          endTimeMinutes: 0,
+          meetingType: MeetingType.EXAM,
+          section: testSection,
+        });
+        const testMeeting2 = {
+          ...testMeeting1,
+          meetingDays: [false, true, false, false, false, false, false],
+        };
+
+        const sectionSelected = {
+          section: testSection,
+          meetings: [testMeeting1, testMeeting2],
+          selected: false,
+        };
+
+        // Add the SectionSelected type to the store so it shows up in the SectionSelect component
+        store.dispatch<any>(updateCourseCard(0, {
+          sections: [sectionSelected],
+        }, '201931'));
+
+        // assert
+        expect(getAllByText(/(EXAM)|(LEC)/)).toHaveLength(2);
       });
     });
   });

--- a/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
@@ -676,7 +676,7 @@ describe('Course Select Card UI', () => {
         expect(getAllByText('EXAM')).toHaveLength(1);
       });
 
-      test('for slightly different exam times', () => {
+      test('for slightly different exam times, as long as they have the same start time', () => {
         // arrange
         const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
 
@@ -708,13 +708,14 @@ describe('Course Select Card UI', () => {
           startTimeHours: 19,
           startTimeMinutes: 0,
           endTimeHours: 20,
-          endTimeMinutes: 0,
+          endTimeMinutes: 30,
           meetingType: MeetingType.EXAM,
           section: testSection,
         });
         const testMeeting2 = {
           ...testMeeting,
-          endTimeMinutes: 30,
+          endTimeHours: 21,
+          endTimeMinutes: 0,
         };
 
         const sectionSelected = {
@@ -730,6 +731,64 @@ describe('Course Select Card UI', () => {
 
         // assert
         expect(getAllByText('EXAM')).toHaveLength(1);
+      });
+
+      test('for labs on different days, as long as they have the same start time', () => {
+        // arrange
+        const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
+
+        const { getAllByText } = render(
+          <Provider store={store}><SectionSelect id={0} /></Provider>,
+        );
+
+        const testSection = new Section({
+          id: 0,
+          crn: 0,
+          subject: 'CSCE',
+          courseNum: '121',
+          sectionNum: '200',
+          minCredits: 3,
+          maxCredits: null,
+          currentEnrollment: 0,
+          maxEnrollment: 0,
+          instructor: new Instructor({
+            name: 'Test',
+          }),
+          honors: false,
+          web: true,
+          grades: null,
+        });
+        const testMeeting = new Meeting({
+          id: 1,
+          building: '',
+          meetingDays: [true, false, false, false, false, false, false],
+          startTimeHours: 19,
+          startTimeMinutes: 0,
+          endTimeHours: 20,
+          endTimeMinutes: 30,
+          meetingType: MeetingType.LAB,
+          section: testSection,
+        });
+        const testMeeting2 = {
+          ...testMeeting,
+          meetingDays: [false, true, false, false, false, false, false],
+          endTimeHours: 21,
+          endTimeMinutes: 0,
+        };
+
+        const sectionSelected = {
+          section: testSection,
+          meetings: [testMeeting, testMeeting, testMeeting, testMeeting2],
+          selected: false,
+        };
+
+        // Add the SectionSelected type to the store so it shows up in the SectionSelect component
+        store.dispatch<any>(updateCourseCard(0, {
+          sections: [sectionSelected],
+        }, '201931'));
+
+        // assert
+        expect(getAllByText('LAB')).toHaveLength(1);
       });
     });
 
@@ -777,62 +836,6 @@ describe('Course Select Card UI', () => {
           endTimeHours: 10,
           endTimeMinutes: 30,
           meetingType: MeetingType.LEC,
-        };
-
-        const sectionSelected = {
-          section: testSection,
-          meetings: [testMeeting1, testMeeting2],
-          selected: false,
-        };
-
-        // Add the SectionSelected type to the store so it shows up in the SectionSelect component
-        store.dispatch<any>(updateCourseCard(0, {
-          sections: [sectionSelected],
-        }, '201931'));
-
-        // assert
-        expect(getAllByText(/(EXAM)|(LEC)/)).toHaveLength(2);
-      });
-
-      test('for the same meeting time on different days', () => {
-        // arrange
-        const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
-
-        const { getAllByText } = render(
-          <Provider store={store}><SectionSelect id={0} /></Provider>,
-        );
-
-        const testSection = new Section({
-          id: 0,
-          crn: 0,
-          subject: 'CSCE',
-          courseNum: '121',
-          sectionNum: '200',
-          minCredits: 3,
-          maxCredits: null,
-          currentEnrollment: 0,
-          maxEnrollment: 0,
-          instructor: new Instructor({
-            name: 'Test',
-          }),
-          honors: false,
-          web: true,
-          grades: null,
-        });
-        const testMeeting1 = new Meeting({
-          id: 1,
-          building: '',
-          meetingDays: [true, false, false, false, false, false, false],
-          startTimeHours: 19,
-          startTimeMinutes: 0,
-          endTimeHours: 20,
-          endTimeMinutes: 0,
-          meetingType: MeetingType.EXAM,
-          section: testSection,
-        });
-        const testMeeting2 = {
-          ...testMeeting1,
-          meetingDays: [false, true, false, false, false, false, false],
         };
 
         const sectionSelected = {


### PR DESCRIPTION
## Description

Some classes have multiple meetings listed for common exams, but each of these meetings meet on the same day of the week, at the same time, and have the same meeting type. This PR filters out those duplicates and condenses them into one meeting in `SectionSelect`.

## Rationale

At the moment, I have elected to also condense meetings that start and end at the same hour, even if the minutes are different. However, this change is implemented in `SectionSelect`, so in the `Schedule`, we'll still see overlapping exam times. I think I'll probably change that as this PR progresses.

Furthermore, the current changes affect all meeting types, not just exams. This is probably desired, even though we have no use cases at the moment.

Finally, exams that meet on different days but the same time will currently not be concatenated. This can be changed if desired.

## How to test

Tests have been implemented for this feature. To see the change in the UI, check out PHYS 207 - 501, term 202031

## Screenshots

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/10082177/83951072-bfcd8f00-a7f4-11ea-9813-9f803637d34d.png)|![image](https://user-images.githubusercontent.com/10082177/83951048-93197780-a7f4-11ea-8e6f-0331551ea184.png)|


## Related tasks

Closes #256