### PR TITLE
Fix 415 error in scheduler/generate

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
@@ -89,6 +89,9 @@ const ConfigureCard: React.FC = () => {
     // make request to generate schedules and update redux, will also save availabilities
     fetch('scheduler/generate', {
       method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
       body: JSON.stringify({
         term,
         includeFull,


### PR DESCRIPTION
## Description

Fixes the error `415 Unsupported media type "text/plain;charset=UTF-8" in request.` by adding a `Content-Type` header to `scheduler/generate`

## Rationale
DRF expects the `Content-Type` to be set (see [this page](https://www.django-rest-framework.org/api-guide/parsers/#how-the-parser-is-determined)), and since we weren't setting it, there was no guarantee that requests would be handled properly.

## How to test

Click the generate schedules button, and now instead of a 415 error, you get a 403 error (which we need to fix separately for all of our POST + PUT requests)! Hooray! Our tests were already setting `Content-Type`:
```python
        result = self.client.post('/scheduler/generate', request_body, format='json')
```
so there's no need to change anything there.

## Related tasks
We don't have an issue for this problem, but Gannon pointed it out yesterday in our discord server.
