### PR TITLE
Added grade distribution displaying to SectionSelect

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/GradeDist/GradeDist.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/GradeDist/GradeDist.css
@@ -15,7 +15,7 @@
     overflow: hidden;
 
     padding: 0;
-    margin-left: 10px;
+    margin-left: 5px;
     margin-right: 5px;
 }
 

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/GradeDist/GradeDist.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/GradeDist/GradeDist.css
@@ -1,0 +1,24 @@
+.grades-container {
+    display: flex;
+    align-items: center;
+
+    width: 50%;
+}
+
+.grades-dist {
+    display: flex;
+    width: 90%;
+    height: 0.9rem;
+
+    border-radius: 5px;
+    /* hide the overflow so it actually applies the border-radius on the children */
+    overflow: hidden;
+
+    padding: 0;
+    margin-left: 10px;
+    margin-right: 5px;
+}
+
+.gpa-underline {
+    border-bottom: 1px solid rgb(221, 221, 221);
+}

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/GradeDist/GradeDist.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/GradeDist/GradeDist.css
@@ -1,13 +1,14 @@
 .grades-container {
     display: flex;
     align-items: center;
+    flex-grow: 1;
 
-    width: 50%;
+    max-width: 10rem;
 }
 
 .grades-dist {
     display: flex;
-    width: 90%;
+    width: 100%;
     height: 0.9rem;
 
     border-radius: 5px;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/GradeDist/GradeDist.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/GradeDist/GradeDist.css.d.ts
@@ -1,0 +1,17 @@
+declare namespace GradeDistCssModule {
+  export interface IGradeDistCss {
+    "gpa-underline": string;
+    gpaUnderline: string;
+    "grades-container": string;
+    "grades-dist": string;
+    gradesContainer: string;
+    gradesDist: string;
+  }
+}
+
+declare const GradeDistCssModule: GradeDistCssModule.IGradeDistCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: GradeDistCssModule.IGradeDistCss;
+};
+
+export = GradeDistCssModule;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/GradeDist/GradeDist.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/GradeDist/GradeDist.tsx
@@ -35,7 +35,10 @@ const GradeDist: React.FC<GradeDistProps> = ({ grades }) => {
           disablePortal: true,
         }}
       >
-        <div style={{ width: `${percent}%`, backgroundColor: color }} />
+        <div
+          style={{ width: `${percent}%`, backgroundColor: color }}
+          data-testid={`${letter}-dist`}
+        />
       </Tooltip>
     );
   }

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/GradeDist/GradeDist.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/GradeDist/GradeDist.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { Tooltip } from '@material-ui/core';
+import Grades from '../../../../../../../types/Grades';
+import * as styles from './GradeDist.css';
+
+interface GradeDistProps {
+  grades: Grades;
+}
+
+const GradeDist: React.FC<GradeDistProps> = ({ grades }) => {
+  const gradesTotal = grades.A + grades.B + grades.C + grades.D + grades.F + grades.I
+                      + grades.Q + grades.S + grades.X;
+
+  const colors = {
+    A: '#6FCF97', // green
+    B: '#56CCF2', // light blue
+    C: '#F2C94C', // yellow
+    D: '#F2994A', // orange
+    F: '#EB5757', // red
+    Q: '#9B51E0', // purple
+    // Other includes: X, I, S, U
+    Other: '#828282', // gray
+  };
+
+  function makeGradesRect(gradeCount: number, color: string, letter: string): JSX.Element {
+    const percent = gradeCount / gradesTotal * 100;
+    const tooltipText = `${letter} - ${percent.toFixed(2)}%`;
+
+    return (
+      <Tooltip
+        title={tooltipText}
+        arrow
+        PopperProps={{
+          // Fixes Tooltip scroll issue. See: https://github.com/mui-org/material-ui/issues/14366
+          disablePortal: true,
+        }}
+      >
+        <div style={{ width: `${percent}%`, backgroundColor: color }} />
+      </Tooltip>
+    );
+  }
+
+  return (
+    <div className={styles.gradesContainer}>
+      <div className={styles.gradesDist}>
+        {makeGradesRect(grades.A, colors.A, 'A')}
+        {makeGradesRect(grades.B, colors.B, 'B')}
+        {makeGradesRect(grades.C, colors.C, 'C')}
+        {makeGradesRect(grades.D, colors.D, 'D')}
+        {makeGradesRect(grades.F, colors.F, 'F')}
+        {makeGradesRect(grades.Q, colors.Q, 'Q')}
+        {makeGradesRect(grades.I + grades.S + grades.U + grades.X, colors.Other, 'Other')}
+      </div>
+      <Tooltip
+        title={`From ${grades.count} total sections`}
+        arrow
+        PopperProps={{
+          disablePortal: true,
+        }}
+      >
+        <div className={styles.gpaUnderline}>
+          {`${grades.gpa.toFixed(2)}`}
+        </div>
+      </Tooltip>
+    </div>
+  );
+};
+
+export default GradeDist;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/GradeDist/GradeDist.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/GradeDist/GradeDist.tsx
@@ -53,15 +53,6 @@ const GradeDist: React.FC<GradeDistProps> = ({ grades }) => {
 
   return (
     <div className={styles.gradesContainer}>
-      <div className={styles.gradesDist}>
-        {makeGradesRect(grades.A, colors.A, 'A')}
-        {makeGradesRect(grades.B, colors.B, 'B')}
-        {makeGradesRect(grades.C, colors.C, 'C')}
-        {makeGradesRect(grades.D, colors.D, 'D')}
-        {makeGradesRect(grades.F, colors.F, 'F')}
-        {makeGradesRect(grades.Q, colors.Q, 'Q')}
-        {makeGradesRect(grades.I + grades.S + grades.U + grades.X, colors.Other, 'Other')}
-      </div>
       <Tooltip
         title={makeFromTotalSectionsTooltipText(grades.count)}
         arrow
@@ -73,6 +64,15 @@ const GradeDist: React.FC<GradeDistProps> = ({ grades }) => {
           {`${grades.gpa.toFixed(2)}`}
         </div>
       </Tooltip>
+      <div className={styles.gradesDist}>
+        {makeGradesRect(grades.A, colors.A, 'A')}
+        {makeGradesRect(grades.B, colors.B, 'B')}
+        {makeGradesRect(grades.C, colors.C, 'C')}
+        {makeGradesRect(grades.D, colors.D, 'D')}
+        {makeGradesRect(grades.F, colors.F, 'F')}
+        {makeGradesRect(grades.Q, colors.Q, 'Q')}
+        {makeGradesRect(grades.I + grades.S + grades.U + grades.X, colors.Other, 'Other')}
+      </div>
     </div>
   );
 };

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/GradeDist/GradeDist.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/GradeDist/GradeDist.tsx
@@ -43,6 +43,14 @@ const GradeDist: React.FC<GradeDistProps> = ({ grades }) => {
     );
   }
 
+  function makeFromTotalSectionsTooltipText(gradeCount: number): string {
+    if (gradeCount === 1) {
+      return 'From 1 total section';
+    }
+
+    return `From ${gradeCount} total sections`;
+  }
+
   return (
     <div className={styles.gradesContainer}>
       <div className={styles.gradesDist}>
@@ -55,7 +63,7 @@ const GradeDist: React.FC<GradeDistProps> = ({ grades }) => {
         {makeGradesRect(grades.I + grades.S + grades.U + grades.X, colors.Other, 'Other')}
       </div>
       <Tooltip
-        title={`From ${grades.count} total sections`}
+        title={makeFromTotalSectionsTooltipText(grades.count)}
         arrow
         PopperProps={{
           disablePortal: true,

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
@@ -44,6 +44,10 @@
     align-items: center;
 }
 
+.no-grades-available {
+    margin-right: 5px;
+}
+
 .gray-text {
     color: rgba(0, 0, 0, 0.56);
     padding-bottom: 8px;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
@@ -36,6 +36,12 @@
     position: initial;
     display: flex;
     align-items: center;
+    justify-content: space-between;
+}
+
+.name-honors-icon {
+    display: flex;
+    align-items: center;
 }
 
 .gray-text {

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css.d.ts
@@ -16,11 +16,12 @@ declare namespace SectionSelectCssModule {
     "my-list-item-icon": string;
     myIconButton: string;
     myListItemIcon: string;
-    "right-aligned-text": string;
-    rightAlignedText: string;
     "name-honors-icon": string;
     nameHonorsIcon: string;
-    "section-num": string;
+    "no-grades-available": string;
+    noGradesAvailable: string;
+    "right-aligned-text": string;
+    rightAlignedText: string;
     "section-rows": string;
     sectionRows: string;
   }

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css.d.ts
@@ -18,6 +18,9 @@ declare namespace SectionSelectCssModule {
     myListItemIcon: string;
     "right-aligned-text": string;
     rightAlignedText: string;
+    "name-honors-icon": string;
+    nameHonorsIcon: string;
+    "section-num": string;
     "section-rows": string;
     sectionRows: string;
   }

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
@@ -12,6 +12,7 @@ import { SectionSelected } from '../../../../../../types/CourseCardOptions';
 import { RootState } from '../../../../../../redux/reducer';
 import * as styles from './SectionSelect.css';
 import { updateCourseCard } from '../../../../../../redux/actions/courseCards';
+import GradeDist from './GradeDist/GradeDist';
 
 interface SectionSelectProps {
   id: number;
@@ -144,6 +145,9 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
                   <HonorsIcon data-testid="honors" />
                 </Tooltip>
               ) : null}
+              {section.grades
+                ? <GradeDist grades={section.grades} />
+                : null}
             </ListSubheader>
             <div className={styles.dividerContainer}>
               <Divider />

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
@@ -139,12 +139,14 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
         ? (
           <>
             <ListSubheader disableGutters className={styles.listSubheaderDense}>
-              {section.instructor.name}
-              {section.honors ? (
-                <Tooltip title="Honors" placement="right">
-                  <HonorsIcon data-testid="honors" />
-                </Tooltip>
-              ) : null}
+              <div className={styles.nameHonorsIcon}>
+                {section.instructor.name}
+                {section.honors ? (
+                  <Tooltip title="Honors" placement="right">
+                    <HonorsIcon data-testid="honors" />
+                  </Tooltip>
+                ) : null}
+              </div>
               {section.grades
                 ? <GradeDist grades={section.grades} />
                 : null}

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
@@ -149,7 +149,11 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
               </div>
               {section.grades
                 ? <GradeDist grades={section.grades} />
-                : null}
+                : (
+                  <div className={styles.noGradesAvailable}>
+                    No grades available
+                  </div>
+                )}
             </ListSubheader>
             <div className={styles.dividerContainer}>
               <Divider />

--- a/autoscheduler/frontend/src/tests/redux/CourseCardRedux.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/CourseCardRedux.test.ts
@@ -12,7 +12,7 @@ describe('Course Cards Redux', () => {
       test('on a normal input', () => {
         // arrange
         const grades = {
-          gpa: 4.0, A: 1, B: 0, C: 0, D: 0, F: 0, I: 0, S: 0, Q: 0, X: 0,
+          gpa: 4.0, A: 1, B: 0, C: 0, D: 0, F: 0, I: 0, S: 0, U: 0, Q: 0, X: 0, count: 0,
         };
 
         const input = [{

--- a/autoscheduler/frontend/src/tests/types/Grades.test.ts
+++ b/autoscheduler/frontend/src/tests/types/Grades.test.ts
@@ -2,14 +2,14 @@ import Grades from '../../types/Grades';
 import { Indexable, fetchMock } from '../util';
 
 const correctArgs: Indexable = {
-  gpa: 0.0, A: 0, B: 0, C: 0, D: 0, F: 0, I: 0, S: 0, Q: 0, X: 0,
+  gpa: 0.0, A: 0, B: 0, C: 0, D: 0, F: 0, I: 0, S: 0, U: 0, Q: 0, X: 0, count: 0,
 };
 
 const createGrades = jest.fn((args) => new Grades(fetchMock(args)));
 
 describe('Grades type', () => {
   describe('throws an error', () => {
-    const nonNullableProps = ['gpa', 'A', 'B', 'C', 'D', 'F', 'I', 'S', 'Q', 'X'];
+    const nonNullableProps = ['gpa', 'A', 'B', 'C', 'D', 'F', 'I', 'S', 'U', 'Q', 'X'];
     test.each(nonNullableProps)('when any of the properties are null %s', (prop) => {
       // arrange
       const badArgs = { ...correctArgs };

--- a/autoscheduler/frontend/src/tests/ui/GradeDist.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/GradeDist.test.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import Grades from '../../types/Grades';
+import GradeDist from '../../components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/GradeDist/GradeDist';
+
+describe('GradeDist', () => {
+  beforeAll(() => { // Fixes the document.createRange is not a function error
+    const nodeProps = Object.create(Node.prototype, {});
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore
+    document.createRange = (): Range => ({
+      setStart: (): void => {},
+      setEnd: (): void => {},
+      commonAncestorContainer: {
+        ...nodeProps,
+        nodeName: 'BODY',
+        ownerDocument: document,
+      },
+    });
+  });
+
+  describe('Shows the correct % of students that received that grade', () => {
+    test('When hovering over that grade rect', async () => {
+      // arrange
+      const grades = new Grades({
+        gpa: 3.5, A: 1, B: 1, C: 0, D: 0, F: 0, I: 0, S: 0, U: 0, Q: 0, X: 0, count: 2,
+      });
+
+      const { findByText, getByTestId } = render(
+        <GradeDist grades={grades} />,
+      );
+
+      // act
+      const aDist = getByTestId('A-dist');
+      fireEvent.mouseEnter(aDist); // Hover over the A grade rect
+
+      // assert
+      const text = await findByText('A - 50.00%');
+      expect(text).toBeInTheDocument();
+    });
+  });
+
+  describe('Shows the amount of sections used in the calculation', () => {
+    test('When hovering over the overall GPA average', async () => {
+      // arrange
+      const count = 2;
+      const grades = new Grades({
+        gpa: 3.5, A: 1, B: 1, C: 0, D: 0, F: 0, I: 0, S: 0, U: 0, Q: 0, X: 0, count,
+      });
+
+      const { findByText, getByText } = render(
+        <GradeDist grades={grades} />,
+      );
+
+      // act
+      const gpaText = getByText('3.50');
+      fireEvent.mouseEnter(gpaText); // Hover over the GPA text
+
+      // assert
+      const text = await findByText(`From ${count} total sections`);
+      expect(text).toBeInTheDocument();
+    });
+  });
+});

--- a/autoscheduler/frontend/src/tests/ui/SchedulePreview.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SchedulePreview.test.tsx
@@ -72,10 +72,10 @@ describe('SchedulePreview component', () => {
 
         const schedule = [
           createMeetingWithGrades(new Grades({
-            gpa: 4.0, A: 0, B: 0, C: 0, D: 0, F: 0, I: 0, S: 0, Q: 0, X: 0,
+            gpa: 4.0, A: 0, B: 0, C: 0, D: 0, F: 0, I: 0, S: 0, U: 0, Q: 0, X: 0, count: 0,
           }), numCredits, 0),
           createMeetingWithGrades(new Grades({
-            gpa: 3.0, A: 0, B: 0, C: 0, D: 0, F: 0, I: 0, S: 0, Q: 0, X: 0,
+            gpa: 3.0, A: 0, B: 0, C: 0, D: 0, F: 0, I: 0, S: 0, U: 0, Q: 0, X: 0, count: 0,
           }), numCredits, 1),
         ];
 
@@ -93,7 +93,7 @@ describe('SchedulePreview component', () => {
 
         const schedule = [
           createMeetingWithGrades(new Grades({
-            gpa: 4.0, A: 0, B: 0, C: 0, D: 0, F: 0, I: 0, S: 0, Q: 0, X: 0,
+            gpa: 4.0, A: 0, B: 0, C: 0, D: 0, F: 0, I: 0, S: 0, U: 0, Q: 0, X: 0, count: 0,
           }), numCredits, 0),
           createMeetingWithGrades(null, numCredits, 1),
         ];
@@ -112,10 +112,10 @@ describe('SchedulePreview component', () => {
 
         const schedule = [
           createMeetingWithGrades(new Grades({
-            gpa: 4.0, A: 0, B: 0, C: 0, D: 0, F: 0, I: 0, S: 0, Q: 0, X: 0,
+            gpa: 4.0, A: 0, B: 0, C: 0, D: 0, F: 0, I: 0, S: 0, U: 0, Q: 0, X: 0, count: 0,
           }), numCredits0, 0),
           createMeetingWithGrades(new Grades({
-            gpa: 3.0, A: 0, B: 0, C: 0, D: 0, F: 0, I: 0, S: 0, Q: 0, X: 0,
+            gpa: 3.0, A: 0, B: 0, C: 0, D: 0, F: 0, I: 0, S: 0, U: 0, Q: 0, X: 0, count: 0,
           }), numCredits1, 1),
         ];
 

--- a/autoscheduler/frontend/src/types/Grades.ts
+++ b/autoscheduler/frontend/src/types/Grades.ts
@@ -7,8 +7,10 @@ interface GradesInit {
     F: number;
     I: number;
     S: number;
+    U: number;
     Q: number;
     X: number;
+    count: number;
 }
 
 export default class Grades {
@@ -20,8 +22,10 @@ export default class Grades {
   F: number;
   I: number;
   S: number;
+  U: number;
   Q: number;
   X: number;
+  count: number; // The number of Sections that this Grades object averages from
   constructor(init: GradesInit) {
     // None of the properties can be null
     if (init.gpa == null) { throw Error(`Grades.gpa is invalid: ${init.gpa}`); }
@@ -32,8 +36,10 @@ export default class Grades {
     if (init.F == null) { throw Error(`Grades.F is invalid: ${init.F}`); }
     if (init.I == null) { throw Error(`Grades.I is invalid: ${init.I}`); }
     if (init.S == null) { throw Error(`Grades.S is invalid: ${init.S}`); }
+    if (init.U == null) { throw Error(`Grades.U is invalid: ${init.U}`); }
     if (init.Q == null) { throw Error(`Grades.Q is invalid: ${init.Q}`); }
     if (init.X == null) { throw Error(`Grades.X is invalid: ${init.X}`); }
+    if (init.count == null) { throw Error(`Grades.count is invalid: ${init.count}`); }
 
     Object.assign(this, init);
   }

--- a/autoscheduler/scraper/models/grades.py
+++ b/autoscheduler/scraper/models/grades.py
@@ -40,6 +40,10 @@ class GradeManager(models.Manager):
                 U=models.Sum("U"),
                 Q=models.Sum("Q"),
                 X=models.Sum("X"),
+
+                # Could really count any of the fields, since it doesn't count only unique
+                # values
+                count=models.Count("gpa"),
             )
         )
 

--- a/autoscheduler/scraper/serializers.py
+++ b/autoscheduler/scraper/serializers.py
@@ -51,7 +51,7 @@ class SectionSerializer(serializers.ModelSerializer):
         grades = Grades.objects.instructor_performance(obj.subject, obj.course_num,
                                                        obj.instructor)
         # If GPA is none, then there weren't any grades for this course & professor
-        if grades.get("gpa") is None:
+        if grades.get("gpa") is None or obj.instructor is None:
             return None
 
         return grades

--- a/autoscheduler/scraper/tests/api_tests.py
+++ b/autoscheduler/scraper/tests/api_tests.py
@@ -403,7 +403,7 @@ class APITests(APITestCase): #pylint: disable=too-many-public-methods
                 'web': False,
                 'grades': {
                     'gpa': 1, 'A': 0, 'B': 0, 'C': 0, 'D': 0, 'F': 0, 'I': 0, 'S': 0,
-                    'U': 0, 'Q': 0, 'X': 0,
+                    'U': 0, 'Q': 0, 'X': 0, "count": 1,
                 }
             },
         ]
@@ -671,7 +671,7 @@ class APITests(APITestCase): #pylint: disable=too-many-public-methods
             of a course for an instructor """
         # Arrange
         expected = {"gpa": 3, "A": 1, "B": 1, "C": 1, "D": 0, "F": 0, "I": 0,
-                    "S": 0, "U": 0, "Q": 0, "X": 0}
+                    "S": 0, "U": 0, "Q": 0, "X": 0, "count": 3, }
         data = {'subject': 'ASCC', 'course_num': '101', 'instructor': 'Akash Tyagi'}
 
         # Act
@@ -686,7 +686,7 @@ class APITests(APITestCase): #pylint: disable=too-many-public-methods
             a course for an instructor """
         # Arrange
         expected = {"gpa": 1, "A": 0, "B": 0, "C": 0, "D": 0, "F": 0, "I": 0,
-                    "S": 0, "U": 0, "Q": 0, "X": 0}
+                    "S": 0, "U": 0, "Q": 0, "X": 0, "count": 1, }
         data = {'subject': 'CSCE', 'course_num': '310', 'instructor': 'John Moore'}
 
         # Act
@@ -702,7 +702,7 @@ class APITests(APITestCase): #pylint: disable=too-many-public-methods
         """
         # Arrange
         expected = {"gpa": 2.5, "A": 1, "B": 0, "C": 2, "D": 0, "F": 0, "I": 0,
-                    "S": 0, "U": 0, "Q": 0, "X": 0}
+                    "S": 0, "U": 0, "Q": 0, "X": 0, "count": 2, }
         data = {'subject': 'BIMS', 'course_num': '110', 'instructor': 'Akash Tyagi'}
 
         # Act
@@ -718,7 +718,7 @@ class APITests(APITestCase): #pylint: disable=too-many-public-methods
         """
         # Arrange
         expected = {"gpa": 2.5, "A": 1, "B": 0, "C": 2, "D": 0, "F": 0, "I": 0,
-                    "S": 0, "U": 0, "Q": 0, "X": 0}
+                    "S": 0, "U": 0, "Q": 0, "X": 0, "count": 2, }
         data = {'subject': 'bims', 'course_num': '110', 'instructor': 'Akash Tyagi'}
 
         # Act

--- a/autoscheduler/scraper/tests/models_tests.py
+++ b/autoscheduler/scraper/tests/models_tests.py
@@ -76,7 +76,7 @@ class GradesTests(django.test.TestCase):
         Grades.objects.bulk_create(grades)
 
         expected = {
-            "gpa": 3.5, "A": 1, "B": 1, # Values that matter
+            "gpa": 3.5, "A": 1, "B": 1, "count": 2, # Values that matter
             "C": 0, "D": 0, "F": 0, "I": 0, "S": 0, "U": 0, "Q": 0, "X": 0
         }
 
@@ -123,7 +123,7 @@ class GradesTests(django.test.TestCase):
         Grades.objects.bulk_create(grades)
 
         expected = {
-            "gpa": 2.5, "A": 0, "B": 1, "C": 1, # Values that matter
+            "gpa": 2.5, "A": 0, "B": 1, "C": 1, "count": 2, # Values that matter
             "D": 0, "F": 0, "I": 0, "S": 0, "U": 0, "Q": 0, "X": 0
         }
 


### PR DESCRIPTION
## Description

This adds grade distribution displaying to the `SectionSelect` for each instructor group. It also adds the counting of the total amount of sections to `GradesManager.instructor_performance`, so we can display the `From X total sections` text when the GPA is hovered over (thanks for the idea www.aggiegrades.com)

## How to test

Not sure if there are any edge cases that I can think of. I've just been testing it with `CSCE 121- 202031`, which is my go to typically. 

## Screenshots

|1080p|1440p|
|--|--|
|![chrome_PU3RrvU9Zu](https://user-images.githubusercontent.com/7295783/83978593-499d5b00-a8ce-11ea-8c68-e0582d5ba21e.png)|![chrome_ZRthy0cd3G](https://user-images.githubusercontent.com/7295783/83978596-4bffb500-a8ce-11ea-9872-30b89ad413b4.png)|



## Related tasks

Closes #163
