### PR TITLE
GCP: Scrape courses on a schedule

### DIFF
--- a/.github/workflows/backend-workflow.yml
+++ b/.github/workflows/backend-workflow.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@master
       - name: docker-build
       # This option makes the Postgres container exit when the autoscheduler container does
-        run: docker-compose up db web --abort-on-container-exit
+        run: docker-compose up --abort-on-container-exit web
 
   lint-backend:
     name: 'Linting'

--- a/.github/workflows/backend-workflow.yml
+++ b/.github/workflows/backend-workflow.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@master
       - name: docker-build
       # This option makes the Postgres container exit when the autoscheduler container does
-        run: docker-compose up --abort-on-container-exit
+        run: docker-compose up db web --abort-on-container-exit
 
   lint-backend:
     name: 'Linting'

--- a/autoscheduler/autoscheduler/settings/docker.py
+++ b/autoscheduler/autoscheduler/settings/docker.py
@@ -18,12 +18,12 @@ _IS_SCHEDULE = os.getenv('SETTINGS_MODE') == 'schedule'
 if _IS_SCHEDULE:
     DATABASES = {
         'default': {
+            'USER': config.get_prop("user"),
+            'PASSWORD': config.get_prop("password"),
             'ENGINE': 'django.db.backends.postgresql',
             'NAME': 'postgres',
             'HOST': 'cloud-sql-proxy',
             'PORT': '3306',
-            'USER': config.get_prop("user"),
-            'PASSWORD': config.get_prop("password"),
         }
     }
 else:

--- a/autoscheduler/autoscheduler/settings/docker.py
+++ b/autoscheduler/autoscheduler/settings/docker.py
@@ -2,21 +2,37 @@
     This is needed as we need to create the database from scratch
 """
 
+import os
 # Says the imports are unused, but they actually since they're just constants for Django
 # pylint: disable=unused-wildcard-import
 
 # Normally not supposed to use wildcard-imports, but it's needed in this case
 # pylint: disable=wildcard-import
 from autoscheduler.settings.base import *
+from autoscheduler.config import config
 
 SECRET_KEY = open("/run/secrets/SECRET_DJANGO_KEY").read()
 
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.postgresql_psycopg2",
-        "NAME": "dbautoscheduler",
-        "USER": open("/run/secrets/SECRET_POSTGRES_USER").read(),
-        "PASSWORD": open("/run/secrets/SECRET_POSTGRES_PASS").read(),
-        "HOST": "db",
+_IS_SCHEDULE = os.getenv('SETTINGS_MODE') == 'schedule'
+
+if _IS_SCHEDULE:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql',
+            'NAME': 'postgres',
+            'HOST': 'cloud-sql-proxy',
+            'PORT': '3306',
+            'USER': config.get_prop("user"),
+            'PASSWORD': config.get_prop("password"),
+        }
     }
-}
+else:
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.postgresql_psycopg2",
+            "NAME": "dbautoscheduler",
+            "USER": open("/run/secrets/SECRET_POSTGRES_USER").read(),
+            "PASSWORD": open("/run/secrets/SECRET_POSTGRES_PASS").read(),
+            "HOST": "db",
+        }
+    }

--- a/autoscheduler/scraper/management/commands/scrape_courses.py
+++ b/autoscheduler/scraper/management/commands/scrape_courses.py
@@ -12,7 +12,7 @@ from scraper.models import Course, Instructor, Section, Meeting, Department
 from scraper.models.course import generate_course_id
 from scraper.models.section import generate_meeting_id
 from scraper.management.commands.utils.scraper_utils import (
-    get_all_terms, determine_terms_to_scrape,
+    get_all_terms, get_recent_terms,
 )
 
 # Set of the courses' ID's
@@ -311,7 +311,7 @@ class Command(base.BaseCommand):
             if options['year']:
                 terms = get_all_terms(options['year'])
             elif options['recent']:
-                terms = determine_terms_to_scrape()
+                terms = get_recent_terms()
 
             depts_terms = get_department_names(terms)
 

--- a/autoscheduler/scraper/management/commands/scrape_courses.py
+++ b/autoscheduler/scraper/management/commands/scrape_courses.py
@@ -236,7 +236,7 @@ def save_models(instructors: List[Instructor], sections: List[Section], # pylint
     with transaction.atomic():
         if term:
             queryset = Section.objects.filter(term_code=term)
-        elif options['year']:
+        elif options['year'] or options['recent']:
             queryset = Section.objects.filter(term_code__in=terms)
         else:
             queryset = Section.objects.all()
@@ -260,7 +260,7 @@ def save_models(instructors: List[Instructor], sections: List[Section], # pylint
     with transaction.atomic():
         if term:
             queryset = Course.objects.filter(term=term)
-        elif options['year']:
+        elif options['year'] or options['recent']:
             queryset = Course.objects.filter(term__in=terms)
         else:
             queryset = Course.objects.all()

--- a/autoscheduler/scraper/management/commands/utils/scraper_utils.py
+++ b/autoscheduler/scraper/management/commands/utils/scraper_utils.py
@@ -22,9 +22,9 @@ def get_all_terms(year: int = -1) -> List[str]:
     return [f"{year}{semester}{location}"
             for year, semester, location in product(years, semesters, locations)]
 
-def determine_semesters_to_scrape(now=datetime.now()) -> List[str]:
+def get_recent_semesters(now=datetime.now()) -> List[str]:
     """ Calculates and returns which semester(s) we should be scraping for.
-        Returns semesters (just year + semester), not terms
+        Returns semesters (just year + semester, no location), not terms. e.g. 20201
     """
 
     year = now.year
@@ -46,10 +46,12 @@ def determine_semesters_to_scrape(now=datetime.now()) -> List[str]:
     # Between [11/05/2020, 04/01/2021]
     return [f"{year + 1}1"]
 
-def determine_terms_to_scrape(now=datetime.now()) -> List[str]:
-    """ Gets the most recent semesters and makes the product for the terms """
+def get_recent_terms(now=datetime.now()) -> List[str]:
+    """ Gets all of the most recent semesters + locations and combines them to get the
+        most recent terms to scrape.
+    """
 
-    recent_semesters = determine_semesters_to_scrape(now)
+    recent_semesters = get_recent_semesters(now)
 
     locations = range(1, 4)
 

--- a/autoscheduler/scraper/management/commands/utils/scraper_utils.py
+++ b/autoscheduler/scraper/management/commands/utils/scraper_utils.py
@@ -34,14 +34,14 @@ def get_recent_semesters(now=datetime.now()) -> List[str]:
     summer_fall_reg_start = datetime.strptime(f'04/01/{year}', date_format)
     spring_reg_start = datetime.strptime(f'11/05/{year}', date_format)
 
-    # We're between [1/1/2020, pre-registration for summer/fall in the spring)
+    # For the comments, use now.year = 2020
+    # Between [01/01/2020, 04/01/2020)
     if now < summer_fall_reg_start:
         return [f"{year}1"]
 
     # Between [04/01/2020, 11/05/2020]
     if summer_fall_reg_start <= now < spring_reg_start:
-        # Summer and Fall for the current year
-        return [f"{year}2", f"{year}{3}"]
+        return [f"{year}2", f"{year}3"]
 
     # Between [11/05/2020, 04/01/2021]
     return [f"{year + 1}1"]

--- a/autoscheduler/scraper/management/commands/utils/scraper_utils.py
+++ b/autoscheduler/scraper/management/commands/utils/scraper_utils.py
@@ -21,3 +21,37 @@ def get_all_terms(year: int = -1) -> List[str]:
 
     return [f"{year}{semester}{location}"
             for year, semester, location in product(years, semesters, locations)]
+
+def determine_semesters_to_scrape(now=datetime.now()) -> List[str]:
+    """ Calculates and returns which semester(s) we should be scraping for.
+        Returns semesters (just year + semester), not terms
+    """
+
+    year = now.year
+
+    date_format = '%m/%d/%Y'
+
+    summer_fall_reg_start = datetime.strptime(f'04/01/{year}', date_format)
+    spring_reg_start = datetime.strptime(f'11/05/{year}', date_format)
+
+    # We're between [1/1/2020, pre-registration for summer/fall in the spring)
+    if now < summer_fall_reg_start:
+        return [f"{year}1"]
+
+    # Between [04/01/2020, 11/05/2020]
+    if summer_fall_reg_start <= now < spring_reg_start:
+        # Summer and Fall for the current year
+        return [f"{year}2", f"{year}{3}"]
+
+    # Between [11/05/2020, 04/01/2021]
+    return [f"{year + 1}1"]
+
+def determine_terms_to_scrape(now=datetime.now()) -> List[str]:
+    """ Gets the most recent semesters and makes the product for the terms """
+
+    recent_semesters = determine_semesters_to_scrape(now)
+
+    locations = range(1, 4)
+
+    return [f"{year_semester}{location}"
+            for year_semester, location in product(recent_semesters, locations)]

--- a/autoscheduler/scraper/tests/commands/scraper_utils_tests.py
+++ b/autoscheduler/scraper/tests/commands/scraper_utils_tests.py
@@ -1,11 +1,11 @@
 import unittest
 from datetime import datetime
 from scraper.management.commands.utils.scraper_utils import (
-    determine_terms_to_scrape, determine_semesters_to_scrape,
+    get_recent_terms, get_recent_semesters,
 )
 
-class DetermineSemestersToScrapeTests(unittest.TestCase):
-    """ Tests for determine_semesters_to_scrape """
+class GetRecentSemestersTests(unittest.TestCase):
+    """ Tests for get_recent_semesters """
 
     def setUp(self):
         self.strp_format = "%m/%d/%Y"
@@ -16,35 +16,35 @@ class DetermineSemestersToScrapeTests(unittest.TestCase):
     def test_dec30_2020_is_spring_2021(self):
         """ Tests that 11/30/2020 results in spring 2021 (20211) """
         date = datetime.strptime('12/30/2020', self.strp_format)
-        result = determine_semesters_to_scrape(date)
+        result = get_recent_semesters(date)
 
         self.assertEqual(self.spring_2021, result)
 
     def test_march1_2021_is_spring_2021(self):
         """ Tests that 03/01/2020 results in spring 2021 (20211) """
         date = datetime.strptime('03/01/2021', self.strp_format)
-        result = determine_semesters_to_scrape(date)
+        result = get_recent_semesters(date)
 
         self.assertEqual(self.spring_2021, result)
 
     def test_april1_2021_is_summer_fall_2021(self):
         """ Tests that 04/01/2020 results in summer/fall 2021 (20212, 20213) """
         date = datetime.strptime('04/01/2021', self.strp_format)
-        result = determine_semesters_to_scrape(date)
+        result = get_recent_semesters(date)
 
         self.assertEqual(self.summer_fall_2021, result)
 
     def test_november5_2020_is_spring_2021(self):
         """ Tests that 11/30/2020 results in spring 2021 (20211) """
         date = datetime.strptime('11/05/2020', self.strp_format)
-        result = determine_semesters_to_scrape(date)
+        result = get_recent_semesters(date)
 
         self.assertEqual(self.spring_2021, result)
 
-class DetermineTermsToScrapeTests(unittest.TestCase):
-    """ Tests for determine_terms_to_scrape.
+class GetRecentTermsTests(unittest.TestCase):
+    """ Tests for get_recent_terms.
         These are really only testing the product functionality of
-        determine_terms_to_scrape, and really aren't that important.
+        get_recent_terms, and really aren't that important.
     """
     def setUp(self):
         self.strp_format = "%m/%d/%Y"
@@ -52,7 +52,7 @@ class DetermineTermsToScrapeTests(unittest.TestCase):
     def test_does_product_location_and_semesters_correctly(self):
         """ Tests that it does all of the correct locations for summer/fall 2020 """
         date = datetime.strptime('04/01/2020', self.strp_format)
-        result = determine_terms_to_scrape(date)
+        result = get_recent_terms(date)
 
         self.assertEqual(result, ['202021', '202022', '202023',
                                   '202031', '202032', '202033'])

--- a/autoscheduler/scraper/tests/commands/scraper_utils_tests.py
+++ b/autoscheduler/scraper/tests/commands/scraper_utils_tests.py
@@ -1,0 +1,58 @@
+import unittest
+from datetime import datetime
+from scraper.management.commands.utils.scraper_utils import (
+    determine_terms_to_scrape, determine_semesters_to_scrape,
+)
+
+class DetermineSemestersToScrapeTests(unittest.TestCase):
+    """ Tests for determine_semesters_to_scrape """
+
+    def setUp(self):
+        self.strp_format = "%m/%d/%Y"
+        self.spring_2021 = ['20211']
+        self.summer_fall_2020 = ['20202', '20203']
+        self.summer_fall_2021 = ['20212', '20213']
+
+    def test_dec30_2020_is_spring_2021(self):
+        """ Tests that 11/30/2020 results in spring 2021 (20211) """
+        date = datetime.strptime('12/30/2020', self.strp_format)
+        result = determine_semesters_to_scrape(date)
+
+        self.assertEqual(self.spring_2021, result)
+
+    def test_march1_2021_is_spring_2021(self):
+        """ Tests that 03/01/2020 results in spring 2021 (20211) """
+        date = datetime.strptime('03/01/2021', self.strp_format)
+        result = determine_semesters_to_scrape(date)
+
+        self.assertEqual(self.spring_2021, result)
+
+    def test_april1_2021_is_summer_fall_2021(self):
+        """ Tests that 04/01/2020 results in summer/fall 2021 (20212, 20213) """
+        date = datetime.strptime('04/01/2021', self.strp_format)
+        result = determine_semesters_to_scrape(date)
+
+        self.assertEqual(self.summer_fall_2021, result)
+
+    def test_november5_2020_is_spring_2021(self):
+        """ Tests that 11/30/2020 results in spring 2021 (20211) """
+        date = datetime.strptime('11/05/2020', self.strp_format)
+        result = determine_semesters_to_scrape(date)
+
+        self.assertEqual(self.spring_2021, result)
+
+class DetermineTermsToScrapeTests(unittest.TestCase):
+    """ Tests for determine_terms_to_scrape.
+        These are really only testing the product functionality of
+        determine_terms_to_scrape, and really aren't that important.
+    """
+    def setUp(self):
+        self.strp_format = "%m/%d/%Y"
+
+    def test_does_product_location_and_semesters_correctly(self):
+        """ Tests that it does all of the correct locations for summer/fall 2020 """
+        date = datetime.strptime('04/01/2020', self.strp_format)
+        result = determine_terms_to_scrape(date)
+
+        self.assertEqual(result, ['202021', '202022', '202023',
+                                  '202031', '202032', '202033'])

--- a/autoscheduler/scraper/tests/commands/scraper_utils_tests.py
+++ b/autoscheduler/scraper/tests/commands/scraper_utils_tests.py
@@ -8,35 +8,34 @@ class GetRecentSemestersTests(unittest.TestCase):
     """ Tests for get_recent_semesters """
 
     def setUp(self):
-        self.strp_format = "%m/%d/%Y"
         self.spring_2021 = ['20211']
         self.summer_fall_2020 = ['20202', '20203']
         self.summer_fall_2021 = ['20212', '20213']
 
     def test_dec30_2020_is_spring_2021(self):
         """ Tests that 11/30/2020 results in spring 2021 (20211) """
-        date = datetime.strptime('12/30/2020', self.strp_format)
+        date = datetime(2020, 12, 30)
         result = get_recent_semesters(date)
 
         self.assertEqual(self.spring_2021, result)
 
     def test_march1_2021_is_spring_2021(self):
         """ Tests that 03/01/2020 results in spring 2021 (20211) """
-        date = datetime.strptime('03/01/2021', self.strp_format)
+        date = datetime(2021, 3, 1)
         result = get_recent_semesters(date)
 
         self.assertEqual(self.spring_2021, result)
 
     def test_april1_2021_is_summer_fall_2021(self):
         """ Tests that 04/01/2020 results in summer/fall 2021 (20212, 20213) """
-        date = datetime.strptime('04/01/2021', self.strp_format)
+        date = datetime(2021, 4, 1)
         result = get_recent_semesters(date)
 
         self.assertEqual(self.summer_fall_2021, result)
 
     def test_november5_2020_is_spring_2021(self):
         """ Tests that 11/30/2020 results in spring 2021 (20211) """
-        date = datetime.strptime('11/05/2020', self.strp_format)
+        date = datetime(2020, 11, 5)
         result = get_recent_semesters(date)
 
         self.assertEqual(self.spring_2021, result)
@@ -46,12 +45,9 @@ class GetRecentTermsTests(unittest.TestCase):
         These are really only testing the product functionality of
         get_recent_terms, and really aren't that important.
     """
-    def setUp(self):
-        self.strp_format = "%m/%d/%Y"
-
     def test_does_product_location_and_semesters_correctly(self):
         """ Tests that it does all of the correct locations for summer/fall 2020 """
-        date = datetime.strptime('04/01/2020', self.strp_format)
+        date = datetime(2020, 4, 1)
         result = get_recent_terms(date)
 
         self.assertEqual(result, ['202021', '202022', '202023',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,20 @@ services:
       - SECRET_POSTGRES_USER
       - SECRET_POSTGRES_PASS
 
+  scrape-courses: # The Django container, which connects to the db container and runs our tests
+    build:
+      context: .
+      dockerfile: docker/scrape-courses/Dockerfile
+    volumes:
+      - .:/code
+    ports:
+      - "3306:3306"
+    container_name: scrape-courses
+    secrets:
+      - SECRET_DJANGO_KEY
+      - SECRET_POSTGRES_USER
+      - SECRET_POSTGRES_PASS
+
 volumes:
   pgdata:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,8 @@ services:
 
   cloud-sql-proxy:
     image: gcr.io/cloudsql-docker/gce-proxy:1.11
-    command: /cloud_sql_proxy -instances=revregistration1:us-central1:db-revregistration=tcp:3306
+    # The 0.0.0.0 is key to having this work on Compute Engine
+    command: /cloud_sql_proxy -instances=revregistration1:us-central1:db-revregistration=tcp:0.0.0.0:3306
     ports:
       - 3306:3006
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,15 +33,21 @@ services:
     build:
       context: .
       dockerfile: docker/scrape-courses/Dockerfile
+    depends_on:
+      - cloud-sql-proxy
     volumes:
       - .:/code
-    ports:
-      - "3306:3306"
     container_name: scrape-courses
     secrets:
       - SECRET_DJANGO_KEY
       - SECRET_POSTGRES_USER
       - SECRET_POSTGRES_PASS
+
+  cloud-sql-proxy:
+    image: gcr.io/cloudsql-docker/gce-proxy:1.11
+    command: /cloud_sql_proxy -instances=revregistration1:us-central1:db-revregistration=tcp:3306
+    ports:
+      - 3306:3006
 
 volumes:
   pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,13 @@ services:
       - SECRET_POSTGRES_PASS
 
   # These two containers are for running scrape_courses on a schedule in Compute Engine
+  cloud-sql-proxy:
+    image: gcr.io/cloudsql-docker/gce-proxy:1.11
+    # The 0.0.0.0 is key to having this work on Compute Engine
+    command: /cloud_sql_proxy -instances=$GCP_DB_NAME=tcp:0.0.0.0:3306
+    ports:
+      - 3306:3006
+
   scrape-courses:
     build:
       context: .
@@ -43,13 +50,6 @@ services:
       - SECRET_DJANGO_KEY
       - SECRET_POSTGRES_USER
       - SECRET_POSTGRES_PASS
-
-  cloud-sql-proxy:
-    image: gcr.io/cloudsql-docker/gce-proxy:1.11
-    # The 0.0.0.0 is key to having this work on Compute Engine
-    command: /cloud_sql_proxy -instances=$GCP_DB_NAME=tcp:0.0.0.0:3306
-    ports:
-      - 3306:3006
 
 volumes:
   pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,8 @@ services:
       - SECRET_POSTGRES_USER
       - SECRET_POSTGRES_PASS
 
-  scrape-courses: # The Django container, which connects to the db container and runs our tests
+  # These two containers are for running scrape_courses on a schedule in Compute Engine
+  scrape-courses:
     build:
       context: .
       dockerfile: docker/scrape-courses/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
   cloud-sql-proxy:
     image: gcr.io/cloudsql-docker/gce-proxy:1.11
     # The 0.0.0.0 is key to having this work on Compute Engine
-    command: /cloud_sql_proxy -instances=revregistration1:us-central1:db-revregistration=tcp:0.0.0.0:3306
+    command: /cloud_sql_proxy -instances=$GCP_DB_NAME=tcp:0.0.0.0:3306
     ports:
       - 3306:3006
 

--- a/docker/scrape-courses/Dockerfile
+++ b/docker/scrape-courses/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.7-slim
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+WORKDIR /app
+
+COPY autoscheduler /app
+RUN pip install -r requirements.txt
+
+COPY entrypoint.sh /usr/local/bin
+ENTRYPOINT ["entrypoint.sh"]

--- a/docker/scrape-courses/Dockerfile
+++ b/docker/scrape-courses/Dockerfile
@@ -7,4 +7,5 @@ COPY autoscheduler /app
 RUN pip install -r requirements.txt
 
 COPY entrypoint.sh /usr/local/bin
+RUN chmod +x /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["entrypoint.sh"]

--- a/docker/scrape-courses/Dockerfile
+++ b/docker/scrape-courses/Dockerfile
@@ -6,6 +6,6 @@ WORKDIR /app
 COPY autoscheduler /app
 RUN pip install -r requirements.txt
 
-COPY entrypoint.sh /usr/local/bin
+COPY docker/scrape-courses/entrypoint.sh /usr/local/bin
 RUN chmod +x /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["entrypoint.sh"]

--- a/docker/scrape-courses/entrypoint.sh
+++ b/docker/scrape-courses/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 export SETTINGS_MODE=schedule
 # Need to dynamically retrieve the current term?
-python3 manage.py scrape_courses -t 202031 --settings=autoscheduler.settings.docker
+python3 manage.py scrape_courses --recent --settings=autoscheduler.settings.docker

--- a/docker/scrape-courses/entrypoint.sh
+++ b/docker/scrape-courses/entrypoint.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 export SETTINGS_MODE=schedule
-# Need to dynamically retrieve the current term?
 python3 manage.py scrape_courses --recent --settings=autoscheduler.settings.docker

--- a/docker/scrape-courses/entrypoint.sh
+++ b/docker/scrape-courses/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-export SETTINGS_MODE=proxy
+export SETTINGS_MODE=schedule
 # Need to dynamically retrieve the current term?
-python3 manage.py scrape_courses -t 202031
+python3 manage.py scrape_courses -t 202031 --settings=autoscheduler.settings.docker

--- a/docker/scrape-courses/entrypoint.sh
+++ b/docker/scrape-courses/entrypoint.sh
@@ -1,6 +1,4 @@
 #!/bin/sh
-# Connect to the thing
 export SETTINGS_MODE=proxy
-#./cloud_sql_proxy -instances=$GCP_INSTANCE_NAME=tcp:3306 &
 # Need to dynamically retrieve the current term?
 python3 manage.py scrape_courses -t 202031

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Connect to the thing
+export SETTINGS_MODE=proxy
+#./cloud_sql_proxy -instances=$GCP_INSTANCE_NAME=tcp:3306 &
+# Need to dynamically retrieve the current term?
+python3 manage.py scrape_courses -t 202031


### PR DESCRIPTION
## Description

So this is mainly two parts: getting scrape_courses to connect to Google Cloud SQL and running scrape courses in Docker, and adding `--recent` flag to `scrape_courses`. I'll also discuss how the scheduling works in GCP, but since it's all just configs you really can't see the changes in this PR lol.

### Docker containers

So this actually won't work if you run it locally since the cloud sql proxy won't be authenticated. However if you run it on Compute Engine, it uses Google Default App Credentials that are automatically on the Compute Engine instance, so we don't need to pass any credentials.

Since I added new docker containers to the `docker-compose.yml` file, so we run the according container by specifying it, e.g. `docker-compose up --build scrape-courses` (`cloud-sql-proxy` will automatically start since `scrape-courses` depends on it). Note that we have to do the same thing when we run the tests for CI, i.e. `docker-compose up --build web`.

For the settings changes, I opted to use the docker settings file rather than add another to `base.py` just to reduce confusion with the environment variables. The `_IS_SCHEDULE` flag db settings is the same as the `_IS_PROXY` one, except that the host is `cloud-sql-proxy` (corresponds to the docker container name).

### Scrape_courses --recent

Pretty straight-forward, just adds a `--recent` flag to scrape_courses. I basically follow the logic that if it's before the registration date for that term, scrape the one before it.

### GCP Scheduling setup

It follows [this tutorial](https://cloud.google.com/scheduler/docs/start-and-stop-compute-engine-instances-on-a-schedule) on the GCP website.

It starts with the [Cloud Scheduler](https://console.cloud.google.com/cloudscheduler), which I have configured to run every 3 hours. Cloud Scheduler triggers a [Cloud Pub/Sub](https://console.cloud.google.com/cloudpubsub/topic/list) `start-instance-event`. Then there is a [Cloud Function](https://console.cloud.google.com/functions) that responds to the `start-instance-event` (called `startInstancePubSub`). The Cloud Function runs a JS script (copy/pasted from the tutorial) that starts the specified [Compute Engine](https://console.cloud.google.com/compute/instances) instances. Next, when the Compute Engine starts up, it runs a startup script that fetches the repo and updates itself with `origin/master`, runs `docker-compose up --build scrape-courses`, then runs `sudo terminate` at the end of it to stop the instance. 

Succinctly: 
1. Cloud Scheduler runs every 3 hours, sending a Pub/Sub `start-instance-event` event
2. The Pub/Sub event triggers a Cloud Function
3. The Cloud Function starts the Compute Engine instance
4. Compute Engine instance runs the startup script and updates & runs scrape_courses
5. Compute Engine script finishes and runs `sudo terminate` to stop the instance.

## How to test

You can test the `--recent` change just by running `scrape_courses --recent` and ensuring it scrapes for the correct terms (fall+summer 2020 for all locations).

Testing the docker change is a bit harder since we have to change it to pass in the credentials file. As such, you can just check that Compute Engine is running correctly by checking out the logs for it [here](https://console.cloud.google.com/sql/instances)

## Related tasks

Closes #192
