### PR TITLE
Got rid of getOptionSelected warning in tests

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.tsx
@@ -115,16 +115,17 @@ const ExpandedCourseCard: React.FC<ExpandedCourseCardProps> = ({
           value={course}
           multiple={false}
           filterOptions={(): any[] => options} // Options are not filtered
+          getOptionSelected={(option): boolean => option === options[0]}
           onClose={(): void => {
             if (!options.find((val) => val === inputValue)) setInputValue('');
           }}
-          onChange={(evt: object, val: string): void => {
+          onChange={(_evt: object, val: string): void => {
             if (val) setLoading(true);
             dispatch(updateCourseCard(id, {
               course: val,
             }, term));
           }}
-          onInputChange={(evt: object, val: string, reason: string): void => {
+          onInputChange={(_evt: object, val: string, reason: string): void => {
             setInputValue(val);
             if (val === '') { // Skip empty inputs
               setOptions([]); // Clear the autocomplete options so previous results don't show

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.tsx
@@ -115,7 +115,7 @@ const ExpandedCourseCard: React.FC<ExpandedCourseCardProps> = ({
           value={course}
           multiple={false}
           filterOptions={(): any[] => options} // Options are not filtered
-          getOptionSelected={(option): boolean => option === options[0]}
+          getOptionSelected={(): boolean => true}
           onClose={(): void => {
             if (!options.find((val) => val === inputValue)) setInputValue('');
           }}


### PR DESCRIPTION
## Description

So I fixed the annoying warning we got with the `CourseSelectCard` tests about no option being selected. Basically , I told it to select the first option. In the browser, however, this only works after you type at least two letters, which is good enough for me.
¯\\\_(ツ)\_/¯

## Rationale

It's like a one-line change, just read the code.

I did also add some underscores for unused arguments on the functions below it, just for better linting

## How to test

Run `npm run test`. You hsould get no yellow warnings. There are still some red warnings about an update not wrapped inside `act`, but I believe I fixed those in #278 

## Screenshots

N/A

## Related tasks

I acutally don't think we ever made one for this
