### PR TITLE
Optimize course card loading

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.tsx
@@ -29,11 +29,10 @@ const ExpandedCourseCard: React.FC<ExpandedCourseCardProps> = ({
 
   const term = useSelector<RootState, string>((state) => state.term);
   const dispatch = useDispatch();
-  const { course, customizationLevel, sections } = courseCardOptions;
+  const { course, customizationLevel, loading } = courseCardOptions;
 
   const [options, setOptions] = React.useState([]);
   const [inputValue, setInputValue] = React.useState('');
-  const [loading, setLoading] = React.useState(false);
 
   function getAutocomplete(text: string): void {
     fetch(`api/course/search?search=${text}&term=${term}`).then(
@@ -73,7 +72,6 @@ const ExpandedCourseCard: React.FC<ExpandedCourseCardProps> = ({
       </div>
     );
   }
-  React.useEffect(() => setLoading(false), [sections]);
 
   return (
     <Card>
@@ -120,7 +118,6 @@ const ExpandedCourseCard: React.FC<ExpandedCourseCardProps> = ({
             if (options.length === 0) setInputValue('');
           }}
           onChange={(_evt: object, val: string): void => {
-            if (val) setLoading(true);
             dispatch(updateCourseCard(id, {
               course: val,
             }, term));

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.tsx
@@ -107,6 +107,7 @@ const ExpandedCourseCard: React.FC<ExpandedCourseCardProps> = ({
           size="small"
           autoHighlight
           autoSelect
+          disabled={loading}
           inputValue={inputValue}
           value={course}
           multiple={false}

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.tsx
@@ -44,34 +44,32 @@ const ExpandedCourseCard: React.FC<ExpandedCourseCardProps> = ({
     });
   }
 
-  // determine customization content based on customization level
-  let customizationContent: JSX.Element = null;
-  switch (customizationLevel) {
-    case CustomizationLevel.BASIC:
-      customizationContent = <BasicSelect id={id} />;
-      break;
-    case CustomizationLevel.SECTION:
-      customizationContent = course
-        ? <SectionSelect id={id} />
-        : (
-          <Typography className={styles.grayText}>
-            Select a course to show available sections
-          </Typography>
-        );
-      break;
-    default:
-      customizationContent = null;
-  }
-
-  // show loading if we're not sure what sections are available
-  if (loading) {
-    customizationContent = (
-      <div id={styles.centerProgress}>
-        <SmallFastProgress />
-        Loading sections...
-      </div>
-    );
-  }
+  // determine customization content based on whether the card is loading and customization level
+  const customizationContent = React.useMemo(() => {
+    // show loading if we're not sure what sections are available
+    if (loading) {
+      return (
+        <div id={styles.centerProgress}>
+          <SmallFastProgress />
+          Loading sections...
+        </div>
+      );
+    }
+    switch (customizationLevel) {
+      case CustomizationLevel.BASIC:
+        return <BasicSelect id={id} />;
+      case CustomizationLevel.SECTION:
+        return course
+          ? <SectionSelect id={id} />
+          : (
+            <Typography className={styles.grayText}>
+              Select a course to show available sections
+            </Typography>
+          );
+      default:
+        return null;
+    }
+  }, [course, customizationLevel, id, loading]);
 
   return (
     <Card>

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
@@ -26,7 +26,7 @@ const CourseSelectColumn: React.FC = () => {
     if (term) {
       fetch(`sessions/get_saved_courses?term=${term}`).then((res) => (
         res.json()
-      )).then((courses: SerializedCourseCardOptions[]) => {
+      )).catch(() => []).then((courses: SerializedCourseCardOptions[]) => {
         dispatch(replaceCourseCards(courses, term));
       });
     }

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
@@ -7,7 +7,10 @@ import { RootState } from '../../../redux/reducer';
 import { CourseCardArray, SerializedCourseCardOptions } from '../../../types/CourseCardOptions';
 import CourseSelectCard from './CourseSelectCard/CourseSelectCard';
 import { addCourseCard, replaceCourseCards, clearCourseCards } from '../../../redux/actions/courseCards';
-import throttle from '../../../utils/throttle';
+import createThrottleFunction from '../../../utils/createThrottleFunction';
+
+// Creates a throttle function that shares state between calls
+const throttle = createThrottleFunction();
 
 /**
  * Renders a column of CourseSelectCards, as well as a button to add course cards
@@ -75,9 +78,8 @@ const CourseSelectColumn: React.FC = () => {
       });
     };
 
-    throttle(`saveCourseCards${term}`, saveCourses, 15000, true);
+    throttle(`${term}`, saveCourses, 15000, true);
   }, [courseCards, term]);
-
 
   const rows: JSX.Element[] = [];
 

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
@@ -42,6 +42,11 @@ const CourseSelectColumn: React.FC = () => {
   React.useEffect(() => {
     if (!term) return;
 
+    // if any course cards are loading, don't try to save
+    for (let i = 0; i < courseCards.numCardsCreated; i++) {
+      if (courseCards[i]?.loading) return;
+    }
+
     const saveCourses = (): void => {
       // Serialize courseCards and make API call
       const courses: SerializedCourseCardOptions[] = [];

--- a/autoscheduler/frontend/src/redux/actions/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/actions/courseCards.ts
@@ -210,7 +210,7 @@ function updateCourseCardAsync(
 ): ThunkAction<Promise<void>, RootState, undefined, UpdateCourseAction> {
   return (dispatch): Promise<void> => new Promise((resolve) => {
     fetchCourseCardFrom(courseCard, term).then((updatedCourseCard) => {
-      if (courseCard) {
+      if (updatedCourseCard) {
         dispatch(updateCourseCardSync(index, updatedCourseCard));
         resolve();
       }

--- a/autoscheduler/frontend/src/redux/actions/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/actions/courseCards.ts
@@ -4,10 +4,7 @@ import {
 } from '../../types/CourseCardOptions';
 import {
   AddCourseAction, ADD_COURSE_CARD, RemoveCourseAction, REMOVE_COURSE_CARD, UpdateCourseAction,
-  UPDATE_COURSE_CARD,
-  ClearCourseCardsAction,
-  CLEAR_COURSE_CARDS,
-  CourseCardAction,
+  UPDATE_COURSE_CARD, ClearCourseCardsAction, CLEAR_COURSE_CARDS, CourseCardAction,
 } from '../reducers/courseCards';
 import { RootState } from '../reducer';
 import Meeting, { MeetingType } from '../../types/Meeting';
@@ -173,7 +170,7 @@ function sortSections(sections: SectionSelected[]): SectionSelected[] {
 
 /**
  * Fetches sections for course in courseCard, then updates courseCard with new sections.
- * If the course card is valid or sections can't be fetched, returns undefined.
+ * If the course card is invalid or sections can't be fetched, returns undefined.
  * @param courseCard course to get sections for
  * @param term term to fetch sections for
  */
@@ -301,7 +298,7 @@ export function replaceCourseCards(
       dispatch(updateCourseCardSync(idx, deserializedCard));
     });
 
-    // all course cards are now loading (preventing courses from being overwritten
+    // all course cards are now marked as loading (preventing courses from being overwritten
     // if the page is closed), fetch sections
     deserializedCards.forEach((deserializedCard, idx) => {
       dispatch(updateCourseCardAsync(idx, deserializedCard, term)).then(() => {

--- a/autoscheduler/frontend/src/redux/actions/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/actions/courseCards.ts
@@ -194,7 +194,6 @@ async function fetchCourseCardFrom(
         sections,
         hasHonors,
         hasWeb,
-        loading: false,
       };
     })
     .catch(() => undefined);
@@ -210,7 +209,6 @@ function updateCourseCardAsync(
   index: number, courseCard: CourseCardOptions, term: string,
 ): ThunkAction<Promise<void>, RootState, undefined, UpdateCourseAction> {
   return (dispatch): Promise<void> => new Promise((resolve) => {
-    dispatch(updateCourseCardSync(index, { course: courseCard.course, loading: true }));
     fetchCourseCardFrom(courseCard, term).then((updatedCourseCard) => {
       if (courseCard) {
         dispatch(updateCourseCardSync(index, updatedCourseCard));
@@ -234,7 +232,10 @@ export function updateCourseCard(index: number, courseCard: CourseCardOptions, t
       if (term === '') {
         throw Error('Term is empty string when passed to updateCourseCardAsync!');
       }
-      dispatch(updateCourseCardAsync(index, courseCard, term));
+      dispatch(updateCourseCardSync(index, { course: courseCard.course, loading: true }));
+      dispatch(updateCourseCardAsync(index, courseCard, term)).then(() => {
+        dispatch(updateCourseCardSync(index, { loading: false }));
+      });
     } else {
       dispatch(updateCourseCardSync(index, { ...courseCard, loading: false }));
     }

--- a/autoscheduler/frontend/src/redux/reducers/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/reducers/courseCards.ts
@@ -41,6 +41,7 @@ const initialCourseCardArray: CourseCardArray = {
     web: 'exclude',
     honors: 'exclude',
     sections: [],
+    loading: true,
   },
 };
 

--- a/autoscheduler/frontend/src/redux/reducers/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/reducers/courseCards.ts
@@ -66,6 +66,7 @@ export default function courseCards(
       return {
         ...state,
         [action.index]: { ...state[action.index], ...action.courseCard },
+        numCardsCreated: Math.max(state.numCardsCreated, action.index + 1),
       };
     case CLEAR_COURSE_CARDS:
       return initialCourseCardArray;

--- a/autoscheduler/frontend/src/tests/redux/CourseCards.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/CourseCards.test.ts
@@ -309,7 +309,7 @@ describe('Course Cards Redux', () => {
       store.dispatch(clearCourseCards());
 
       // assert
-      expect(store.getState().courseCards).toEqual(expected);
+      expect(store.getState().courseCards).toMatchObject(expected);
     });
   });
 

--- a/autoscheduler/frontend/src/tests/redux/Redux.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/Redux.test.ts
@@ -126,7 +126,7 @@ test('Initial state has one empty course card', () => {
   const store = createStore(autoSchedulerReducer);
 
   // asssert
-  expect(store.getState().courseCards).toEqual({
+  expect(store.getState().courseCards).toMatchObject({
     0: {
       course: '',
       customizationLevel: CustomizationLevel.BASIC,

--- a/autoscheduler/frontend/src/tests/ui/ConfigureCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/ConfigureCard.test.tsx
@@ -108,7 +108,7 @@ describe('ConfigureCard component', () => {
       expect(courses[0].sections).toEqual(['501', '502', '503']);
     });
 
-    test('Does not send honors and web when customization level is Section', () => {
+    test('Does not send honors and web when customization level is Section', async () => {
       // arrange
       const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
       const { getByText } = render(
@@ -140,6 +140,7 @@ describe('ConfigureCard component', () => {
       }));
 
       // act
+      await new Promise(setImmediate);
       fireEvent.click(getByText('Generate Schedules'));
 
       // second call is the /scheduler/generate call. Second index of that call is the body

--- a/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
@@ -17,6 +17,7 @@ import CourseSelectCard from '../../components/SchedulingPage/CourseSelectColumn
 import autoSchedulerReducer from '../../redux/reducer';
 import testFetch from '../testData';
 import setTerm from '../../redux/actions/term';
+import { updateCourseCard } from '../../redux/actions/courseCards';
 
 const dummySectionArgs = {
   id: 123456,
@@ -561,6 +562,8 @@ describe('Course Select Card UI', () => {
         const { getByText } = render(
           <Provider store={store}><CourseSelectCard id={0} /></Provider>,
         );
+        // Stop course card from loading
+        store.dispatch<any>(updateCourseCard(0, { loading: false }));
 
         // assert
         expect(getByText('Select a course to show available options')).toBeInTheDocument();

--- a/autoscheduler/frontend/src/tests/ui/CourseSelectColumn.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/CourseSelectColumn.test.tsx
@@ -204,7 +204,6 @@ describe('CourseSelectColumn', () => {
       await new Promise(setImmediate);
 
       // assert
-      // console.log(fetchMock.mock.calls)
       expectCardsToBeSavedForTerm('202031');
     });
 

--- a/autoscheduler/frontend/src/tests/ui/CourseSelectColumn.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/CourseSelectColumn.test.tsx
@@ -13,6 +13,7 @@ import autoSchedulerReducer from '../../redux/reducer';
 import CourseSelectColumn from '../../components/SchedulingPage/CourseSelectColumn/CourseSelectColumn';
 import testFetch from '../testData';
 import setTerm from '../../redux/actions/term';
+import { updateCourseCard } from '../../redux/actions/courseCards';
 
 beforeAll(() => fetchMock.enableMocks());
 
@@ -24,6 +25,19 @@ function ignoreInvisible(content: string, element: HTMLElement, query: string | 
   if (element.style.visibility === 'hidden') return false;
   return content.match(query) && content.match(query).length > 0;
 }
+
+// Function that mocks responses from save_courses and get_saved_courses
+const mockCourseAPI = (request: Request): Promise<MockResponseInit | string> => (
+  new Promise((resolve) => {
+    if (request.url === 'sessions/save_courses') {
+      resolve({
+        body: '',
+        init: { status: 204 },
+      });
+    }
+    resolve(JSON.stringify({}));
+  })
+);
 
 describe('CourseSelectColumn', () => {
   describe('Adds a course card', () => {
@@ -164,19 +178,6 @@ describe('CourseSelectColumn', () => {
   });
 
   describe('saves course cards', () => {
-    // Function that mocks responses from save_courses and get_saved_courses
-    const mockCourseAPI = (request: Request): Promise<MockResponseInit | string> => (
-      new Promise((resolve) => {
-        if (request.url === 'sessions/save_courses') {
-          resolve({
-            body: '',
-            init: { status: 204 },
-          });
-        }
-        resolve(JSON.stringify({}));
-      })
-    );
-
     const expectCardsToBeSavedForTerm = (term: string): void => {
       const saved = fetchMock.mock.calls.some((call) => (
         call[0] === 'sessions/save_courses' && JSON.parse(call[1].body.toString()).term === term
@@ -207,7 +208,7 @@ describe('CourseSelectColumn', () => {
       expectCardsToBeSavedForTerm('202031');
     });
 
-    test('when the website is closed', () => {
+    test('when the website is closed', async () => {
       // arrange
       fetchMock.mockResponse(mockCourseAPI);
 
@@ -220,12 +221,46 @@ describe('CourseSelectColumn', () => {
         </Provider>,
       );
 
+      await new Promise(setImmediate);
+
       // act
       // dispatch beforeunload event, since jest doesn't handle window.close() properly
       window.dispatchEvent(new Event('beforeunload'));
 
       // assert
       expectCardsToBeSavedForTerm('202031');
+    });
+  });
+
+  describe('does not save courses', () => {
+    const expectCardsNotToBeSavedForTerm = (term: string): void => {
+      const saved = fetchMock.mock.calls.some((call) => (
+        call[0] === 'sessions/save_courses' && JSON.parse(call[1].body.toString()).term === term
+      ));
+
+      if (saved) throw new Error(`save_courses was called for term ${term}`);
+    };
+
+    test('when a course card is loading', async () => {
+      // arrange
+      fetchMock.mockResponse(mockCourseAPI);
+
+      const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
+      store.dispatch(setTerm('202031'));
+
+      render(
+        <Provider store={store}>
+          <CourseSelectColumn />
+        </Provider>,
+      );
+
+      // act: wait for all cards to finish loading, then make them load again
+      // to avoid this test passing by chance
+      await new Promise(setImmediate);
+      store.dispatch<any>(updateCourseCard(0, { loading: true }));
+
+      // assert
+      expectCardsNotToBeSavedForTerm('202031');
     });
   });
 });

--- a/autoscheduler/frontend/src/types/CourseCardOptions.ts
+++ b/autoscheduler/frontend/src/types/CourseCardOptions.ts
@@ -24,6 +24,7 @@ export interface CourseCardOptions {
   hasHonors?: boolean;
   hasWeb? : boolean;
   sections?: SectionSelected[];
+  loading?: boolean;
 }
 
 // Represents a course card when saved and serialized, sections are saved as strings

--- a/autoscheduler/frontend/src/utils/createThrottleFunction.ts
+++ b/autoscheduler/frontend/src/utils/createThrottleFunction.ts
@@ -1,13 +1,17 @@
 /**
- * Function to throttles the execution of another function (specified by callback). If throttle is
- * called again with the same id before delay ms has passed, it will run the new callback once the
- * timer is over instead of running the old one. Each id works on a separate timer.
+ * Generates a function that throttles execution of other functions(specified by callback). If
+ * throttle is called again with the same id before delay ms has passed, it runs the new callback
+ * once the timer is over instead of running the old one. Each id works on a separate timer.
+ * To use, put the following line at the top of a module:
+ * const throttle = createThrottleFunction();
+ * Then to use it, use "throttle(id, callback, delay, runOtherIds)"
  * @param id ID to use, each ID operates on a separate timer
  * @param callback Callback to run after delay expires
  * @param delay Delay (in ms) before running effect
  * @param runOtherIDs Whether to immediately run pending callbacks for IDs other than specified id
  */
-const throttle = ((): (id: string, callback: any, delay: number, runOtherIDs: boolean) => void => {
+const createThrottleFunction = (): (
+  id: string, callback: any, delay: number, runOtherIDs: boolean) => void => {
   const intervals = new Map<string, number>();
   const intervalTimes = new Map<string, number>();
   const functions = new Map<string, any>();
@@ -52,6 +56,6 @@ const throttle = ((): (id: string, callback: any, delay: number, runOtherIDs: bo
     // Update function to run when interval completes
     functions.set(id, callback);
   };
-})();
+};
 
-export default throttle;
+export default createThrottleFunction;

--- a/autoscheduler/frontend/src/utils/throttle.ts
+++ b/autoscheduler/frontend/src/utils/throttle.ts
@@ -27,7 +27,7 @@ const throttle = ((): (id: string, callback: any, delay: number, runOtherIDs: bo
         const toRun = functions.get(id);
         if (typeof toRun === 'function') toRun();
         functions.delete(id);
-        window.removeEventListener('beforeunload', functions.get(id));
+        window.removeEventListener('beforeunload', toRun);
       }, delay);
     }
 
@@ -45,11 +45,12 @@ const throttle = ((): (id: string, callback: any, delay: number, runOtherIDs: bo
       });
     }
 
+    // Update beforeunload event listener so callback is fired before close/refresh
+    window.removeEventListener('beforeunload', functions.get(id));
+    window.addEventListener('beforeunload', callback);
+
     // Update function to run when interval completes
     functions.set(id, callback);
-
-    // Update beforeunload event listener so callback is fired before close/refresh
-    window.addEventListener('beforeunload', callback);
   };
 })();
 


### PR DESCRIPTION
## Description

This PR moves `loading` for course cards into redux, and makes a couple of really nice changes that are now possible because of this change:
- Course names are loaded as soon as saved courses are fetched, and the loading indicator is displayed while it fetches the sections for each course
- It's now impossible (at least as far as I can tell) to overwrite your saved courses, since it checks if any course cards are loading before trying to save, and there should always be a course card loading from the time the page loads until either the fetch for saved courses fails, or all of the cards have been loaded.
I also added error handling to several places in the courseCards redux and course card column, I think that now it's robust enough that it shouldn't throw errors regardless of what any fetches return.

## Rationale

I moved course card loading to redux so that I could abstract away loading from the component itself (and let redux deal with all the logic), and also use it outside of individual course cards. I had to reorganize a fair bit of the redux to do this, but I think it's just as clean/cleaner than before.

## How to test

Try closing the page or switching terms whenever you want, and I think that there's no way it will overwrite your course cards until they're fully loaded, also look at how you can see loading indicators while course cards are initially loading

## Screenshots

![image](https://user-images.githubusercontent.com/28655462/93559896-67a33e80-f946-11ea-9cfd-65fbe007bd49.png)

## Related tasks

Closing tag. Don't forget to link the issue w/ the PR in ZenHub at the bottom.

Closes #323.