### PR TITLE
Shows snackbar when no schedules can be generated

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
@@ -25,13 +25,14 @@ const ConfigureCard: React.FC = () => {
   const [includeFull, setIncludeFull] = React.useState(false);
   const [loading, setLoading] = React.useState(false);
   const [showSnackbar, setShowSnackbar] = React.useState(false);
+  const ref = React.useRef();
   const courseCards = useSelector<RootState, CourseCardArray>((state) => state.courseCards);
   const term = useSelector<RootState, string>((state) => state.term);
   const avsList = useSelector<RootState, Availability[]>((state) => state.availability);
   const dispatch = useDispatch();
 
   const checkIfEmpty = (schedules: Meeting[][]): Meeting[][] => {
-    if (schedules.length === 0) setShowSnackbar(true);
+    if (ref.current && schedules.length === 0) setShowSnackbar(true);
     return schedules;
   };
 
@@ -90,7 +91,7 @@ const ConfigureCard: React.FC = () => {
       .then((schedules: Meeting[][]) => {
         dispatch(replaceSchedules(schedules));
         dispatch(selectSchedule(0));
-        setLoading(false);
+        if (ref.current) setLoading(false);
       });
   }, [avsList, courseCards, dispatch, includeFull, term]);
 
@@ -100,7 +101,7 @@ const ConfigureCard: React.FC = () => {
         <div id={styles.cardHeader}>Configure</div>
       }
     >
-      <div className={styles.buttonContainer}>
+      <div className={styles.buttonContainer} ref={ref}>
         <div id={styles.instructions}>
           Click and drag in the calendar on the right to block off times when you
           are unavailable, then press Generate Schedules below.

--- a/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
@@ -36,6 +36,12 @@ const ConfigureCard: React.FC = () => {
     return schedules;
   };
 
+  // closes the snackbar if the user presses the close icon, but not if they click away
+  const handleSnackbarClose = (_event: any, reason: string): void => {
+    if (reason === 'clickaway') return;
+    setShowSnackbar(false);
+  };
+
   const fetchSchedules = React.useCallback(() => {
     // show loading indicator
     setLoading(true);
@@ -131,9 +137,9 @@ const ConfigureCard: React.FC = () => {
       </div>
       <Snackbar
         open={showSnackbar}
-        autoHideDuration={10000}
+        autoHideDuration={5000}
         message="No schedules found. Try widening your criteria."
-        onClose={(): void => setShowSnackbar(false)}
+        onClose={handleSnackbarClose}
         action={(
           <IconButton aria-label="close" onClick={(): void => setShowSnackbar(false)}>
             <CloseIcon fontSize="small" style={{ color: 'white' }} />

--- a/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
@@ -25,6 +25,7 @@ const ConfigureCard: React.FC = () => {
   const [includeFull, setIncludeFull] = React.useState(false);
   const [loading, setLoading] = React.useState(false);
   const [showSnackbar, setShowSnackbar] = React.useState(false);
+  // Holds a reference to the DOM element to check if the component is still mounted
   const ref = React.useRef();
   const courseCards = useSelector<RootState, CourseCardArray>((state) => state.courseCards);
   const term = useSelector<RootState, string>((state) => state.term);

--- a/autoscheduler/frontend/src/tests/ui/ConfigureCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/ConfigureCard.test.tsx
@@ -153,4 +153,47 @@ describe('ConfigureCard component', () => {
       expect(sections.length).toEqual(0);
     });
   });
+
+  describe('shows an error message', () => {
+    test('when the backend returns no schedules', async () => {
+      // arrange
+      const store = createStore(autoSchedulerReducer);
+      const { getByText, findByText } = render(
+        <Provider store={store}>
+          <ConfigureCard />
+        </Provider>,
+      );
+
+      fetchMock.mockResponseOnce(JSON.stringify([]));
+
+      // act
+      fireEvent.click(getByText('Generate Schedules'));
+      const errorMessage = await findByText('No schedules found. Try widening your criteria.');
+
+      // assert
+      expect(errorMessage).toBeInTheDocument();
+    });
+  });
+
+  describe('does not show an error message', () => {
+    test('when the backend returns schedules', async () => {
+      // arrange
+      const store = createStore(autoSchedulerReducer);
+      const { queryByText, findByRole } = render(
+        <Provider store={store}>
+          <ConfigureCard />
+        </Provider>,
+      );
+
+      fetchMock.mockResponseOnce(JSON.stringify([[], []]));
+
+      // act
+      fireEvent.click(queryByText('Generate Schedules'));
+      await findByRole('progressbar');
+      const errorMessage = queryByText('No schedules found. Try widening your criteria.');
+
+      // assert
+      expect(errorMessage).not.toBeInTheDocument();
+    });
+  });
 });

--- a/autoscheduler/frontend/src/tests/ui/ConfigureCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/ConfigureCard.test.tsx
@@ -154,7 +154,7 @@ describe('ConfigureCard component', () => {
     });
   });
 
-  describe('shows an error message', () => {
+  describe('shows an error snackbar', () => {
     test('when the backend returns no schedules', async () => {
       // arrange
       const store = createStore(autoSchedulerReducer);
@@ -175,7 +175,7 @@ describe('ConfigureCard component', () => {
     });
   });
 
-  describe('does not show an error message', () => {
+  describe('does not show an error snackbar', () => {
     test('when the backend returns schedules', async () => {
       // arrange
       const store = createStore(autoSchedulerReducer);


### PR DESCRIPTION
## Description

I often hit "Generate Schedules" and then sit for a very confusing minute wondering why it's taking so long, until I realize that I didn't check "Include full sections". Users will almost certainly make similar mistakes, so we need an error handling method to let them know that they need to change their filters. To this end, I have added a snackbar that shows when the Generate Schedules  button returns no schedules.

***tests coming soon***

## Rationale

I think the only possible controversial thing here would be the text in the error bar. It currently reads "No schedules found. Try widening your criteria." Let me know if you'd like something else.

## How to test

Hitting Generate Schedules without adding any courses is the easiest way to test this.

## Screenshots

![image](https://user-images.githubusercontent.com/10082177/85933180-da49d400-b899-11ea-9654-88d55451532d.png)

## Related tasks

Closes #278 
