### PR TITLE
Store term in sessions

### DIFF
--- a/autoscheduler/autoscheduler/settings/base.py
+++ b/autoscheduler/autoscheduler/settings/base.py
@@ -46,6 +46,7 @@ INSTALLED_APPS = [
     'frontend',
     'scheduler',
     'scraper',
+    'user_sessions',
 ]
 
 MIDDLEWARE = [

--- a/autoscheduler/autoscheduler/urls.py
+++ b/autoscheduler/autoscheduler/urls.py
@@ -20,5 +20,6 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/', include('scraper.urls')),
     path('scheduler/', include('scheduler.urls')),
+    path('sessions/', include('user_sessions.urls')),
     path('', include('frontend.urls')),
 ]

--- a/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
+++ b/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
@@ -3,6 +3,8 @@ import {
   Menu, MenuItem, Button,
 } from '@material-ui/core';
 import { navigate } from '@reach/router';
+import { useDispatch } from 'react-redux';
+import setTerm from '../../../redux/actions/term';
 import * as styles from './SelectTerm.css';
 
 const SelectTerm: React.FC = () => {
@@ -27,6 +29,8 @@ const SelectTerm: React.FC = () => {
 
   const [selectedTerm, setSelectedTerm] = React.useState(options[0]);
 
+  const dispatch = useDispatch();
+
   const handleClick = (event: React.MouseEvent<HTMLElement>): void => {
     setAnchorEl(event.currentTarget);
   };
@@ -42,9 +46,16 @@ const SelectTerm: React.FC = () => {
     const term: string = termMap.get(option);
 
     // Redirect to the main page, term will be set and retrieved by API calls
+    // Ignore any errors (caused by cookies not being enabled) so that sessions aren't needed
+    // in order to set term
     fetch(`sessions/set_last_term?term=${term}`, {
       method: 'PUT',
-    }).then(() => { navigate('/schedule'); });
+    }).catch(() => {
+    }).finally(() => {
+      // Set term, if cookies are enabled this will be overwritten when the scheduling page loads
+      dispatch(setTerm(term));
+      navigate('/schedule');
+    });
   };
 
   return (

--- a/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
+++ b/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
@@ -3,8 +3,6 @@ import {
   Menu, MenuItem, Button,
 } from '@material-ui/core';
 import { navigate } from '@reach/router';
-import { useDispatch } from 'react-redux';
-import setTerm from '../../../redux/actions/term';
 import * as styles from './SelectTerm.css';
 
 const SelectTerm: React.FC = () => {
@@ -29,8 +27,6 @@ const SelectTerm: React.FC = () => {
 
   const [selectedTerm, setSelectedTerm] = React.useState(options[0]);
 
-  const dispatch = useDispatch();
-
   const handleClick = (event: React.MouseEvent<HTMLElement>): void => {
     setAnchorEl(event.currentTarget);
   };
@@ -45,10 +41,10 @@ const SelectTerm: React.FC = () => {
     // Get the corresponding option given the term's description
     const term: string = termMap.get(option);
 
-    dispatch(setTerm(term));
-
-    // Redirect to the main page
-    navigate('/schedule');
+    // Redirect to the main page, term will be set and retrieved by API calls
+    fetch(`sessions/set_last_term?term=${term}`, {
+      method: 'PUT',
+    }).then(() => { navigate('/schedule'); });
   };
 
   return (

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulingPage.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulingPage.tsx
@@ -10,13 +10,16 @@ import setTerm from '../../redux/actions/term';
 
 const SchedulingPage: React.FC<RouteComponentProps> = (): JSX.Element => {
   const dispatch = useDispatch();
+
   // Set redux state on page load based on term from user session
   React.useEffect(() => {
-    fetch('sessions/get_last_term').then((res) => res.json()).then((json) => {
-      const { term } = json;
-      dispatch(setTerm(term));
+    fetch('sessions/get_last_term').then((res) => res.json()).then(({ term }) => {
+      // If unable to get a term, do nothing (term is set by SelectTerm on landing page,
+      // but session functionality will be unavailable)
+      if (term) dispatch(setTerm(term));
     });
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [dispatch]);
+
   return (
     <div className={styles.pageContainer}>
       <div className={styles.leftContainer}>

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulingPage.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulingPage.tsx
@@ -1,26 +1,38 @@
 import * as React from 'react';
+import { useDispatch } from 'react-redux';
 import { RouteComponentProps } from '@reach/router';
 import Schedule from './Schedule/Schedule';
 import * as styles from './SchedulingPage.css';
 import ConfigureCard from './ConfigureCard/ConfigureCard';
 import SchedulePreview from './SchedulePreview/SchedulePreview';
 import CourseSelectColumn from './CourseSelectColumn/CourseSelectColumn';
+import setTerm from '../../redux/actions/term';
 
-const SchedulingPage: React.FC<RouteComponentProps> = (): JSX.Element => (
-  <div className={styles.pageContainer}>
-    <div className={styles.leftContainer}>
-      <div className={styles.courseCardColumnContainer}>
-        <CourseSelectColumn />
+const SchedulingPage: React.FC<RouteComponentProps> = (): JSX.Element => {
+  const dispatch = useDispatch();
+  // Set redux state on page load based on term from user session
+  React.useEffect(() => {
+    fetch('sessions/get_last_term').then((res) => res.json()).then((json) => {
+      const { term } = json;
+      dispatch(setTerm(term));
+    });
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  return (
+    <div className={styles.pageContainer}>
+      <div className={styles.leftContainer}>
+        <div className={styles.courseCardColumnContainer}>
+          <CourseSelectColumn />
+        </div>
+        <div className={styles.middleColumn}>
+          <ConfigureCard />
+          <SchedulePreview />
+        </div>
       </div>
-      <div className={styles.middleColumn}>
-        <ConfigureCard />
-        <SchedulePreview />
+      <div className={styles.scheduleContainer}>
+        <Schedule />
       </div>
     </div>
-    <div className={styles.scheduleContainer}>
-      <Schedule />
-    </div>
-  </div>
-);
+  );
+};
 
 export default SchedulingPage;

--- a/autoscheduler/frontend/src/tests/ui/SchedulingPage.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SchedulingPage.test.tsx
@@ -18,6 +18,10 @@ describe('Scheduling Page UI', () => {
     test('when there are no schedules to show', async () => {
       // arrange
       const store = createStore(autoSchedulerReducer);
+
+      // sessions/get_last_term
+      fetchMock.mockResponseOnce(JSON.stringify({ term: '201931' }));
+
       const { findByText } = render(
         <Provider store={store}>
           <SchedulingPage />
@@ -34,6 +38,10 @@ describe('Scheduling Page UI', () => {
     test('when the user clicks Generate Schedules', async () => {
       // arrange
       const store = createStore(autoSchedulerReducer);
+
+      // sessions/get_last_term
+      fetchMock.mockResponseOnce(JSON.stringify({ term: '201931' }));
+
       const { getByText, queryByText } = render(
         <Provider store={store}>
           <SchedulingPage />
@@ -57,6 +65,10 @@ describe('Scheduling Page UI', () => {
     test('when the user clicks on a different schedule in the Schedule Preview', async () => {
       // arrange
       const store = createStore(autoSchedulerReducer);
+
+      // sessions/get_last_term
+      fetchMock.mockResponseOnce(JSON.stringify({ term: '201931' }));
+
       const {
         getByLabelText, getByRole, findByText, findAllByText,
       } = render(

--- a/autoscheduler/frontend/src/tests/ui/SchedulingPage.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SchedulingPage.test.tsx
@@ -96,4 +96,25 @@ describe('Scheduling Page UI', () => {
       expect(queryContainerByText(calendarDay, /CSCE 121-200.*/)).toBeTruthy();
     });
   });
+
+  describe('updates redux term based on sessions/get_last_term result', () => {
+    test('when the page is loaded', async () => {
+      // arrange
+      const store = createStore(autoSchedulerReducer);
+
+      // sessions/get_last_term
+      fetchMock.mockResponseOnce(JSON.stringify({ term: '202031' }));
+
+      render(
+        <Provider store={store}>
+          <SchedulingPage />
+        </Provider>,
+      );
+
+      const { term } = store.getState();
+
+      // assert
+      waitFor(() => expect(term).toBe('202031'));
+    });
+  });
 });

--- a/autoscheduler/frontend/src/tests/ui/SelectTerm.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SelectTerm.test.tsx
@@ -83,6 +83,9 @@ describe('SelectTerm', () => {
         </Provider>,
       );
 
+      // Mock sessions/set_last_term
+      fetchMock.mockResponseOnce(JSON.stringify({}));
+
       // act
       const button = await findByText('Select Term');
       fireEvent.click(button);
@@ -92,7 +95,7 @@ describe('SelectTerm', () => {
 
       // assert
       // see jest.mock at top of the file
-      expect(navigate).toHaveBeenCalledWith('/schedule');
+      waitFor(() => expect(navigate).toHaveBeenCalledWith('/schedule'));
     });
   });
 });

--- a/autoscheduler/frontend/src/tests/ui/SelectTerm.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SelectTerm.test.tsx
@@ -34,7 +34,7 @@ describe('SelectTerm', () => {
   afterEach(fetchMock.mockReset);
 
   describe('Menu opens', () => {
-    test('Menu opens after button is clicked', async () => {
+    test('after button is clicked', async () => {
       // arrange
       const store = createStore(autoSchedulerReducer);
 
@@ -73,7 +73,7 @@ describe('SelectTerm', () => {
   });
 
   describe('Redirects to /schedule', () => {
-    test('When term is selected', async () => {
+    test('when a term is selected', async () => {
       // arrange
       const store = createStore(autoSchedulerReducer);
 
@@ -96,6 +96,32 @@ describe('SelectTerm', () => {
       // assert
       // see jest.mock at top of the file
       waitFor(() => expect(navigate).toHaveBeenCalledWith('/schedule'));
+    });
+  });
+
+  describe('Makes the correct API call to /sessions/set_last_term', () => {
+    test('when a term is selected', async () => {
+      // arrange
+      const store = createStore(autoSchedulerReducer);
+
+      const { findByText } = render(
+        <Provider store={store}>
+          <SelectTerm />
+        </Provider>,
+      );
+      // Mock sessions/set_last_term
+      const setLastTerm = fetchMock.mockResponseOnce(JSON.stringify({}));
+
+      // act
+      const button = await findByText('Select Term');
+      fireEvent.click(button);
+      // Wait for SelectTerm to finish rendering
+      const testSemester = await findByText('Fall 2020');
+      fireEvent.click(testSemester);
+
+      // assert
+      // see jest.mock at top of the file
+      expect(setLastTerm).toHaveBeenCalledWith('sessions/set_last_term?term=202031', { method: 'PUT' });
     });
   });
 });

--- a/autoscheduler/user_sessions/tests/api_tests.py
+++ b/autoscheduler/user_sessions/tests/api_tests.py
@@ -1,0 +1,87 @@
+from rest_framework.test import APITestCase
+from django.contrib.sessions.models import Session
+
+class APITests(APITestCase):
+    """ Tests functionality of the sessions api """
+    def tearDown(self):
+        """ Delete sessions table after each test so logging in creates a new session """
+        Session.objects.all().delete()
+
+    def test_set_last_term_gives_valid_response_non_empty(self):
+        """ Tests that /sessions/set_last_term updates correctly
+            with a valid term code
+        """
+        # Arrange
+        expected_term = '202031'
+        # login() is necessary for test client to use sessions
+        self.client.login()
+
+        # Act
+        response = self.client.put(f'/sessions/set_last_term?term={expected_term}')
+        session = self.client.session
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(session['term'], expected_term)
+
+    def test_set_last_term_gives_valid_response_empty(self):
+        """ Tests that /sessions/set_last_term updates correctly
+            with an empty string as the term
+        """
+        # Arrange
+        expected_term = ''
+        # login() is necessary for test client to use sessions
+        self.client.login()
+
+        # Act
+        response = self.client.put(f'/sessions/set_last_term?term={expected_term}')
+        session = self.client.session
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(session['term'], expected_term)
+
+    def test_set_last_term_rejects_no_term(self):
+        """ Tests that /sessions/set_last_term rejects a call with no term specified
+        """
+        # Arrange
+        # login() is necessary for test client to use sessions
+        self.client.login()
+
+        # Act
+        response = self.client.put(f'/sessions/set_last_term')
+
+        # Assert
+        self.assertNotEqual(response.status_code, 200)
+
+    def test_get_last_term_defaults_when_not_set(self):
+        """ Tests that /sessions/get_last_term response defaults to empty string
+            when it has not been set
+        """
+        # Arrange
+        expected = {'term': ''}
+        # login() is necessary for test client to use sessions
+        self.client.login()
+
+        # Act
+        response = self.client.get(f'/sessions/get_last_term')
+
+        # Assert
+        self.assertEqual(response.json(), expected)
+
+    def test_get_last_term_returns_correct_value(self):
+        """ Tests that /sessions/get_last_term response is equal to the session's term """
+        # Arrange
+        expected_term = '202031'
+        expected = {'term': expected_term}
+        # login() is necessary for test client to use sessions
+        self.client.login()
+        session = self.client.session
+
+        # Act
+        session['term'] = expected_term
+        session.save()
+        response = self.client.get(f'/sessions/get_last_term')
+
+        # Assert
+        self.assertEqual(response.json(), expected)

--- a/autoscheduler/user_sessions/tests/term_api_tests.py
+++ b/autoscheduler/user_sessions/tests/term_api_tests.py
@@ -1,11 +1,12 @@
 from rest_framework.test import APITestCase
 from django.contrib.sessions.models import Session
 
-class APITests(APITestCase):
+class TermAPITests(APITestCase):
     """ Tests functionality of the sessions api """
-    def tearDown(self):
-        """ Delete sessions table after each test so logging in creates a new session """
+    def setUp(self):
+        """ Delete sessions table and log in before each test to create a new session """
         Session.objects.all().delete()
+        self.client.login()
 
     def test_set_last_term_gives_valid_response_non_empty(self):
         """ Tests that /sessions/set_last_term updates correctly
@@ -13,8 +14,6 @@ class APITests(APITestCase):
         """
         # Arrange
         expected_term = '202031'
-        # login() is necessary for test client to use sessions
-        self.client.login()
 
         # Act
         response = self.client.put(f'/sessions/set_last_term?term={expected_term}')
@@ -30,8 +29,6 @@ class APITests(APITestCase):
         """
         # Arrange
         expected_term = ''
-        # login() is necessary for test client to use sessions
-        self.client.login()
 
         # Act
         response = self.client.put(f'/sessions/set_last_term?term={expected_term}')
@@ -44,10 +41,6 @@ class APITests(APITestCase):
     def test_set_last_term_rejects_no_term(self):
         """ Tests that /sessions/set_last_term rejects a call with no term specified
         """
-        # Arrange
-        # login() is necessary for test client to use sessions
-        self.client.login()
-
         # Act
         response = self.client.put(f'/sessions/set_last_term')
 
@@ -60,13 +53,12 @@ class APITests(APITestCase):
         """
         # Arrange
         expected = {'term': ''}
-        # login() is necessary for test client to use sessions
-        self.client.login()
 
         # Act
         response = self.client.get(f'/sessions/get_last_term')
 
         # Assert
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), expected)
 
     def test_get_last_term_returns_correct_value(self):
@@ -74,8 +66,6 @@ class APITests(APITestCase):
         # Arrange
         expected_term = '202031'
         expected = {'term': expected_term}
-        # login() is necessary for test client to use sessions
-        self.client.login()
         session = self.client.session
 
         # Act
@@ -84,4 +74,5 @@ class APITests(APITestCase):
         response = self.client.get(f'/sessions/get_last_term')
 
         # Assert
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), expected)

--- a/autoscheduler/user_sessions/urls.py
+++ b/autoscheduler/user_sessions/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+from user_sessions.views import get_last_term, set_last_term
+
+urlpatterns = [
+    path('get_last_term', get_last_term),
+    path('set_last_term', set_last_term),
+]

--- a/autoscheduler/user_sessions/views.py
+++ b/autoscheduler/user_sessions/views.py
@@ -1,0 +1,22 @@
+from rest_framework.response import Response
+from rest_framework.decorators import api_view
+
+@api_view(['GET'])
+def get_last_term(request):
+    """ View that returns JSON containing last term for the current user's session.
+        Used by landing page to determine whether to redirect to schedules. """
+    term = request.session.setdefault('term', '')
+    response = {'term': term}
+    return Response(response)
+
+@api_view(['PUT'])
+def set_last_term(request):
+    """ View that sets term for the current session. Called when a term is selected,
+        or when the title bar is clicked to unset last term.
+    """
+    term = request.query_params.get('term')
+    # empty string term is valid (used to unset term), so explicitly check for None
+    if term is None:
+        return Response(status=400)
+    request.session['term'] = term
+    return Response(status=200)

--- a/autoscheduler/user_sessions/views.py
+++ b/autoscheduler/user_sessions/views.py
@@ -19,4 +19,4 @@ def set_last_term(request):
     if term is None:
         return Response(status=400)
     request.session['term'] = term
-    return Response(status=200)
+    return Response()


### PR DESCRIPTION
## Description

Sessions now store the last term code used, so when you refresh on the schedule page, it will automatically set your term.

## Rationale

I can't think of anything controversial in this PR, the website should work as it did before without cookies (and therefore sessions) enabled

## How to test

Select a term on the landing page, then refresh the page and notice that search results correspond to the term you selected

## Related tasks

Adds part of the functionality of #260, storing all of the data for a term will likely be pretty complicated (it'll at least involve adding redux actions to overwrite each slice of state and adding additional API routes), so that will be done in a separate PR, since the two are only related in that they both involve the use of sessions.