### PR TITLE
Fix bug with course name disappearing

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.tsx
@@ -117,7 +117,7 @@ const ExpandedCourseCard: React.FC<ExpandedCourseCardProps> = ({
           filterOptions={(): any[] => options} // Options are not filtered
           getOptionSelected={(): boolean => true}
           onClose={(): void => {
-            if (!options.find((val) => val === inputValue)) setInputValue('');
+            if (options.length === 0) setInputValue('');
           }}
           onChange={(_evt: object, val: string): void => {
             if (val) setLoading(true);


### PR DESCRIPTION
## Description

Used to be that if you selected the same course twice, the name would disappear. This was because I had a function that would clear the autocomplete if the input value didn't match any of the courses. since `CSCE 121` isn't going to exactly match `CSCE 121 - INTRO PRGM DESIGN CONCEPT`, I decided that a better way to do this would be to check if the `options` array returned by the backend was empty. That way, all filtering occurs at the backend level and the frontend just displays the results rather than applying any additional filtering.

## Rationale

I have no idea how to set up the mocks to test this bug. If anyone has any ideas, I'd be willing to try them out, but for now, I've just patched the bug.

## How to test

- Enter a course and select it so that it fetches sections for the course
- Instead of clicking the X, delete all the text and re-enter the same course
- Instead of the input losing focus, the course name will simply disappear and then re-appear when you manually click outside of it

Alse See #300 for a GIF of how to reproduce

## Related tasks

Closes #300 
