### PR TITLE
Made api/terms show College Station terms first

### DIFF
--- a/autoscheduler/scraper/views.py
+++ b/autoscheduler/scraper/views.py
@@ -40,7 +40,15 @@ class RetrieveTermView(generics.ListAPIView):
         This view returns all the terms
     """
     def get_queryset(self):
-        return Department.objects.all().distinct('term').order_by('-term')
+        def term_code_value(dept):
+            """ Comparison key function for departments, when sorted in reverse order this
+                sorts departments in descending year, with terms in College Station first
+            """
+            term = int(dept.term)
+            return term - term % 10
+
+        return sorted(Department.objects.distinct('term').only('term'),
+                      key=term_code_value, reverse=True)
 
     def list(self, request): # pylint: disable=arguments-differ
         """ Overrides default behavior of list method so terms are ouput in


### PR DESCRIPTION
## Description

Terms are now shown in the order College Station, Galveston, Qatar rather than reversed

## How to test

Look at the home page, all terms are now in the order that we wanted

## Screenshots

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/28655462/84597707-705a1500-ae2b-11ea-8355-828f87793e4b.png)|![image](https://user-images.githubusercontent.com/28655462/84597697-5b7d8180-ae2b-11ea-8986-2c5f06360f0b.png)|

## Related tasks

Closes #245.