### PR TITLE
Fix filtering by section

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
@@ -39,7 +39,9 @@ const ConfigureCard: React.FC = () => {
         const courseCard = courseCards[i];
 
         // Iterate through the sections and only choose the ones that are selected
-        const selectedSections = courseCard.sections.filter((sectionSel) => sectionSel.selected);
+        const selectedSections = courseCard.sections
+          .filter((sectionSel) => sectionSel.selected)
+          .map((sectionSel) => sectionSel.section.sectionNum);
 
         const [subject, courseNum] = courseCard.course.split(' ');
         const isBasic = courseCard.customizationLevel === CustomizationLevel.BASIC;

--- a/autoscheduler/frontend/src/tests/ui/ConfigureCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/ConfigureCard.test.tsx
@@ -5,14 +5,14 @@ enableFetchMocks();
 /* eslint-disable import/first */ // enableFetchMocks must be called before others are imported
 
 import * as React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import { createStore, applyMiddleware } from 'redux';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import ConfigureCard from '../../components/SchedulingPage/ConfigureCard/ConfigureCard';
 import autoSchedulerReducer from '../../redux/reducer';
 import { updateCourseCard } from '../../redux/actions/courseCards';
-import { CustomizationLevel } from '../../types/CourseCardOptions';
+import { CustomizationLevel, SectionSelected } from '../../types/CourseCardOptions';
 import testFetch from '../testData';
 
 describe('ConfigureCard component', () => {
@@ -64,7 +64,51 @@ describe('ConfigureCard component', () => {
   });
 
   describe('Clicking generate schedules', () => {
-    test('Does not send honors and web when "SECTION" customization level is selected', () => {
+    test('Sends a list of section numbers when customization level is Section', async () => {
+      // arrange
+      const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
+      fetchMock.mockImplementationOnce(testFetch); // Mock api/sections
+      store.dispatch<any>(updateCourseCard(0, {
+        customizationLevel: CustomizationLevel.SECTION,
+        honors: 'include',
+        web: 'include',
+        course: 'CSCE 121',
+      }, '201931'));
+      const { getByText } = render(
+        <Provider store={store}>
+          <ConfigureCard />
+        </Provider>,
+      );
+
+      // Doesn't need to return anything valid
+      fetchMock.mockOnce('[]'); // mocks scheduler/generate call
+
+      const getCardSections = (): SectionSelected[] => store.getState().courseCards[0].sections;
+      // wait for Redux to fill in sections
+      await waitFor(() => expect(getCardSections()).not.toHaveLength(0));
+
+      // Make all of the sections selected
+      store.dispatch<any>(updateCourseCard(0, {
+        sections: getCardSections().map((sec) => ({
+          section: sec.section,
+          selected: true,
+          meetings: sec.meetings,
+        })),
+      }));
+
+      // act
+      fireEvent.click(getByText('Generate Schedules'));
+
+      // second call is the /scheduler/generate call. Second index of that call is the body
+      const { body } = fetchMock.mock.calls[1][1]; // Body is returned as a "blob"
+      // Convert the body into a string, parse it into an object, then get the honors & web fields
+      const { courses } = JSON.parse(body.toString());
+
+      // assert
+      expect(courses[0].sections).toEqual(['501', '502', '503']);
+    });
+
+    test('Does not send honors and web when customization level is Section', () => {
       // arrange
       const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
       const { getByText } = render(


### PR DESCRIPTION
## Description

The `<ConfigureCard />` had been sending raw `SectionSelected` objects instead of a list of section numbers, so this PR fixes that issue with a quick `.map()`

## Rationale

The testing was more complicated than the 2 lines of actual code changes

## How to test

Pick a course, select 2 sections, then see that there are only 2 schedules generated. Also added a test in `ConfigureCard.test.tsx` to prevent this in the future.

## Screenshots

N/A

## Related tasks

Closes #283
