### PR TITLE
Add Google Auth .env filling for CD

### DIFF
--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Fill in Postgres credentials
         run: bash fill_credentials.sh ${{ secrets.POSTGRES_USER }} ${{ secrets.POSTGRES_PASS }}
 
+      - name: Fill .env Google Auth credentials
+        run: bash fill_google_auth_credentials.sh ${{ secrets.GOOGLE_CLIENT_ID }} ${{ secrets.GOOGLE_CLIENT_SECRET }}
+
       - name: Initialize Google Cloud SDK
         uses: zxyle/publish-gae-action@master
         with:

--- a/autoscheduler/.gcloudignore
+++ b/autoscheduler/.gcloudignore
@@ -139,7 +139,6 @@ celerybeat-schedule
 *.sage.py
 
 # Environments
-.env
 .venv
 ENV/
 env.bak/

--- a/fill_google_auth_credentials.sh
+++ b/fill_google_auth_credentials.sh
@@ -1,0 +1,2 @@
+# -e enables interpretation of backslash escapes (so we can use \n for a new line)
+echo -e "GOOGLE_OAUTH2_CLIENT_ID='$1'\nGOOGLE_OAUTH2_SECRET='$2'" > autoscheduler/autoscheduler/settings/.env


### PR DESCRIPTION
## Description

Pretty straightforward - this adds the filling of the `.env` file for Google Auth.

## How to test

Per 6c7d749, I added a temp commit that makes the deployment run on PR so we can double check that this is actually working. As such, just go to http://revregistration.com and check that you can log in with Google!

Note that frankly this is a terrible way of testing this (cause I could break the deployment), but lol yolo

## Related tasks

Closes #314
