### PR TITLE
Moved availability instructions to dialog

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.css
@@ -2,7 +2,8 @@
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    width: calc(100% - 16px);
+    width: 100%;
+    box-sizing: border-box;
     padding: 8px;
     user-select: none;
 }

--- a/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.css
@@ -1,8 +1,9 @@
 .button-container {
     display: flex;
     flex-direction: column;
-    padding: 8px;
     justify-content: space-between;
+    width: calc(100% - 16px);
+    padding: 8px;
     user-select: none;
 }
 
@@ -13,9 +14,4 @@
 #card-header {
     text-align: center;
     width: 100%;
-}
-
-#instructions {
-    margin-left: 8px;
-    margin-right: 8px;
 }

--- a/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.css.d.ts
@@ -4,7 +4,6 @@ declare namespace ConfigureCardCssModule {
     buttonContainer: string;
     "card-header": string;
     cardHeader: string;
-    instructions: string;
     spacer: string;
   }
 }

--- a/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
@@ -122,10 +122,6 @@ const ConfigureCard: React.FC = () => {
       }
     >
       <div className={styles.buttonContainer}>
-        <div id={styles.instructions}>
-          Click and drag in the calendar on the right to block off times when you
-          are unavailable, then press Generate Schedules below.
-        </div>
         <ListItem
           disableGutters
           onClick={(): void => setIncludeFull(!includeFull)}

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/InstructionsDialog/InstructionsDialog.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/InstructionsDialog/InstructionsDialog.css
@@ -1,0 +1,22 @@
+.modal-backdrop {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+
+.availability-dialog {
+    width: 50%;
+    height: fit-content;
+    max-width: 400px;
+}
+
+.buttons-on-right {
+    justify-content: right;
+}

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/InstructionsDialog/InstructionsDialog.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/InstructionsDialog/InstructionsDialog.css.d.ts
@@ -1,0 +1,17 @@
+declare namespace InstructionsDialogCssModule {
+  export interface IInstructionsDialogCss {
+    "availability-dialog": string;
+    availabilityDialog: string;
+    "buttons-on-right": string;
+    buttonsOnRight: string;
+    "modal-backdrop": string;
+    modalBackdrop: string;
+  }
+}
+
+declare const InstructionsDialogCssModule: InstructionsDialogCssModule.IInstructionsDialogCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: InstructionsDialogCssModule.IInstructionsDialogCss;
+};
+
+export = InstructionsDialogCssModule;

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/InstructionsDialog/InstructionsDialog.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/InstructionsDialog/InstructionsDialog.tsx
@@ -8,10 +8,26 @@ import { RootState } from '../../../../redux/reducer';
 
 const InstructionsDialog: React.FC = () => {
   const [open, setOpen] = React.useState(true);
-  const hasGeneratedSchedules = useSelector<RootState, boolean>(
-    (state) => state.availability.length > 0 || state.schedules.allSchedules.length > 0,
+  const hasCurrentAv = useSelector<RootState, boolean>(
+    (state) => state.availability.length > 0,
   );
-  if (hasGeneratedSchedules && open) setOpen(false);
+  // can have 1 of 3 values:
+  // null -> user's first time on site
+  // ''   -> user has not yet made an av
+  // 'Y'  -> user has made an av or has manually dismissed dialog in the past
+  const hasPastAv = localStorage.getItem('has-created-availability');
+  // if the past availabilities is either null or '', update it
+  if (!hasPastAv) {
+    localStorage.setItem('has-created-availability', hasCurrentAv ? 'Y' : '');
+  }
+  // close the dialog if the user has ever created an av
+  if ((hasCurrentAv || hasPastAv) && open) setOpen(false);
+
+  // dismiss the dialog... forever!
+  const handleOkClick = (): void => {
+    localStorage.setItem('has-created-availability', 'Y');
+    setOpen(false);
+  };
 
   return (
     <Fade in={open}>
@@ -24,7 +40,7 @@ const InstructionsDialog: React.FC = () => {
             </Typography>
           </CardContent>
           <CardActions className={styles.buttonsOnRight}>
-            <Button onClick={(): void => setOpen(false)} color="primary">OK</Button>
+            <Button onClick={handleOkClick} color="primary">OK</Button>
           </CardActions>
         </Card>
       </div>

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/InstructionsDialog/InstructionsDialog.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/InstructionsDialog/InstructionsDialog.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import {
+  Card, CardActions, CardContent, Button, Typography, Fade,
+} from '@material-ui/core';
+import { useSelector } from 'react-redux';
+import * as styles from './InstructionsDialog.css';
+import { RootState } from '../../../../redux/reducer';
+
+const InstructionsDialog: React.FC = () => {
+  const [open, setOpen] = React.useState(true);
+  const hasGeneratedSchedules = useSelector<RootState, boolean>(
+    (state) => state.availability.length > 0 || state.schedules.allSchedules.length > 0,
+  );
+  if (hasGeneratedSchedules && open) setOpen(false);
+
+  return (
+    <Fade in={open}>
+      <div className={styles.modalBackdrop}>
+        <Card className={styles.availabilityDialog}>
+          <CardContent>
+            <Typography>
+              Click and drag to block off times when you are unavailable,
+              then press Generate Schedules
+            </Typography>
+          </CardContent>
+          <CardActions className={styles.buttonsOnRight}>
+            <Button onClick={(): void => setOpen(false)} color="primary">OK</Button>
+          </CardActions>
+        </Card>
+      </div>
+    </Fade>
+  );
+};
+
+export default InstructionsDialog;

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/Schedule.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/Schedule.tsx
@@ -12,6 +12,7 @@ import HoveredTime from './HoveredTime/HoveredTime';
 import { FIRST_HOUR, LAST_HOUR, formatTime } from '../../../utils/timeUtil';
 import DayOfWeek from '../../../types/DayOfWeek';
 import useMeetingColor from './meetingColors';
+import InstructionsDialog from './InstructionsDialog/InstructionsDialog';
 
 const emptySchedule: Meeting[] = [];
 
@@ -346,6 +347,7 @@ const Schedule: React.FC = () => {
         {hourBars}
         <div className={styles.meetingsContainer} id="meetings-container">
           {scheduleDays}
+          <InstructionsDialog />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Description

The instructions for how to create availabilities would never be read by users if they stayed in the `ConfigureCard`, where they were before this PR. This PR moves the instructions into a dialog that obscures the schedule until the user dismisses it.

The new, schedule-covering dialog is set to appear by default, and can be removed if the user has saved schedules, if the user has generated schedules, or if the user presses OK. However, it might be worth considering setting a cookie so that it's only shown once per user, because I could easily see this becoming a nuisance if you don't have any saved availabilities.

## Rationale

Placed in a separate component because the `Schedule` component is already a little thicc.

## How to test

Look at it: http://localhost:8080

## Screenshots

If it's a frontend change, provide screenshots of it. If possible, show the change on different
resolutions/sizes.

If you're changing a existing frontend look, provide a before and after screenshot in the table below.

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/10082177/92408397-f58b5800-f102-11ea-87c7-371e03f4fc2a.png)|![image](https://user-images.githubusercontent.com/10082177/92408311-bd841500-f102-11ea-8e98-326945ab93b0.png)|

## Related tasks

None
