### PR TITLE
Update GCP Database & Storage names

### DIFF
--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -18,7 +18,7 @@ jobs:
           DJANGO_SECRET: ${{ secrets.DJANGO_SECRET }}
 
       - name: Fill in Postgres credentials
-        run: bash fill_credentials.sh ${{ secrets.POSTGRES_USER }} ${{ secrets.POSTGRESS_PASS }}
+        run: bash fill_credentials.sh ${{ secrets.POSTGRES_USER }} ${{ secrets.POSTGRES_PASS }}
 
       - name: Initialize Google Cloud SDK
         uses: zxyle/publish-gae-action@master

--- a/autoscheduler/autoscheduler/settings/base.py
+++ b/autoscheduler/autoscheduler/settings/base.py
@@ -85,7 +85,7 @@ if _IS_GCP:
         'default': {
             'ENGINE': 'django.db.backends.postgresql',
             'NAME': 'postgres',
-            'HOST': '/cloudsql/revregistration:us-central1:revregistration',
+            'HOST': '/cloudsql/revregistration1:us-central1:db-revregistration',
             'USER': config.get_prop("user"),
             'PASSWORD': config.get_prop("password"),
         }
@@ -155,6 +155,6 @@ USE_TZ = True
 if _IS_GCP or _IS_STATIC:
     print("Using GCP/prod for static files")
     STATIC_ROOT = 'static'
-    STATIC_URL = 'https://storage.googleapis.com/revregistration.appspot.com'
+    STATIC_URL = 'https://storage.googleapis.com/revregistration1.appspot.com'
 else:
     STATIC_URL = '/static/'


### PR DESCRIPTION
## Description

In re-creating the GCP setup, the DB connection name & storage URL were changed, so this updates them. Frankly these should probably shouldn't be tracked / we should pass them in as secrets, but I don't want to change it (and it would be annoying for like using the proxy for updating the DB) so I'm leaving it alone for now.

## How to test

I made the deploy workflow work on pushes temporarily to test this, so visit http://revregistration1.appspot.com to check! 

## Related Tasks

Closes #250 