### PR TITLE
Rename schedules

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/Schedule.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/Schedule.tsx
@@ -22,7 +22,7 @@ const Schedule: React.FC = () => {
 
   // "props" derived from Redux store
   const schedule = useSelector<RootState, Meeting[]>(
-    (state) => state.schedules.allSchedules[state.selectedSchedule] || emptySchedule,
+    (state) => state.schedules[state.selectedSchedule]?.meetings || emptySchedule,
   );
   const availabilityList = useSelector<RootState, Availability[]>((state) => state.availability);
   const availabilityMode = useSelector<RootState, AvailabilityType>(

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/meetingColors.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/meetingColors.ts
@@ -8,9 +8,9 @@ export const colors = [
 
 export default function useMeetingColor(): Map<string, string> {
   const allSectionIds = new Set(useSelector<RootState, string[]>(
-    (state) => state.schedules.allSchedules.reduce<string[]>(
+    (state) => state.schedules.reduce<string[]>(
       (arr, schedule) => arr.concat(
-        schedule.map(
+        schedule.meetings.map(
           (meeting) => meeting.section.subject + meeting.section.courseNum,
         ),
       ),

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/Buttons/DeleteScheduleButton.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/Buttons/DeleteScheduleButton.tsx
@@ -6,7 +6,7 @@ import {
 import RemoveIcon from '@material-ui/icons/Delete';
 import { removeSchedule, unsaveSchedule } from '../../../../../redux/actions/schedules';
 import { RootState } from '../../../../../redux/reducer';
-import Meeting from '../../../../../types/Meeting';
+import Schedule from '../../../../../types/Schedule';
 
 interface DeleteScheduleButtonProps {
   index: number;
@@ -15,14 +15,9 @@ interface DeleteScheduleButtonProps {
 const DeleteScheduleButton: React.FC<DeleteScheduleButtonProps> = ({ index }) => {
   const dispatch = useDispatch();
 
-  const schedule = useSelector<RootState, Meeting[]>((state) => (
-    state.schedules.allSchedules[index]
+  const schedule = useSelector<RootState, Schedule>((state) => (
+    state.schedules[index]
   ));
-  const savedSchedules = useSelector<RootState, Meeting[][]>((state) => (
-    state.schedules.savedSchedules
-  ));
-
-  const saved = savedSchedules.includes(schedule);
 
   const [dialogOpen, setDialogOpen] = React.useState(false);
 
@@ -38,7 +33,7 @@ const DeleteScheduleButton: React.FC<DeleteScheduleButtonProps> = ({ index }) =>
 
   const handleDeleteButtonClick = (): void => {
     // Show dialog confirmation if schedule is saved, otherwise just delete it
-    if (saved) setDialogOpen(true);
+    if (schedule.saved) setDialogOpen(true);
     else deleteSchedule();
   };
 

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/Buttons/DeleteScheduleButton.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/Buttons/DeleteScheduleButton.tsx
@@ -70,7 +70,7 @@ const DeleteScheduleButton: React.FC<DeleteScheduleButtonProps> = ({ index }) =>
         </DialogTitle>
         <DialogContent>
           <DialogContentText>
-            {`This schedule is saved. Are you sure you want to delete schedule ${index + 1}?`}
+            {`This schedule is saved. Are you sure you want to delete ${schedule.name}?`}
           </DialogContentText>
         </DialogContent>
         <DialogActions>

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/Buttons/SaveScheduleButton.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/Buttons/SaveScheduleButton.tsx
@@ -4,9 +4,7 @@ import { IconButton, Tooltip } from '@material-ui/core';
 import LockIcon from '@material-ui/icons/Lock';
 import LockOpenIcon from '@material-ui/icons/LockOpen';
 import { saveSchedule, unsaveSchedule } from '../../../../../redux/actions/schedules';
-import { containsSchedule } from '../../../../../redux/reducers/schedules';
 import { RootState } from '../../../../../redux/reducer';
-import Meeting from '../../../../../types/Meeting';
 
 interface SaveScheduleButtonProps {
   index: number;
@@ -15,18 +13,7 @@ interface SaveScheduleButtonProps {
 const SaveScheduleButton: React.FC<SaveScheduleButtonProps> = ({ index }) => {
   const dispatch = useDispatch();
 
-  const allSchedules = useSelector<RootState, Meeting[][]>((state) => state.schedules.allSchedules);
-  const savedSchedules = useSelector<RootState, Meeting[][]>((state) => (
-    state.schedules.savedSchedules
-  ));
-
-  const [saved, setSaved] = React.useState(false);
-
-  // schedule indices may change when schedules is changed, so refresh state whenever this happens
-  // or whenever saved schedules change
-  React.useEffect(() => {
-    setSaved(containsSchedule(savedSchedules, allSchedules[index]));
-  }, [allSchedules, savedSchedules, index]);
+  const saved = useSelector<RootState, boolean>((state) => state.schedules[index].saved);
 
   // TODO: Once API for saving schedules is created, call it here
   const handleClick = (event: React.MouseEvent<HTMLElement>): void => {

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/Buttons/ScheduleName.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/Buttons/ScheduleName.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import { IconButton, TextField, Tooltip } from '@material-ui/core';
+import DoneIcon from '@material-ui/icons/Done';
+import EditIcon from '@material-ui/icons/Edit';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from '../../../../../redux/reducer';
+import * as styles from '../../SchedulePreview.css';
+import { renameSchedule } from '../../../../../redux/actions/schedules';
+
+interface ScheduleNameProps {
+  index: number;
+}
+
+const ScheduleName: React.FC<ScheduleNameProps> = ({ index }) => {
+  const dispatch = useDispatch();
+
+  const savedName = useSelector<RootState, string>((state) => state.schedules[index].name);
+
+  const [renaming, setRenaming] = React.useState(false);
+  const [currentName, setCurrentName] = React.useState(savedName);
+
+  const renameButtonIcon = renaming ? <DoneIcon fontSize="inherit" /> : <EditIcon fontSize="inherit" />;
+
+  const tooltipText = renaming ? 'Done' : 'Rename';
+
+  const handleClick = (): void => {
+    if (renaming) {
+      // Don't let user set an empty name
+      if (currentName) {
+        dispatch(renameSchedule(index, currentName));
+        setRenaming(false);
+      }
+    } else setRenaming(true);
+  };
+
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLElement>): void => {
+    // Allow user to confirm name by pressing enter or cancel with escape
+    if (renaming) {
+      if (e.key === 'Enter') handleClick();
+      else if (e.key === 'Escape') {
+        setCurrentName(savedName);
+        setRenaming(false);
+      }
+    }
+  };
+
+  const nameComponent = renaming ? (
+    <TextField
+      className={styles.enablePointerEvents}
+      size="small"
+      defaultValue={savedName}
+      onChange={(e): void => setCurrentName(e.target.value)}
+      onKeyPress={handleKeyPress}
+      autoFocus
+    />
+  ) : (
+    // Allow clicking through text if not editing name
+    <span>
+      {savedName}
+    </span>
+  );
+
+  const renameButton = (
+    <Tooltip title={tooltipText} placement="top">
+      <IconButton className={styles.enablePointerEvents} size="small" onClick={handleClick} aria-label="Rename schedule">
+        {renameButtonIcon}
+      </IconButton>
+    </Tooltip>
+  );
+
+  return (
+    <div className={styles.scheduleNameContainer}>
+      {nameComponent}
+      {renameButton}
+    </div>
+  );
+};
+
+export default ScheduleName;

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/Buttons/ScheduleName.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/Buttons/ScheduleName.tsx
@@ -26,7 +26,7 @@ const ScheduleName: React.FC<ScheduleNameProps> = ({ index }) => {
   const handleClick = (): void => {
     if (renaming) {
       // Don't let user set an empty name
-      if (currentName) {
+      if (currentName.trim()) {
         dispatch(renameSchedule(index, currentName));
         setRenaming(false);
       }
@@ -47,12 +47,13 @@ const ScheduleName: React.FC<ScheduleNameProps> = ({ index }) => {
   const nameComponent = renaming ? (
     <TextField
       className={styles.enablePointerEvents}
-      size="small"
       defaultValue={savedName}
+      fullWidth
       onChange={(e): void => setCurrentName(e.target.value)}
       onKeyDown={handleKeyPress}
       autoFocus
-      inputProps={{ 'aria-label': 'Schedule name' }}
+      onFocus={(e): void => e.target.select()}
+      inputProps={{ 'aria-label': 'Schedule name', style: { paddingTop: 7 } }}
     />
   ) : (
     // Allow clicking through text if not editing name

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/Buttons/ScheduleName.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/Buttons/ScheduleName.tsx
@@ -56,14 +56,19 @@ const ScheduleName: React.FC<ScheduleNameProps> = ({ index }) => {
     />
   ) : (
     // Allow clicking through text if not editing name
-    <span>
+    <span className={styles.scheduleNameText}>
       {savedName}
     </span>
   );
 
   const renameButton = (
     <Tooltip title={tooltipText} placement="top">
-      <IconButton className={styles.enablePointerEvents} size="small" onClick={handleClick} aria-label="Rename schedule">
+      <IconButton
+        className={`${styles.enablePointerEvents} ${styles.noFlexShrink}`}
+        size="small"
+        onClick={handleClick}
+        aria-label="Rename schedule"
+      >
         {renameButtonIcon}
       </IconButton>
     </Tooltip>

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/Buttons/ScheduleName.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/Buttons/ScheduleName.tsx
@@ -50,7 +50,7 @@ const ScheduleName: React.FC<ScheduleNameProps> = ({ index }) => {
       size="small"
       defaultValue={savedName}
       onChange={(e): void => setCurrentName(e.target.value)}
-      onKeyPress={handleKeyPress}
+      onKeyDown={handleKeyPress}
       autoFocus
       inputProps={{ 'aria-label': 'Schedule name' }}
     />

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/Buttons/ScheduleName.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/Buttons/ScheduleName.tsx
@@ -52,6 +52,7 @@ const ScheduleName: React.FC<ScheduleNameProps> = ({ index }) => {
       onChange={(e): void => setCurrentName(e.target.value)}
       onKeyPress={handleKeyPress}
       autoFocus
+      inputProps={{ 'aria-label': 'Schedule name' }}
     />
   ) : (
     // Allow clicking through text if not editing name

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/Buttons/ScheduleName.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/Buttons/ScheduleName.tsx
@@ -75,8 +75,11 @@ const ScheduleName: React.FC<ScheduleNameProps> = ({ index }) => {
     </Tooltip>
   );
 
+  // Take full width if renaming
+  const nameContainerStyles = renaming ? { width: '100%' } : {};
+
   return (
-    <div className={styles.scheduleNameContainer}>
+    <div className={styles.scheduleNameContainer} style={nameContainerStyles}>
       {nameComponent}
       {renameButton}
     </div>

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ScheduleListItem.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ScheduleListItem.tsx
@@ -15,6 +15,7 @@ import DeleteScheduleButton from './Buttons/DeleteScheduleButton';
 import { RootState } from '../../../../redux/reducer';
 import Schedule from '../../../../types/Schedule';
 import ScheduleName from './Buttons/ScheduleName';
+import useDimensions from '../../../../hooks/useDimensions';
 
 interface ScheduleListItemProps {
   index: number;
@@ -53,18 +54,21 @@ const ScheduleListItem: React.FC<ScheduleListItemProps> = ({ index }) => {
   ));
   const selectedSchedule = useSelector<RootState, number>((state) => state.selectedSchedule);
 
-  // Dynamically create style for buttons to place them after the schedule name,
-  // since absolute positioning must be used to place a button inside another button
-  const scheduleNameRef = React.useRef(null);
-
   const meetingColors = useMeetingColor();
 
+  // Dynamically create style for schedule name and buttons to position them properly
+  // since absolute positioning must be used to place a button inside another button
+  const scheduleNameRef = React.useRef(null);
+  const nameDimensions = useDimensions(scheduleNameRef);
+
   const buttonContainerStyle: React.CSSProperties = {
-    top: scheduleNameRef.current?.offsetTop + (scheduleNameRef.current?.offsetHeight / 2) || 0,
-    left: scheduleNameRef.current?.offsetLeft + scheduleNameRef.current?.offsetWidth || 0,
     // Disable pointer events so that schedule name can be clicked through, it will be re-enabled
     // on each clickable element
     pointerEvents: 'none',
+    // Determine proper positioning and width
+    top: nameDimensions.top + (nameDimensions.height / 2),
+    left: nameDimensions.left,
+    maxWidth: nameDimensions.width,
   };
 
   return (
@@ -83,10 +87,10 @@ const ScheduleListItem: React.FC<ScheduleListItemProps> = ({ index }) => {
       <ListItemText
         primary={(
           <>
-            <div>
-              {/* This element exists to reserve vertical space for the schedule name + buttons,
-                  and is used  as a ref for where to place those components */}
-              <span ref={scheduleNameRef} className={styles.hidden}>
+            {/* This element exists to reserve vertical space for the schedule name + buttons,
+                and is used  as a ref for where to place those components */}
+            <div ref={scheduleNameRef}>
+              <span className={styles.hidden}>
                 .
               </span>
             </div>
@@ -116,7 +120,7 @@ const ScheduleListItem: React.FC<ScheduleListItemProps> = ({ index }) => {
       <ListItemSecondaryAction style={buttonContainerStyle}>
         <div className={styles.scheduleHeader}>
           <ScheduleName index={index} />
-          <span className={styles.enablePointerEvents}>
+          <span className={`${styles.enablePointerEvents} ${styles.noFlexShrink}`}>
             <SaveScheduleButton index={index} />
             <DeleteScheduleButton index={index} />
           </span>

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ScheduleListItem.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ScheduleListItem.tsx
@@ -13,6 +13,7 @@ import useMeetingColor from '../../Schedule/meetingColors';
 import SaveScheduleButton from './Buttons/SaveScheduleButton';
 import DeleteScheduleButton from './Buttons/DeleteScheduleButton';
 import { RootState } from '../../../../redux/reducer';
+import Schedule from '../../../../types/Schedule';
 
 interface ScheduleListItemProps {
   index: number;
@@ -46,8 +47,8 @@ export function getAverageGPATextForSchedule(schedule: Meeting[]): string {
 const ScheduleListItem: React.FC<ScheduleListItemProps> = ({ index }) => {
   const dispatch = useDispatch();
 
-  const schedule = useSelector<RootState, Meeting[]>((state) => (
-    state.schedules.allSchedules[index]
+  const schedule = useSelector<RootState, Schedule>((state) => (
+    state.schedules[index]
   ));
   const selectedSchedule = useSelector<RootState, number>((state) => state.selectedSchedule);
 
@@ -79,17 +80,17 @@ const ScheduleListItem: React.FC<ScheduleListItemProps> = ({ index }) => {
           <>
             <div className={styles.scheduleHeader}>
               <span ref={scheduleNameRef}>
-                {`Schedule ${index + 1}`}
+                {schedule.name}
               </span>
             </div>
             <Typography className={styles.gpa} variant="subtitle2">
-              {getAverageGPATextForSchedule(schedule)}
+              {getAverageGPATextForSchedule(schedule.meetings)}
             </Typography>
           </>
         )}
         secondary={
           // get unique sections, assuming that meetings from the same section are adjacent
-          schedule.reduce((acc, curr): Section[] => {
+          schedule.meetings.reduce((acc, curr): Section[] => {
             const lastSection = acc[acc.length - 1];
             if (!lastSection || lastSection.id !== curr.section.id) {
               return acc.concat(curr.section);
@@ -104,7 +105,7 @@ const ScheduleListItem: React.FC<ScheduleListItemProps> = ({ index }) => {
           ))
         }
       />
-      <MiniSchedule schedule={schedule} />
+      <MiniSchedule schedule={schedule.meetings} />
       <ListItemSecondaryAction style={buttonContainerStyle}>
         <SaveScheduleButton index={index} />
         <DeleteScheduleButton index={index} />

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ScheduleListItem.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ScheduleListItem.tsx
@@ -14,6 +14,7 @@ import SaveScheduleButton from './Buttons/SaveScheduleButton';
 import DeleteScheduleButton from './Buttons/DeleteScheduleButton';
 import { RootState } from '../../../../redux/reducer';
 import Schedule from '../../../../types/Schedule';
+import ScheduleName from './Buttons/ScheduleName';
 
 interface ScheduleListItemProps {
   index: number;
@@ -58,9 +59,12 @@ const ScheduleListItem: React.FC<ScheduleListItemProps> = ({ index }) => {
 
   const meetingColors = useMeetingColor();
 
-  const buttonContainerStyle = {
+  const buttonContainerStyle: React.CSSProperties = {
     top: scheduleNameRef.current?.offsetTop + (scheduleNameRef.current?.offsetHeight / 2) || 0,
     left: scheduleNameRef.current?.offsetLeft + scheduleNameRef.current?.offsetWidth || 0,
+    // Disable pointer events so that schedule name can be clicked through, it will be re-enabled
+    // on each clickable element
+    pointerEvents: 'none',
   };
 
   return (
@@ -74,13 +78,16 @@ const ScheduleListItem: React.FC<ScheduleListItemProps> = ({ index }) => {
       // Having a ListItemSecondaryAction overrides the padding-right to 48px, which we don't want
       // The classes prop is injected before material ui classes, so style is used here instead
       style={{ paddingRight: 16 }}
+      aria-label="Schedule preview"
     >
       <ListItemText
         primary={(
           <>
-            <div className={styles.scheduleHeader}>
-              <span ref={scheduleNameRef}>
-                {schedule.name}
+            <div>
+              {/* This element exists to reserve vertical space for the schedule name + buttons,
+                  and is used  as a ref for where to place those components */}
+              <span ref={scheduleNameRef} className={styles.hidden}>
+                .
               </span>
             </div>
             <Typography className={styles.gpa} variant="subtitle2">
@@ -107,8 +114,13 @@ const ScheduleListItem: React.FC<ScheduleListItemProps> = ({ index }) => {
       />
       <MiniSchedule schedule={schedule.meetings} />
       <ListItemSecondaryAction style={buttonContainerStyle}>
-        <SaveScheduleButton index={index} />
-        <DeleteScheduleButton index={index} />
+        <div className={styles.scheduleHeader}>
+          <ScheduleName index={index} />
+          <span className={styles.enablePointerEvents}>
+            <SaveScheduleButton index={index} />
+            <DeleteScheduleButton index={index} />
+          </span>
+        </div>
       </ListItemSecondaryAction>
     </ListItem>
   );

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css
@@ -31,6 +31,13 @@
 .schedule-name-container {
     display: flex;
     align-items: center;
+    min-width: 0px;
+}
+
+.schedule-name-text {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 }
 
 .list-item-with-preview {
@@ -56,8 +63,13 @@
     visibility: hidden;
     display: block;
     width: 0px;
+    padding-bottom: 4px;
 }
 
 .enable-pointer-events {
     pointer-events: all;
+}
+
+.no-flex-shrink {
+    flex-shrink: 0;
 }

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css
@@ -25,7 +25,12 @@
 
 .schedule-header {
     display: flex;
-    align-items: flex-end;
+    align-items: center;
+}
+
+.schedule-name-container {
+    display: flex;
+    align-items: center;
 }
 
 .list-item-with-preview {
@@ -45,4 +50,14 @@
     margin-right: 4px;
     width: 12px;
     height: 12px;
+}
+
+.hidden {
+    visibility: hidden;
+    display: block;
+    width: 0px;
+}
+
+.enable-pointer-events {
+    pointer-events: all;
 }

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css.d.ts
@@ -6,14 +6,19 @@ declare namespace SchedulePreviewCssNamespace {
     colorBox: string;
     "configure-card": string;
     configureCard: string;
+    "enable-pointer-events": string;
+    enablePointerEvents: string;
     gpa: string;
+    hidden: string;
     list: string;
     "list-item-with-preview": string;
     listItemWithPreview: string;
     "no-schedules": string;
     noSchedules: string;
     "schedule-header": string;
+    "schedule-name-container": string;
     scheduleHeader: string;
+    scheduleNameContainer: string;
     "section-label-row": string;
     sectionLabelRow: string;
   }

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css.d.ts
@@ -13,12 +13,16 @@ declare namespace SchedulePreviewCssNamespace {
     list: string;
     "list-item-with-preview": string;
     listItemWithPreview: string;
+    "no-flex-shrink": string;
     "no-schedules": string;
+    noFlexShrink: string;
     noSchedules: string;
     "schedule-header": string;
     "schedule-name-container": string;
+    "schedule-name-text": string;
     scheduleHeader: string;
     scheduleNameContainer: string;
+    scheduleNameText: string;
     "section-label-row": string;
     sectionLabelRow: string;
   }

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
@@ -3,17 +3,16 @@ import { useSelector } from 'react-redux';
 import { List } from '@material-ui/core';
 import GenericCard from '../../GenericCard/GenericCard';
 import { RootState } from '../../../redux/reducer';
-import Meeting from '../../../types/Meeting';
 import * as styles from './SchedulePreview.css';
 import ScheduleListItem from './ScheduleListItem/ScheduleListItem';
+import Schedule from '../../../types/Schedule';
 
 const SchedulePreview: React.FC = () => {
-  const schedules = useSelector<RootState, Meeting[][]>((state) => state.schedules.allSchedules);
+  const schedules = useSelector<RootState, Schedule[]>((state) => state.schedules);
 
   const scheduleListItems = schedules.length === 0
     ? <p className={styles.noSchedules}>No schedules available.</p>
-    // eslint-disable-next-line react/no-array-index-key
-    : schedules.map((schedule, idx) => <ScheduleListItem index={idx} key={idx} />);
+    : schedules.map((schedule, idx) => <ScheduleListItem index={idx} key={schedule.name} />);
 
   return (
     <GenericCard

--- a/autoscheduler/frontend/src/hooks/useDimensions.ts
+++ b/autoscheduler/frontend/src/hooks/useDimensions.ts
@@ -1,0 +1,37 @@
+import * as React from 'react';
+
+interface Dimensions {
+  width: number;
+  height: number;
+  left: number;
+  top: number;
+}
+
+// Returns dimensions of a ref, responsive to resizing
+export default function useDimensions(ref: React.MutableRefObject<any>): Dimensions {
+  const [dimensions, setDimensions] = React.useState<Dimensions>({
+    width: 0,
+    height: 0,
+    left: 0,
+    top: 0,
+  });
+
+  // Update dimensions on ref change or resize
+  React.useEffect(() => {
+    const updateDimensions = (): void => {
+      setDimensions({
+        width: ref.current?.offsetWidth || 0,
+        height: ref.current?.offsetHeight || 0,
+        left: ref.current?.offsetLeft || 0,
+        top: ref.current?.offsetTop || 0,
+      });
+    };
+
+    updateDimensions();
+    window.addEventListener('resize', updateDimensions);
+
+    return (): void => window.removeEventListener('resize', updateDimensions);
+  }, [ref]);
+
+  return dimensions;
+}

--- a/autoscheduler/frontend/src/redux/actions/schedules.ts
+++ b/autoscheduler/frontend/src/redux/actions/schedules.ts
@@ -1,7 +1,7 @@
 import {
   AddScheduleAction, ADD_SCHEDULE, RemoveScheduleAction, REMOVE_SCHEDULE,
   ReplaceSchedulesAction, REPLACE_SCHEDULES, SaveScheduleAction, SAVE_SCHEDULE,
-  UnsaveScheduleAction, UNSAVE_SCHEDULE,
+  UnsaveScheduleAction, UNSAVE_SCHEDULE, RenameScheduleAction, RENAME_SCHEDULE,
 } from '../reducers/schedules';
 import Meeting from '../../types/Meeting';
 
@@ -37,5 +37,13 @@ export function unsaveSchedule(index: number): UnsaveScheduleAction {
   return {
     type: UNSAVE_SCHEDULE,
     index,
+  };
+}
+
+export function renameSchedule(index: number, name: string): RenameScheduleAction {
+  return {
+    type: RENAME_SCHEDULE,
+    index,
+    name,
   };
 }

--- a/autoscheduler/frontend/src/redux/actions/schedules.ts
+++ b/autoscheduler/frontend/src/redux/actions/schedules.ts
@@ -5,10 +5,10 @@ import {
 } from '../reducers/schedules';
 import Meeting from '../../types/Meeting';
 
-export function addSchedule(schedule: Meeting[]): AddScheduleAction {
+export function addSchedule(meetings: Meeting[]): AddScheduleAction {
   return {
     type: ADD_SCHEDULE,
-    schedule,
+    meetings,
   };
 }
 

--- a/autoscheduler/frontend/src/redux/reducers/schedules.ts
+++ b/autoscheduler/frontend/src/redux/reducers/schedules.ts
@@ -51,14 +51,19 @@ const getUniqueName = (
   index: number = undefined,
 ): string => {
   const existingNames = new Set(existingSchedules.map((schedule) => schedule.name));
+  // If this schedule already exists, disregard it when checking existing names
   if (index !== undefined) existingNames.delete(existingSchedules[index].name);
 
-  let name = preferredName || 'Schedule 1';
-  let number = 1;
+  // Trim whitespace from preferred name
+  const baseName = preferredName?.trim();
+  let name = baseName || 'Schedule 1';
+
+  // Default names start counting from 1, if a name is preferred the first copy is called name (1)
+  let number = preferredName ? 0 : 1;
 
   while (existingNames.has(name)) {
     number += 1;
-    name = preferredName ? `${preferredName} (${number})` : `Schedule ${number}`;
+    name = baseName ? `${baseName} (${number})` : `Schedule ${number}`;
   }
 
   return name;

--- a/autoscheduler/frontend/src/redux/reducers/schedules.ts
+++ b/autoscheduler/frontend/src/redux/reducers/schedules.ts
@@ -3,6 +3,7 @@
  * schedule that the user can choose from
  */
 import Meeting from '../../types/Meeting';
+import Schedule from '../../types/Schedule';
 
 // action type strings
 export const ADD_SCHEDULE = 'ADD_SCHEDULE';
@@ -14,7 +15,7 @@ export const UNSAVE_SCHEDULE = 'UNSAVE_SCHEDULE';
 // action type interfaces
 export interface AddScheduleAction {
     type: 'ADD_SCHEDULE';
-    schedule: Meeting[];
+    meetings: Meeting[];
 }
 export interface RemoveScheduleAction {
     type: 'REMOVE_SCHEDULE';
@@ -35,66 +36,91 @@ export interface UnsaveScheduleAction {
 export type ScheduleAction = AddScheduleAction | RemoveScheduleAction
   | ReplaceSchedulesAction | SaveScheduleAction | UnsaveScheduleAction;
 
-interface Schedules {
-  allSchedules: Meeting[][];
-  savedSchedules: Meeting[][];
-}
+const initialSchedules: Schedule[] = [];
 
-const initialSchedules: Schedules = {
-  allSchedules: [],
-  savedSchedules: [],
+// Helper function to create a new function with the default name (Schedule x),
+// where x is the lowest number schedule not already taken
+const createSchedule = (meetings: Meeting[], existingSchedules: Schedule[]): Schedule => {
+  // Ensure schedule with name doesn't already exist
+  let idx = 1;
+  let name;
+  const existingNames = new Set(existingSchedules.map((schedule) => schedule.name));
+  do {
+    name = `Schedule ${idx}`;
+    idx += 1;
+  } while (existingNames.has(name));
+
+  return {
+    meetings,
+    name,
+    saved: false,
+  };
 };
 
+// Creates a copy of oldSchedules that will create new references for each schedule.
+// Note that the meetings array will still use the same reference.
+const cloneSchedules = (oldSchedules: Schedule[]): Schedule[] => (
+  [...oldSchedules].map((schedule) => ({ ...schedule }))
+);
+
 // returns whether a list of schedules contains a schedule with the same meetings as schedule
-export function containsSchedule(schedules: Meeting[][], schedule: Meeting[]): boolean {
+export function containsSchedule(allSchedules: Schedule[], schedule: Meeting[]): boolean {
   const scheduleMeetings = new Set(schedule.map((meeting) => meeting.id));
-  return schedules.some((toCompare) => {
-    const toCompareMeetings = new Set(toCompare.map((meeting) => meeting.id));
+  return allSchedules.some((toCompare) => {
+    const toCompareMeetings = new Set(toCompare.meetings.map((meeting) => meeting.id));
     return scheduleMeetings.size === toCompareMeetings.size
       && [...scheduleMeetings].every((meeting) => toCompareMeetings.has(meeting));
   });
 }
 
-function getUniqueSchedules(...schedules: Meeting[][]): Meeting[][] {
-  const unique: Meeting[][] = [];
-  schedules.forEach((schedule) => {
-    if (!containsSchedule(unique, schedule)) unique.push(schedule);
+function getUniqueSchedules(allSchedules: Schedule[]): Schedule[] {
+  const unique: Schedule[] = [];
+  allSchedules.forEach((schedule) => {
+    if (!containsSchedule(unique, schedule.meetings)) unique.push(schedule);
   });
   return unique;
 }
 
 // reducer
-function meetings(state: Schedules = initialSchedules, action: ScheduleAction): Schedules {
+function schedules(state: Schedule[] = initialSchedules, action: ScheduleAction): Schedule[] {
   switch (action.type) {
-    case ADD_SCHEDULE:
-      return { ...state, allSchedules: [...state.allSchedules, action.schedule] };
-    case REMOVE_SCHEDULE:
-      return {
-        ...state,
-        allSchedules: state.allSchedules.slice(0, action.index)
-          .concat(state.allSchedules.slice(action.index + 1)),
-      };
-    case REPLACE_SCHEDULES:
-      return {
-        ...state,
-        allSchedules: getUniqueSchedules(...state.savedSchedules, ...action.schedules),
-      };
-    case SAVE_SCHEDULE:
-      return {
-        ...state,
-        savedSchedules: state.savedSchedules
-          .concat(containsSchedule(state.savedSchedules, state.allSchedules[action.index])
-            ? [] : [state.allSchedules[action.index]]),
-      };
-    case UNSAVE_SCHEDULE:
-      return {
-        ...state,
-        savedSchedules: state.savedSchedules.filter((schedule) => (
-          schedule !== state.allSchedules[action.index])),
-      };
+    case ADD_SCHEDULE: {
+      const newState = cloneSchedules(state);
+      newState.push(createSchedule(action.meetings, newState));
+      return newState;
+    }
+    case REMOVE_SCHEDULE: {
+      const newState = cloneSchedules(state);
+      newState.splice(action.index, 1);
+      return newState;
+    }
+    case REPLACE_SCHEDULES: {
+      // Copy each saved schedule
+      const newState: Schedule[] = [];
+      state.forEach((schedule) => {
+        if (schedule.saved) newState.push({ ...schedule });
+      });
+
+      // Add all new schedules
+      action.schedules.forEach((meetings) => {
+        newState.push(createSchedule(meetings, newState));
+      });
+
+      return getUniqueSchedules(newState);
+    }
+    case SAVE_SCHEDULE: {
+      const newState = cloneSchedules(state);
+      newState[action.index].saved = true;
+      return newState;
+    }
+    case UNSAVE_SCHEDULE: {
+      const newState = cloneSchedules(state);
+      newState[action.index].saved = false;
+      return newState;
+    }
     default:
       return state;
   }
 }
 
-export default meetings;
+export default schedules;

--- a/autoscheduler/frontend/src/redux/reducers/schedules.ts
+++ b/autoscheduler/frontend/src/redux/reducers/schedules.ts
@@ -77,12 +77,6 @@ const createSchedule = (meetings: Meeting[], existingSchedules: Schedule[]): Sch
   saved: false,
 });
 
-// Creates a copy of oldSchedules that will create new references for each schedule.
-// Note that the meetings array will still use the same reference.
-const cloneSchedules = (oldSchedules: Schedule[]): Schedule[] => (
-  [...oldSchedules].map((schedule) => ({ ...schedule }))
-);
-
 // returns whether a list of schedules contains a schedule with the same meetings as schedule
 export function containsSchedule(allSchedules: Schedule[], schedule: Meeting[]): boolean {
   const scheduleMeetings = new Set(schedule.map((meeting) => meeting.id));
@@ -105,21 +99,16 @@ function getUniqueSchedules(allSchedules: Schedule[]): Schedule[] {
 function schedules(state: Schedule[] = initialSchedules, action: ScheduleAction): Schedule[] {
   switch (action.type) {
     case ADD_SCHEDULE: {
-      const newState = cloneSchedules(state);
-      newState.push(createSchedule(action.meetings, newState));
-      return newState;
+      return [...state, createSchedule(action.meetings, state)];
     }
     case REMOVE_SCHEDULE: {
-      const newState = cloneSchedules(state);
+      const newState = [...state];
       newState.splice(action.index, 1);
       return newState;
     }
     case REPLACE_SCHEDULES: {
       // Copy each saved schedule
-      const newState: Schedule[] = [];
-      state.forEach((schedule) => {
-        if (schedule.saved) newState.push({ ...schedule });
-      });
+      const newState: Schedule[] = state.filter((schedule) => schedule.saved);
 
       // Add all new schedules
       action.schedules.forEach((meetings) => {
@@ -129,18 +118,21 @@ function schedules(state: Schedule[] = initialSchedules, action: ScheduleAction)
       return getUniqueSchedules(newState);
     }
     case SAVE_SCHEDULE: {
-      const newState = cloneSchedules(state);
-      newState[action.index].saved = true;
+      const newState = [...state];
+      newState[action.index] = { ...newState[action.index], saved: true };
       return newState;
     }
     case UNSAVE_SCHEDULE: {
-      const newState = cloneSchedules(state);
-      newState[action.index].saved = false;
+      const newState = [...state];
+      newState[action.index] = { ...newState[action.index], saved: false };
       return newState;
     }
     case RENAME_SCHEDULE: {
-      const newState = cloneSchedules(state);
-      newState[action.index].name = getUniqueName(newState, action.name, action.index);
+      const newState = [...state];
+      newState[action.index] = {
+        ...newState[action.index],
+        name: getUniqueName(newState, action.name, action.index),
+      };
       return newState;
     }
     default:

--- a/autoscheduler/frontend/src/tests/redux/Schedule.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/Schedule.test.ts
@@ -160,8 +160,8 @@ describe('Schedule Redux', () => {
       store.dispatch(addSchedule(schedule2));
 
       // assert
-      expect(store.getState().schedules.allSchedules).toContainEqual(schedule1);
-      expect(store.getState().schedules.allSchedules).toContainEqual(schedule2);
+      expect(store.getState().schedules[0].meetings).toEqual(schedule1);
+      expect(store.getState().schedules[1].meetings).toEqual(schedule2);
     });
   });
 
@@ -177,9 +177,9 @@ describe('Schedule Redux', () => {
       store.dispatch(removeSchedule(0));
 
       // assert
-      expect(store.getState().schedules.allSchedules).not.toContainEqual(schedule1);
-      expect(store.getState().schedules.allSchedules).toContainEqual(schedule2);
-      expect(store.getState().schedules.allSchedules).toContainEqual(schedule3);
+      expect(store.getState().schedules).toHaveLength(2);
+      expect(store.getState().schedules[0].meetings).toEqual(schedule2);
+      expect(store.getState().schedules[1].meetings).toEqual(schedule3);
     });
 
     test('when the middle schedule is deleted', () => {
@@ -193,9 +193,9 @@ describe('Schedule Redux', () => {
       store.dispatch(removeSchedule(1));
 
       // assert
-      expect(store.getState().schedules.allSchedules).toContainEqual(schedule1);
-      expect(store.getState().schedules.allSchedules).not.toContainEqual(schedule2);
-      expect(store.getState().schedules.allSchedules).toContainEqual(schedule3);
+      expect(store.getState().schedules).toHaveLength(2)
+      expect(store.getState().schedules[0].meetings).toEqual(schedule1);
+      expect(store.getState().schedules[1].meetings).toEqual(schedule3);
     });
 
     test('when the last schedule is deleted', () => {
@@ -209,9 +209,9 @@ describe('Schedule Redux', () => {
       store.dispatch(removeSchedule(2));
 
       // assert
-      expect(store.getState().schedules.allSchedules).toContainEqual(schedule1);
-      expect(store.getState().schedules.allSchedules).toContainEqual(schedule2);
-      expect(store.getState().schedules.allSchedules).not.toContainEqual(schedule3);
+      expect(store.getState().schedules).toHaveLength(2)
+      expect(store.getState().schedules[0].meetings).toEqual(schedule1);
+      expect(store.getState().schedules[1].meetings).toEqual(schedule2);
     });
   });
 
@@ -225,9 +225,9 @@ describe('Schedule Redux', () => {
       store.dispatch(replaceSchedules([schedule2, schedule3]));
 
       // assert
-      expect(store.getState().schedules.allSchedules).not.toContainEqual(schedule1);
-      expect(store.getState().schedules.allSchedules).toContainEqual(schedule2);
-      expect(store.getState().schedules.allSchedules).toContainEqual(schedule3);
+      expect(store.getState().schedules).toHaveLength(2);
+      expect(store.getState().schedules[0].meetings).toEqual(schedule2);
+      expect(store.getState().schedules[1].meetings).toEqual(schedule3);
     });
 
     test('when a schedule is saved and then unsaved', () => {
@@ -241,9 +241,9 @@ describe('Schedule Redux', () => {
       store.dispatch(replaceSchedules([schedule2, schedule3]));
 
       // assert
-      expect(store.getState().schedules.allSchedules).not.toContainEqual(schedule1);
-      expect(store.getState().schedules.allSchedules).toContainEqual(schedule2);
-      expect(store.getState().schedules.allSchedules).toContainEqual(schedule3);
+      expect(store.getState().schedules).toHaveLength(2);
+      expect(store.getState().schedules[0].meetings).toEqual(schedule2);
+      expect(store.getState().schedules[1].meetings).toEqual(schedule3);
     });
   });
 
@@ -258,9 +258,13 @@ describe('Schedule Redux', () => {
       store.dispatch(replaceSchedules([schedule2, schedule3]));
 
       // assert
-      expect(store.getState().schedules.allSchedules).toContainEqual(schedule1);
-      expect(store.getState().schedules.allSchedules).toContainEqual(schedule2);
-      expect(store.getState().schedules.allSchedules).toContainEqual(schedule3);
+      expect(store.getState().schedules).toHaveLength(3);
+      expect(store.getState().schedules[0]).toMatchObject({
+        meetings: schedule1,
+        saved: true,
+      });
+      expect(store.getState().schedules[1].meetings).toEqual(schedule2);
+      expect(store.getState().schedules[2].meetings).toEqual(schedule3);
     });
 
     test('when the new schedules contain a schedule identical to a saved one', () => {
@@ -276,27 +280,12 @@ describe('Schedule Redux', () => {
 
       // assert
       // only one schedule should be saved since the schedules are equal
-      expect(store.getState().schedules.allSchedules).toContainEqual(schedule1);
-      expect(store.getState().schedules.allSchedules).toHaveLength(1);
+      expect(store.getState().schedules).toHaveLength(1);
+      expect(store.getState().schedules[0].meetings).toEqual(schedule1);
     });
   });
 
   describe('saves the correct schedule', () => {
-    test('when the schedule at index 0 is saved', () => {
-      // arrange
-      const store = createStore(autoSchedulerReducer);
-
-      // act
-      store.dispatch(addSchedule(schedule1));
-      store.dispatch(saveSchedule(0));
-      store.dispatch(replaceSchedules([schedule2, schedule3]));
-
-      // assert
-      expect(store.getState().schedules.allSchedules).toContainEqual(schedule1);
-      expect(store.getState().schedules.allSchedules).toContainEqual(schedule2);
-      expect(store.getState().schedules.allSchedules).toContainEqual(schedule3);
-    });
-
     test('when the schedule at a non-zero index is saved', () => {
       // arrange
       const store = createStore(autoSchedulerReducer);
@@ -308,9 +297,12 @@ describe('Schedule Redux', () => {
       store.dispatch(replaceSchedules([schedule3]));
 
       // assert
-      expect(store.getState().schedules.allSchedules).not.toContainEqual(schedule1);
-      expect(store.getState().schedules.allSchedules).toContainEqual(schedule2);
-      expect(store.getState().schedules.allSchedules).toContainEqual(schedule3);
+      expect(store.getState().schedules).toHaveLength(2)
+      expect(store.getState().schedules[0]).toMatchObject({
+        meetings: schedule2,
+        saved: true,
+      });
+      expect(store.getState().schedules[1].meetings).toEqual(schedule3);
     });
   });
 
@@ -327,8 +319,8 @@ describe('Schedule Redux', () => {
       store.dispatch(unsaveSchedule(0));
 
       // assert
-      expect(store.getState().schedules.savedSchedules).not.toContainEqual(schedule1);
-      expect(store.getState().schedules.savedSchedules).toContainEqual(schedule2);
+      expect(store.getState().schedules[0].saved).toBe(false);
+      expect(store.getState().schedules[1].saved).toBe(true);
     });
 
     test('when the schedule at a non-zero index is unsaved', () => {
@@ -343,8 +335,8 @@ describe('Schedule Redux', () => {
       store.dispatch(unsaveSchedule(1));
 
       // assert
-      expect(store.getState().schedules.savedSchedules).toContainEqual(schedule1);
-      expect(store.getState().schedules.savedSchedules).not.toContainEqual(schedule2);
+      expect(store.getState().schedules[0].saved).toBe(true);
+      expect(store.getState().schedules[1].saved).toBe(false);
     });
   });
 });

--- a/autoscheduler/frontend/src/tests/redux/Schedule.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/Schedule.test.ts
@@ -193,7 +193,7 @@ describe('Schedule Redux', () => {
       store.dispatch(removeSchedule(1));
 
       // assert
-      expect(store.getState().schedules).toHaveLength(2)
+      expect(store.getState().schedules).toHaveLength(2);
       expect(store.getState().schedules[0].meetings).toEqual(schedule1);
       expect(store.getState().schedules[1].meetings).toEqual(schedule3);
     });
@@ -209,7 +209,7 @@ describe('Schedule Redux', () => {
       store.dispatch(removeSchedule(2));
 
       // assert
-      expect(store.getState().schedules).toHaveLength(2)
+      expect(store.getState().schedules).toHaveLength(2);
       expect(store.getState().schedules[0].meetings).toEqual(schedule1);
       expect(store.getState().schedules[1].meetings).toEqual(schedule2);
     });
@@ -297,7 +297,7 @@ describe('Schedule Redux', () => {
       store.dispatch(replaceSchedules([schedule3]));
 
       // assert
-      expect(store.getState().schedules).toHaveLength(2)
+      expect(store.getState().schedules).toHaveLength(2);
       expect(store.getState().schedules[0]).toMatchObject({
         meetings: schedule2,
         saved: true,
@@ -374,7 +374,7 @@ describe('Schedule Redux', () => {
             meetings: schedule2,
             name: 'Schedule 2',
             saved: false,
-          }
+          },
         ],
       });
       const scheduleName = 'Test schedule';
@@ -403,7 +403,7 @@ describe('Schedule Redux', () => {
             meetings: schedule2,
             name: 'Schedule 2',
             saved: false,
-          }
+          },
         ],
       });
 

--- a/autoscheduler/frontend/src/tests/redux/SchedulingPage.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/SchedulingPage.test.ts
@@ -14,7 +14,10 @@ describe('Scheduling Page Redux', () => {
       store.dispatch(addSchedule(testSchedule2));
 
       // assert
-      expect(store.getState().schedules.allSchedules).toEqual([testSchedule1, testSchedule2]);
+      const { schedules } = store.getState();
+      expect(schedules).toHaveLength(2);
+      expect(schedules[0].meetings).toEqual(testSchedule1);
+      expect(schedules[1].meetings).toEqual(testSchedule2);
     });
 
     test('via replaceSchedules', () => {
@@ -25,7 +28,10 @@ describe('Scheduling Page Redux', () => {
       store.dispatch(replaceSchedules([testSchedule1, testSchedule2]));
 
       // assert
-      expect(store.getState().schedules.allSchedules).toEqual([testSchedule1, testSchedule2]);
+      const { schedules } = store.getState();
+      expect(schedules).toHaveLength(2);
+      expect(schedules[0].meetings).toEqual(testSchedule1);
+      expect(schedules[1].meetings).toEqual(testSchedule2);
     });
   });
   describe('replaces an existing schedule', () => {
@@ -38,7 +44,9 @@ describe('Scheduling Page Redux', () => {
       store.dispatch(replaceSchedules([testSchedule2]));
 
       // assert
-      expect(store.getState().schedules.allSchedules).toEqual([testSchedule2]);
+      const { schedules } = store.getState();
+      expect(schedules).toHaveLength(1);
+      expect(schedules[0].meetings).toEqual(testSchedule2);
     });
     test('via removeSchedule followed by addSchedule', () => {
       // arrange
@@ -50,7 +58,9 @@ describe('Scheduling Page Redux', () => {
       store.dispatch(addSchedule(testSchedule2));
 
       // assert
-      expect(store.getState().schedules.allSchedules).toEqual([testSchedule2]);
+      const { schedules } = store.getState();
+      expect(schedules).toHaveLength(1);
+      expect(schedules[0].meetings).toEqual(testSchedule2);
     });
   });
   describe('removes a schedule', () => {
@@ -64,7 +74,9 @@ describe('Scheduling Page Redux', () => {
       store.dispatch(removeSchedule(0));
 
       // assert
-      expect(store.getState().schedules.allSchedules).toEqual([testSchedule2]);
+      const { schedules } = store.getState();
+      expect(schedules).toHaveLength(1);
+      expect(schedules[0].meetings).toEqual(testSchedule2);
     });
   });
 });

--- a/autoscheduler/frontend/src/tests/ui/Schedule.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/Schedule.test.tsx
@@ -57,8 +57,13 @@ describe('Schedule UI', () => {
     test('when given a schedule with 1 meeting', () => {
       // arrange and act
       const store = createStore(autoSchedulerReducer, {
-        schedules: { allSchedules: [[testMeeting1]], savedSchedules: [] },
-        selectedSchedule: 0,
+        schedules: [
+          {
+            meetings: [testMeeting1],
+            name: 'Schedule 1',
+            saved: false,
+          },
+        ],
       });
       const { container } = render(
         <Provider store={store}>
@@ -75,7 +80,13 @@ describe('Schedule UI', () => {
     test('for up to 10 different sections', () => {
       // arrange
       const store = createStore(autoSchedulerReducer, {
-        schedules: { allSchedules: [testSchedule3], savedSchedules: [] },
+        schedules: [
+          {
+            meetings: testSchedule3,
+            name: 'Schedule 1',
+            saved: false,
+          },
+        ],
         selectedSchedule: 0,
       });
       const { getAllByTestId } = render(

--- a/autoscheduler/frontend/src/tests/ui/SchedulePreview.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SchedulePreview.test.tsx
@@ -166,7 +166,7 @@ describe('SchedulePreview component', () => {
 
       // assert
       await waitFor(() => (
-        expect(store.getState().schedules.savedSchedules).toContainEqual(testSchedule1)
+        expect(store.getState().schedules[0].saved).toBe(true)
       ));
     });
 
@@ -186,7 +186,7 @@ describe('SchedulePreview component', () => {
 
       // assert
       await waitFor(() => (
-        expect(store.getState().schedules.savedSchedules).toContainEqual(testSchedule2)
+        expect(store.getState().schedules[1].saved).toBe(true)
       ));
     });
   });
@@ -211,7 +211,7 @@ describe('SchedulePreview component', () => {
 
       // assert
       await waitFor(() => (
-        expect(store.getState().schedules.savedSchedules).toHaveLength(0)
+        expect(store.getState().schedules.filter((schedule) => schedule.saved)).toHaveLength(0)
       ));
     });
 
@@ -234,7 +234,7 @@ describe('SchedulePreview component', () => {
 
       // assert
       await waitFor(() => (
-        expect(store.getState().schedules.savedSchedules).toHaveLength(0)
+        expect(store.getState().schedules.filter((schedule) => schedule.saved)).toHaveLength(0)
       ));
     });
   });
@@ -255,9 +255,9 @@ describe('SchedulePreview component', () => {
       fireEvent.click(deleteScheduleButton);
 
       // assert
-      const schedules = store.getState().schedules.allSchedules;
+      const { schedules } = store.getState();
       expect(schedules).toHaveLength(1);
-      expect(schedules[0]).toEqual(testSchedule1);
+      expect(schedules[0].meetings).toEqual(testSchedule1);
     });
 
     test('when deleted from the dialog from a saved schedule', async () => {
@@ -281,10 +281,10 @@ describe('SchedulePreview component', () => {
       fireEvent.click(confirmDeleteButton);
 
       // assert
-      const { allSchedules, savedSchedules } = store.getState().schedules;
-      expect(savedSchedules).toHaveLength(0);
-      expect(allSchedules).toHaveLength(1);
-      expect(allSchedules[0]).toEqual(testSchedule1);
+      const { schedules } = store.getState();
+      expect(schedules).toHaveLength(1);
+      expect(schedules[0].saved).toBe(false);
+      expect(schedules[0].meetings).toEqual(testSchedule1);
     });
   });
 });

--- a/autoscheduler/frontend/src/tests/ui/SchedulePreview.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SchedulePreview.test.tsx
@@ -19,7 +19,7 @@ describe('SchedulePreview component', () => {
     test('when the user clicks on the second schedule', async () => {
       // arrange
       const store = createStore(autoSchedulerReducer);
-      const { findByText } = render(
+      const { findAllByLabelText } = render(
         <Provider store={store}>
           <SchedulePreview />
         </Provider>,
@@ -27,7 +27,8 @@ describe('SchedulePreview component', () => {
       store.dispatch(replaceSchedules([testSchedule1, testSchedule2]));
 
       // act
-      fireEvent.click(await findByText('Schedule 2'));
+      const schedules = await findAllByLabelText('Schedule preview');
+      fireEvent.click(schedules[1]);
 
       // assert
       expect(store.getState().selectedSchedule).toBe(1);

--- a/autoscheduler/frontend/src/tests/ui/SchedulePreview.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SchedulePreview.test.tsx
@@ -288,4 +288,64 @@ describe('SchedulePreview component', () => {
       expect(schedules[0].meetings).toEqual(testSchedule1);
     });
   });
+
+  describe('renames the correct schedule', () => {
+    test('when the first schedule is renamed', async () => {
+      // arrange
+      const newScheduleName = 'Test schedule';
+
+      const store = createStore(autoSchedulerReducer);
+      const { findByLabelText, findAllByLabelText } = render(
+        <Provider store={store}>
+          <SchedulePreview />
+        </Provider>,
+      );
+      store.dispatch(replaceSchedules([testSchedule1, testSchedule2]));
+
+      // act
+      // click button to rename schedule
+      const renameScheduleButton = (await findAllByLabelText('Rename schedule'))[0];
+      fireEvent.click(renameScheduleButton);
+
+      // set new name
+      const scheduleNameInput = (await findByLabelText('Schedule name'));
+      if (!(scheduleNameInput instanceof HTMLInputElement)) throw Error('Input element is not valid');
+      fireEvent.change(scheduleNameInput, { target: { value: newScheduleName } });
+
+      // confirm new name
+      fireEvent.click(renameScheduleButton);
+
+      // assert
+      expect(store.getState().schedules[0].name).toBe(newScheduleName);
+    });
+
+    test('when the second schedule is renamed', async () => {
+      // arrange
+      const newScheduleName = 'Cool classes for cool kids';
+
+      const store = createStore(autoSchedulerReducer);
+      const { findByLabelText, findAllByLabelText } = render(
+        <Provider store={store}>
+          <SchedulePreview />
+        </Provider>,
+      );
+      store.dispatch(replaceSchedules([testSchedule1, testSchedule2]));
+
+      // act
+      // click button to rename schedule
+      const renameScheduleButton = (await findAllByLabelText('Rename schedule'))[1];
+      fireEvent.click(renameScheduleButton);
+
+      // set new name
+      const scheduleNameInput = (await findByLabelText('Schedule name'));
+      if (!(scheduleNameInput instanceof HTMLInputElement)) throw Error('Input element is not valid');
+      fireEvent.change(scheduleNameInput, { target: { value: newScheduleName } });
+
+      // confirm new name
+      fireEvent.click(renameScheduleButton);
+
+      // assert
+      expect(store.getState().schedules[1].name).toBe(newScheduleName);
+    });
+  });
 });

--- a/autoscheduler/frontend/src/tests/ui/SchedulingPage.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SchedulingPage.test.tsx
@@ -71,7 +71,7 @@ describe('Scheduling Page UI', () => {
       fetchMock.mockResponseOnce(JSON.stringify({}));
 
       const {
-        getByLabelText, getByRole, findByText, findAllByText,
+        getByLabelText, getByRole, findAllByLabelText, findAllByText,
       } = render(
         <Provider store={store}>
           <SchedulingPage />
@@ -83,7 +83,7 @@ describe('Scheduling Page UI', () => {
 
       // act
       fireEvent.click(getByRole('button', { name: 'Generate Schedules' }));
-      const schedule2 = await findByText('Schedule 2');
+      const schedule2 = (await findAllByLabelText('Schedule preview'))[1];
       fireEvent.click(schedule2);
       // DEPT 123 will be added to the schedule no matter which schedule is chosen
       await findAllByText(/DEPT 123.*/);

--- a/autoscheduler/frontend/src/types/Schedule.ts
+++ b/autoscheduler/frontend/src/types/Schedule.ts
@@ -1,0 +1,7 @@
+import Meeting from './Meeting';
+
+export default interface Schedule {
+  meetings: Meeting[];
+  name: string;
+  saved: boolean;
+}


### PR DESCRIPTION
## Description

Reorganizes the schedules redux (and creates a schedule type so that it can be more flexible in the future), and adds the ability to rename schedules.

Draft for now since I want `frontend/delete-schedule-dialog` merged before this gets worked on more, although it's completely functional with tests (let me know if there are any other tests I should add though)

## Rationale

I made a `Schedule` type since each schedule now needs a name instead of just a list of meetings, which is a lot more flexible than how it was being done before but involved refactoring a decent amount of old code. This makes some parts of our old code a little confusing, like how some meetings arrays were referred to as a schedule in the past, but I opted not to change these for now.

The behavior for creating schedules with identical names could also be a bit controversial? Here are some examples:

Schedule with name `test` exists -> rename another schedule to `test` -> new `test` schedule is renamed to `test (2)`
Schedule with name `Schedule 1` exists -> rename another schedule to `Schedule 1` -> new schedule is renamed to `Schedule 1 (2)`
Schedule with name `Schedule 1` is saved -> generate more schedules -> new schedules generated are `Schedule 2`, `Schedule 3`, etc.

## How to test

Click the rename button and try renaming some schedules/generating more to see how it works (also try creating 2 schedules with the same name and saving a schedule with the default name).

Also try using keyboard controls, I made it autofocus on the schedule name when you click edit so you don't have to click the name input, and you can cancel renaming with escape or confirm with enter.

## Screenshots
|Before|After|
|--|--|
| ![image](https://user-images.githubusercontent.com/28655462/92332434-b77b2f00-f043-11ea-8a6a-dee9af9dae04.png) | ![image](https://user-images.githubusercontent.com/28655462/92332420-a8947c80-f043-11ea-900c-60682c739644.png) |
| | ![image](https://user-images.githubusercontent.com/28655462/92332467-c82ba500-f043-11ea-909e-fda09d5ff292.png) |

## Related tasks

Closes #296.