### PR TITLE
User sessions/get first and last name api

### DIFF
--- a/autoscheduler/frontend/src/components/NavBar.tsx
+++ b/autoscheduler/frontend/src/components/NavBar.tsx
@@ -29,8 +29,8 @@ const NavBar: React.SFC = () => {
     fetch('sessions/get_full_name').then(
       (res) => res.json(),
     ).then((result) => {
-      if (result.full_name) {
-        setUsersName(result.full_name);
+      if (result.fullName) {
+        setUsersName(result.fullName);
       }
     });
     if (usersName === '') {

--- a/autoscheduler/frontend/src/components/NavBar.tsx
+++ b/autoscheduler/frontend/src/components/NavBar.tsx
@@ -23,22 +23,14 @@ const useStyles = makeStyles((theme) => ({
 const NavBar: React.SFC = () => {
   const classes = useStyles(appTheme);
 
-  const [usersName, setUsersName] = React.useState('');
-
-  function getUsersName(): void {
+  const [usersName, setUsersName] = React.useState('Google Login');
+  React.useEffect(() => {
     fetch('sessions/get_full_name').then(
       (res) => res.json(),
-    ).then((result) => {
-      if (result.fullName) {
-        setUsersName(result.fullName);
-      }
+    ).then(({ fullName }) => {
+      if (fullName) setUsersName(fullName);
     });
-    if (usersName === '') {
-      setUsersName('Google Login');
-    }
-  }
-
-  getUsersName();
+  }, []);
 
   return (
     <div className={classes.root}>

--- a/autoscheduler/frontend/src/components/NavBar.tsx
+++ b/autoscheduler/frontend/src/components/NavBar.tsx
@@ -23,6 +23,23 @@ const useStyles = makeStyles((theme) => ({
 const NavBar: React.SFC = () => {
   const classes = useStyles(appTheme);
 
+  const [usersName, setUsersName] = React.useState('');
+
+  function getUsersName(): void {
+    fetch('sessions/get_full_name').then(
+      (res) => res.json(),
+    ).then((result) => {
+      if (result.full_name) {
+        setUsersName(result.full_name);
+      }
+    });
+    if (usersName === '') {
+      setUsersName('Google Login');
+    }
+  }
+
+  getUsersName();
+
   return (
     <div className={classes.root}>
       <AppBar
@@ -51,7 +68,7 @@ const NavBar: React.SFC = () => {
               window.open('/login/google-oauth2/', '_self');
             }}
           >
-            Google Login
+            {usersName}
           </Button>
         </Toolbar>
       </AppBar>

--- a/autoscheduler/frontend/src/tests/ui/App.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/App.test.tsx
@@ -15,7 +15,6 @@ test('renders without errors', async () => {
   // arrange/act
   // Mock responses for the Navbar component so that App renders correctly
   fetchMock.mockResponseOnce(JSON.stringify({}));
-  fetchMock.mockResponseOnce(JSON.stringify({}));
   // Mock response for SelectTerm component so that App renders correctly
   fetchMock.mockResponseOnce(JSON.stringify({}));
 

--- a/autoscheduler/frontend/src/tests/ui/App.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/App.test.tsx
@@ -13,6 +13,9 @@ import autoSchedulerReducer from '../../redux/reducer';
 
 test('renders without errors', async () => {
   // arrange/act
+  // Mock responses for the Navbar component so that App renders correctly
+  fetchMock.mockResponseOnce(JSON.stringify({}));
+  fetchMock.mockResponseOnce(JSON.stringify({}));
   // Mock response for SelectTerm component so that App renders correctly
   fetchMock.mockResponseOnce(JSON.stringify({}));
 

--- a/autoscheduler/user_sessions/tests/name_api_tests.py
+++ b/autoscheduler/user_sessions/tests/name_api_tests.py
@@ -10,7 +10,7 @@ class UsersFullNameAPITests(APITestCase):
 
     def test_get_full_name_returns_correct_value_bob(self):
         """ Tests that /sessions/get_full_name response is equal to the user's name """
-        #Arrange
+        # Arrange
         username = 'user_bob'
         password = 'password_bob'
         user = User.objects.create(username=username, first_name='Bob',
@@ -21,17 +21,17 @@ class UsersFullNameAPITests(APITestCase):
         expected_name = 'Bob Bobbins'
         expected = {'fullName': expected_name}
 
-        #Act
+        # Act
         self.client.login(username=username, password=password)
-        response = self.client.get(f'/sessions/get_full_name')
+        response = self.client.get('/sessions/get_full_name')
 
-        #Assert
+        # Assert
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), expected)
 
     def test_get_full_name_returns_correct_value_joe(self):
         """ Tests that /sessions/get_full_name response is equal to the user's name """
-        #Arrange
+        # Arrange
         username = 'user_joe'
         password = 'password_joe'
         user = User.objects.create(username=username, first_name='Joe',
@@ -42,11 +42,11 @@ class UsersFullNameAPITests(APITestCase):
         expected_name = 'Joe Mama'
         expected = {'fullName': expected_name}
 
-        #Act
+        # Act
         self.client.login(username=username, password=password)
-        response = self.client.get(f'/sessions/get_full_name')
+        response = self.client.get('/sessions/get_full_name')
 
-        #Assert
+        # Assert
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), expected)
 
@@ -54,11 +54,11 @@ class UsersFullNameAPITests(APITestCase):
         """ Tests that /sessions/get_last_term response returns error code 400
             when user is not logged in
         """
-        #Arrange
-        #Nothing because there is no user to log in
+        # Arrange
+        # Nothing because there is no user to log in
 
-        #Act
-        response = self.client.get(f'/sessions/get_full_name')
+        # Act
+        response = self.client.get('/sessions/get_full_name')
 
-        #Assert
+        # Assert
         self.assertEqual(response.status_code, 400)

--- a/autoscheduler/user_sessions/tests/name_api_tests.py
+++ b/autoscheduler/user_sessions/tests/name_api_tests.py
@@ -19,7 +19,7 @@ class UsersFullNameAPITests(APITestCase):
         user.save()
 
         expected_name = 'Bob Bobbins'
-        expected = {'full_name': expected_name}
+        expected = {'fullName': expected_name}
 
         #Act
         self.client.login(username=username, password=password)
@@ -40,7 +40,7 @@ class UsersFullNameAPITests(APITestCase):
         user.save()
 
         expected_name = 'Joe Mama'
-        expected = {'full_name': expected_name}
+        expected = {'fullName': expected_name}
 
         #Act
         self.client.login(username=username, password=password)

--- a/autoscheduler/user_sessions/tests/name_api_tests.py
+++ b/autoscheduler/user_sessions/tests/name_api_tests.py
@@ -1,0 +1,64 @@
+from rest_framework.test import APITestCase
+from django.contrib.sessions.models import Session
+from django.contrib.auth.models import User
+
+class UsersFullNameAPITests(APITestCase):
+    """ Tests the functionality of the get_full_name API """
+    def setUp(self):
+        """ Delete sessions table before each test to ensure new session """
+        Session.objects.all().delete()
+
+    def test_get_full_name_returns_correct_value_bob(self):
+        """ Tests that /sessions/get_full_name response is equal to the user's name """
+        #Arrange
+        username = 'user_bob'
+        password = 'password_bob'
+        user = User.objects.create(username=username, first_name='Bob',
+                                   last_name='Bobbins')
+        user.set_password(password)
+        user.save()
+
+        expected_name = 'Bob Bobbins'
+        expected = {'full_name': expected_name}
+
+        #Act
+        self.client.login(username=username, password=password)
+        response = self.client.get(f'/sessions/get_full_name')
+
+        #Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), expected)
+
+    def test_get_full_name_returns_correct_value_joe(self):
+        """ Tests that /sessions/get_full_name response is equal to the user's name """
+        #Arrange
+        username = 'user_joe'
+        password = 'password_joe'
+        user = User.objects.create(username=username, first_name='Joe',
+                                   last_name='Mama')
+        user.set_password(password)
+        user.save()
+
+        expected_name = 'Joe Mama'
+        expected = {'full_name': expected_name}
+
+        #Act
+        self.client.login(username=username, password=password)
+        response = self.client.get(f'/sessions/get_full_name')
+
+        #Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), expected)
+
+    def test_get_full_name_returns_400_if_not_logged_in(self):
+        """ Tests that /sessions/get_last_term response returns error code 400
+            when user is not logged in
+        """
+        #Arrange
+        #Nothing because there is no user to log in
+
+        #Act
+        response = self.client.get(f'/sessions/get_full_name')
+
+        #Assert
+        self.assertEqual(response.status_code, 400)

--- a/autoscheduler/user_sessions/tests/term_api_tests.py
+++ b/autoscheduler/user_sessions/tests/term_api_tests.py
@@ -2,7 +2,7 @@ from rest_framework.test import APITestCase
 from django.contrib.sessions.models import Session
 
 class TermAPITests(APITestCase):
-    """ Tests functionality of the sessions api """
+    """ Tests functionality of the terms API for sessions """
     def setUp(self):
         """ Delete sessions table and log in before each test to create a new session """
         Session.objects.all().delete()

--- a/autoscheduler/user_sessions/urls.py
+++ b/autoscheduler/user_sessions/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
-from user_sessions.views import (
-    get_last_term, set_last_term, save_courses, get_saved_courses
+from user_sessions.views import(
+    get_last_term, set_last_term, save_courses, get_saved_courses, get_full_name
 )
 
 urlpatterns = [
@@ -8,4 +8,5 @@ urlpatterns = [
     path('set_last_term', set_last_term),
     path('save_courses', save_courses),
     path('get_saved_courses', get_saved_courses),
+    path('get_full_name', get_full_name),
 ]

--- a/autoscheduler/user_sessions/views.py
+++ b/autoscheduler/user_sessions/views.py
@@ -2,6 +2,7 @@ import json
 from rest_framework.response import Response
 from rest_framework.decorators import api_view, parser_classes
 from rest_framework.parsers import JSONParser
+from django.contrib.auth.models import User
 
 @api_view(['GET'])
 def get_last_term(request):
@@ -61,4 +62,15 @@ def get_saved_courses(request):
         courses = session.get(term, {}).get('courses')
         if courses:
             response = courses
+    return Response(response)
+
+@api_view(['GET'])
+def get_full_name(request):
+    """ View that retrieves the first and last name seperated by a space for the user
+    of the current session """
+    user_id = request.session.get('_auth_user_id')
+    if user_id is None:
+        return Response(status=400)
+    user = User.objects.get(pk=user_id)
+    response = {user.get_full_name()}
     return Response(response)

--- a/autoscheduler/user_sessions/views.py
+++ b/autoscheduler/user_sessions/views.py
@@ -72,5 +72,5 @@ def get_full_name(request):
     if user_id is None:
         return Response(status=400)
     user = User.objects.get(pk=user_id)
-    response = {user.get_full_name()}
+    response = {'full_name': user.get_full_name()}
     return Response(response)

--- a/autoscheduler/user_sessions/views.py
+++ b/autoscheduler/user_sessions/views.py
@@ -72,5 +72,5 @@ def get_full_name(request):
     if user_id is None:
         return Response(status=400)
     user = User.objects.get(pk=user_id)
-    response = {'full_name': user.get_full_name()}
+    response = {'fullName': user.get_full_name()}
     return Response(response)

--- a/autoscheduler/user_sessions/views.py
+++ b/autoscheduler/user_sessions/views.py
@@ -66,8 +66,9 @@ def get_saved_courses(request):
 
 @api_view(['GET'])
 def get_full_name(request):
-    """ View that retrieves the first and last name seperated by a space for the user
-    of the current session """
+    """ View that retrieves the first and last name separated by a space for the user
+          of the current session
+    """
     user_id = request.session.get('_auth_user_id')
     if user_id is None:
         return Response(status=400)


### PR DESCRIPTION
## Description

This pull request creates an API that allows for the logged in User's name to be retrieved. It is used to replace the login text where the login option used to let the user know their log in was successful. Should not be merged until after Social Auth.

## Rationale

Honestly kinda hard to do at the moment because it's not done and the name showing is kinda implemented poorly as it overwrites the login button text and ideally it would replace the button with a logout button or something that displayed the name but that would require a logout API (or clearing cookies) I think and that might be a separate PR.

## How to test

Despite the fact this shouldn't be merged until after Social Auth, I kinda needed code from that branch in order to get this one to work so I added that code to this branch. If you just boot up the localhost and login you should be able to see if the Google Login text was overwritten. Also, I still need to add tests for the API route.

## Screenshots

If it's a frontend change, provide screenshots of it. If possible, show the change on different
resolutions/sizes.

If you're changing a existing frontend look, provide a before and after screenshot in the table below.

|Before|After|
|--|--|
|Before Screenshot|After Screenshot|

## Related tasks

Closes #295
