### PR TITLE
Made scrape_courses override previous data

### DIFF
--- a/autoscheduler/scraper/management/commands/scrape_courses.py
+++ b/autoscheduler/scraper/management/commands/scrape_courses.py
@@ -182,7 +182,9 @@ def parse_all_courses(course_list, term: str, courses_set: set,
 
     return (parse_course(course, courses_set, instructors_set) for course in course_list)
 
-def get_course_data(depts_terms) -> Tuple[List[Instructor], List[Section], List[Meeting], List[Course]]: # pylint: disable=too-many-locals
+def get_course_data(  # pylint: disable=too-many-locals
+        depts_terms,
+) -> Tuple[List[Instructor], List[Section], List[Meeting], List[Course]]:
     """ Retrieves all of the course data from Banner """
     # This limit is artifical for speed at this point,
     concurrent_limit = 50
@@ -214,14 +216,13 @@ def get_course_data(depts_terms) -> Tuple[List[Instructor], List[Section], List[
 
     return (instructors, sections, meetings, courses)
 
-def save_models(models_tuple: Tuple[List[Instructor], List[Section], List[Meeting], List[Course]],
-                term: int, terms: List[int], options):
+def save_models(instructors: List[Instructor], sections: List[Section], # pylint: disable=too-many-arguments
+                meetings: List[Meeting], courses: List[Course], term: int,
+                terms: List[int], options):
     """ Takes in a tuple of the models and attempts to save them
         "bulk updates" the models by deleting the according models then re-saving them
         in a single transaction.
     """
-    instructors, sections, meetings, courses = models_tuple
-
     start_save = time.time()
     start = time.time()
     Instructor.objects.bulk_create(instructors,
@@ -304,7 +305,7 @@ class Command(base.BaseCommand):
 
             depts_terms = get_department_names(terms)
 
-        models_tuple = get_course_data(depts_terms)
-        save_models(models_tuple, term, terms, options)
+        instructors, sections, meetings, courses = get_course_data(depts_terms)
+        save_models(instructors, sections, meetings, courses, term, terms, options)
 
         print(f"Finished scraping in {time.time() - start_all:.2f} seconds")

--- a/autoscheduler/scraper/management/commands/scrape_courses.py
+++ b/autoscheduler/scraper/management/commands/scrape_courses.py
@@ -257,18 +257,20 @@ class Command(base.BaseCommand):
             else:
                 queryset = Section.objects.all()
 
+            print("Starting to delete")
             queryset.delete()
+            print(f"Done deleting in {(time.time() - start):.2f}")
 
             Section.objects.bulk_create(sections, batch_size=50_000)
-        finish = time.time()
-        print(f"Saved {len(sections)} sections in {(finish-start):.2f} seconds")
+            finish = time.time()
+            print(f"Saved {len(sections)} sections in {(finish-start):.2f} seconds")
 
-        start = time.time()
-        # Deleting the Sections will cascade into deleting the Meetings,
-        # so no need to do it manually
-        Meeting.objects.bulk_create(meetings, batch_size=50_000)
-        finish = time.time()
-        print(f"Saved {len(meetings)} meetings in {(finish-start):.2f} seconds")
+            start = time.time()
+            # Deleting the Sections will cascade into deleting the Meetings,
+            # so no need to do it manually
+            Meeting.objects.bulk_create(meetings, batch_size=50_000)
+            finish = time.time()
+            print(f"Saved {len(meetings)} meetings in {(finish-start):.2f} seconds")
 
         start = time.time()
         with transaction.atomic():

--- a/autoscheduler/scraper/management/commands/scrape_courses.py
+++ b/autoscheduler/scraper/management/commands/scrape_courses.py
@@ -11,7 +11,7 @@ from scraper.banner_requests import BannerRequests
 from scraper.models import Course, Instructor, Section, Meeting, Department
 from scraper.models.course import generate_course_id
 from scraper.models.section import generate_meeting_id
-from scraper.management.commands.utils.scraper_utils import get_all_terms, slice_every
+from scraper.management.commands.utils.scraper_utils import get_all_terms
 
 # Set of the courses' ID's
 def convert_meeting_time(string_time: str) -> datetime.time:

--- a/autoscheduler/scraper/management/commands/scrape_grades.py
+++ b/autoscheduler/scraper/management/commands/scrape_grades.py
@@ -10,7 +10,6 @@ import bs4
 
 from django.core.management import base
 from scraper.management.commands.utils import pdf_parser
-from scraper.management.commands.utils.scraper_utils import slice_every
 
 # Needed since we have to import the specific models in the functions they're used in
 # due to multiprocessing
@@ -291,8 +290,8 @@ class Command(base.BaseCommand):
         # Save all of the models
         save_start = time.time()
         # ignore_conflicts is only so we can run this multiple times locally
-        for slc in slice_every(scraped_grades, 50_000):
-            Grades.objects.bulk_create(slc, ignore_conflicts=True)
+        Grades.objects.bulk_create(scraped_grades,
+                                   ignore_conflicts=True, batch_size=50_000)
         save_end = time.time()
         elapsed_time = save_end - save_start
         print(f"Saving {len(scraped_grades)} grades took {elapsed_time:.2f} sec")

--- a/autoscheduler/scraper/management/commands/utils/scraper_utils.py
+++ b/autoscheduler/scraper/management/commands/utils/scraper_utils.py
@@ -1,6 +1,6 @@
 from datetime import datetime
-from typing import Iterable, List
-from itertools import chain, islice, product
+from typing import List
+from itertools import product
 
 def get_all_terms(year: int = -1) -> List[str]:
     """ Generates all of the terms, from 2013 until now
@@ -21,18 +21,3 @@ def get_all_terms(year: int = -1) -> List[str]:
 
     return [f"{year}{semester}{location}"
             for year, semester, location in product(years, semesters, locations)]
-
-
-def slice_every(iterable: Iterable, n: int) -> Iterable[Iterable]:
-    """ Divides an iterable into slices of length n. Make sure you consume each slice
-        before trying to evaluate the next.
-    Args:
-        iterable: Any iterable
-        n: Size of each slice
-    Yields:
-        len(iterable)/n iterators of length n corresponding to all items in the iterable.
-    """
-    it = iter(iterable)
-    for first in it:
-        rest = islice(it, n-1)
-        yield chain([first], rest)


### PR DESCRIPTION
## Description

Previously `scrape_courses` wouldn't override the previous data in the database since `bulk_create` doesn't overwrite on conflicts. 
This makes it overwrite previous entries by deleting them & uploading them. Hopefully adding the `transaction.atomic()` makes all of these commit at once, so there isn't a window where the models won't exist.

## Rationale

I deleted `slice_every` since it's really not necessary, as `batch_size` for `bulk_create` provides the same functionality. Sorry Ryan 😢 

## How to test

Run `scrape_courses` for a given term and check if it updates it. A quick way to check if it updates it (assuming the last time you ran it was before the Fall 2020 courses were updated) is to run the server & check (for `202031`) if `CSCE 121 - 200` exists. Before the fall semester shift it existed, but afterwards it doesn't. 

## Related tasks

Closes #293 