### PR TITLE
No longer selects all options

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.tsx
@@ -115,7 +115,7 @@ const ExpandedCourseCard: React.FC<ExpandedCourseCardProps> = ({
           value={course}
           multiple={false}
           filterOptions={(): any[] => options} // Options are not filtered
-          getOptionSelected={(): boolean => true}
+          getOptionSelected={(option): boolean => option === options[0]}
           onClose={(): void => {
             if (!options.find((val) => val === inputValue)) setInputValue('');
           }}


### PR DESCRIPTION
## Description

`CourseSelectCard` used to show all options as selected, this quick PR patches that so that only the first option is selected by default

## Rationale

No test included because the functionality is mostly related to an external library (Material UI)

## How to test

Start typing in the `CourseSelectCard`. Only the first suggestion should be highlighted in gray.

## Screenshots

|Before|After|
|--|--|
|![before](https://user-images.githubusercontent.com/10082177/91732924-88118180-eb6e-11ea-864a-698f47df0602.jpg)|![after](https://user-images.githubusercontent.com/10082177/91732946-8e9ff900-eb6e-11ea-8918-699c98f8082a.jpg)|
