### PR TITLE
Fix Z index for dialog and availability card

### DIFF
--- a/autoscheduler/frontend/src/components/App/App.css.d.ts
+++ b/autoscheduler/frontend/src/components/App/App.css.d.ts
@@ -1,13 +1,13 @@
-declare namespace AppCssModule {
+declare namespace AppCssNamespace {
   export interface IAppCss {
     "app-container": string;
     appContainer: string;
   }
 }
 
-declare const AppCssModule: AppCssModule.IAppCss & {
+declare const AppCssModule: AppCssNamespace.IAppCss & {
   /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
-  locals: AppCssModule.IAppCss;
+  locals: AppCssNamespace.IAppCss;
 };
 
 export = AppCssModule;

--- a/autoscheduler/frontend/src/components/GenericCard/GenericCard.css.d.ts
+++ b/autoscheduler/frontend/src/components/GenericCard/GenericCard.css.d.ts
@@ -1,13 +1,13 @@
-declare namespace GenericCardCssModule {
+declare namespace GenericCardCssNamespace {
   export interface IGenericCardCss {
     container: string;
     header: string;
   }
 }
 
-declare const GenericCardCssModule: GenericCardCssModule.IGenericCardCss & {
+declare const GenericCardCssModule: GenericCardCssNamespace.IGenericCardCss & {
   /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
-  locals: GenericCardCssModule.IGenericCardCss;
+  locals: GenericCardCssNamespace.IGenericCardCss;
 };
 
 export = GenericCardCssModule;

--- a/autoscheduler/frontend/src/components/LandingPage/LandingPage.css.d.ts
+++ b/autoscheduler/frontend/src/components/LandingPage/LandingPage.css.d.ts
@@ -1,12 +1,12 @@
-declare namespace LandingPageCssModule {
+declare namespace LandingPageCssNamespace {
   export interface ILandingPageCss {
     container: string;
   }
 }
 
-declare const LandingPageCssModule: LandingPageCssModule.ILandingPageCss & {
+declare const LandingPageCssModule: LandingPageCssNamespace.ILandingPageCss & {
   /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
-  locals: LandingPageCssModule.ILandingPageCss;
+  locals: LandingPageCssNamespace.ILandingPageCss;
 };
 
 export = LandingPageCssModule;

--- a/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.css.d.ts
+++ b/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.css.d.ts
@@ -1,4 +1,4 @@
-declare namespace SelectTermCssModule {
+declare namespace SelectTermCssNamespace {
   export interface ISelectTermCss {
     "button-container": string;
     buttonContainer: string;
@@ -7,9 +7,9 @@ declare namespace SelectTermCssModule {
   }
 }
 
-declare const SelectTermCssModule: SelectTermCssModule.ISelectTermCss & {
+declare const SelectTermCssModule: SelectTermCssNamespace.ISelectTermCss & {
   /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
-  locals: SelectTermCssModule.ISelectTermCss;
+  locals: SelectTermCssNamespace.ISelectTermCss;
 };
 
 export = SelectTermCssModule;

--- a/autoscheduler/frontend/src/components/LargeTextCard/LargeTextCard.css.d.ts
+++ b/autoscheduler/frontend/src/components/LargeTextCard/LargeTextCard.css.d.ts
@@ -1,13 +1,13 @@
-declare namespace LargeTextCardCssModule {
+declare namespace LargeTextCardCssNamespace {
   export interface ILargeTextCardCss {
     container: string;
     paper: string;
   }
 }
 
-declare const LargeTextCardCssModule: LargeTextCardCssModule.ILargeTextCardCss & {
+declare const LargeTextCardCssModule: LargeTextCardCssNamespace.ILargeTextCardCss & {
   /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
-  locals: LargeTextCardCssModule.ILargeTextCardCss;
+  locals: LargeTextCardCssNamespace.ILargeTextCardCss;
 };
 
 export = LargeTextCardCssModule;

--- a/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.css.d.ts
@@ -1,4 +1,4 @@
-declare namespace ConfigureCardCssModule {
+declare namespace ConfigureCardCssNamespace {
   export interface IConfigureCardCss {
     "button-container": string;
     buttonContainer: string;
@@ -8,9 +8,9 @@ declare namespace ConfigureCardCssModule {
   }
 }
 
-declare const ConfigureCardCssModule: ConfigureCardCssModule.IConfigureCardCss & {
+declare const ConfigureCardCssModule: ConfigureCardCssNamespace.IConfigureCardCss & {
   /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
-  locals: ConfigureCardCssModule.IConfigureCardCss;
+  locals: ConfigureCardCssNamespace.IConfigureCardCss;
 };
 
 export = ConfigureCardCssModule;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/CollapsedCourseCard/CollapsedCourseCard.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/CollapsedCourseCard/CollapsedCourseCard.css.d.ts
@@ -1,4 +1,4 @@
-declare namespace CollapsedCourseCardCssModule {
+declare namespace CollapsedCourseCardCssNamespace {
   export interface ICollapsedCourseCardCss {
     "custom-box": string;
     customBox: string;
@@ -7,9 +7,9 @@ declare namespace CollapsedCourseCardCssModule {
   }
 }
 
-declare const CollapsedCourseCardCssModule: CollapsedCourseCardCssModule.ICollapsedCourseCardCss & {
+declare const CollapsedCourseCardCssModule: CollapsedCourseCardCssNamespace.ICollapsedCourseCardCss & {
   /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
-  locals: CollapsedCourseCardCssModule.ICollapsedCourseCardCss;
+  locals: CollapsedCourseCardCssNamespace.ICollapsedCourseCardCss;
 };
 
 export = CollapsedCourseCardCssModule;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.css.d.ts
@@ -1,4 +1,4 @@
-declare namespace BasicSelectCssModule {
+declare namespace BasicSelectCssNamespace {
   export interface IBasicSelectCss {
     "fit-content": string;
     fitContent: string;
@@ -13,9 +13,9 @@ declare namespace BasicSelectCssModule {
   }
 }
 
-declare const BasicSelectCssModule: BasicSelectCssModule.IBasicSelectCss & {
+declare const BasicSelectCssModule: BasicSelectCssNamespace.IBasicSelectCss & {
   /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
-  locals: BasicSelectCssModule.IBasicSelectCss;
+  locals: BasicSelectCssNamespace.IBasicSelectCss;
 };
 
 export = BasicSelectCssModule;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.css.d.ts
@@ -1,4 +1,4 @@
-declare namespace ExpandedCourseCardCssModule {
+declare namespace ExpandedCourseCardCssNamespace {
   export interface IExpandedCourseCardCss {
     "center-progress": string;
     centerProgress: string;
@@ -20,9 +20,9 @@ declare namespace ExpandedCourseCardCssModule {
   }
 }
 
-declare const ExpandedCourseCardCssModule: ExpandedCourseCardCssModule.IExpandedCourseCardCss & {
+declare const ExpandedCourseCardCssModule: ExpandedCourseCardCssNamespace.IExpandedCourseCardCss & {
   /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
-  locals: ExpandedCourseCardCssModule.IExpandedCourseCardCss;
+  locals: ExpandedCourseCardCssNamespace.IExpandedCourseCardCss;
 };
 
 export = ExpandedCourseCardCssModule;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/GradeDist/GradeDist.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/GradeDist/GradeDist.css.d.ts
@@ -1,4 +1,4 @@
-declare namespace GradeDistCssModule {
+declare namespace GradeDistCssNamespace {
   export interface IGradeDistCss {
     "gpa-underline": string;
     gpaUnderline: string;
@@ -9,9 +9,9 @@ declare namespace GradeDistCssModule {
   }
 }
 
-declare const GradeDistCssModule: GradeDistCssModule.IGradeDistCss & {
+declare const GradeDistCssModule: GradeDistCssNamespace.IGradeDistCss & {
   /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
-  locals: GradeDistCssModule.IGradeDistCss;
+  locals: GradeDistCssNamespace.IGradeDistCss;
 };
 
 export = GradeDistCssModule;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css.d.ts
@@ -1,4 +1,4 @@
-declare namespace SectionSelectCssModule {
+declare namespace SectionSelectCssNamespace {
   export interface ISectionSelectCss {
     "dense-list-item": string;
     denseListItem: string;
@@ -23,9 +23,9 @@ declare namespace SectionSelectCssModule {
   }
 }
 
-declare const SectionSelectCssModule: SectionSelectCssModule.ISectionSelectCss & {
+declare const SectionSelectCssModule: SectionSelectCssNamespace.ISectionSelectCss & {
   /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
-  locals: SectionSelectCssModule.ISectionSelectCss;
+  locals: SectionSelectCssNamespace.ISectionSelectCss;
 };
 
 export = SectionSelectCssModule;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.css.d.ts
@@ -1,4 +1,4 @@
-declare namespace CourseSelectColumnCssModule {
+declare namespace CourseSelectColumnCssNamespace {
   export interface ICourseSelectColumnCss {
     "add-course-button": string;
     addCourseButton: string;
@@ -13,9 +13,9 @@ declare namespace CourseSelectColumnCssModule {
   }
 }
 
-declare const CourseSelectColumnCssModule: CourseSelectColumnCssModule.ICourseSelectColumnCss & {
+declare const CourseSelectColumnCssModule: CourseSelectColumnCssNamespace.ICourseSelectColumnCss & {
   /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
-  locals: CourseSelectColumnCssModule.ICourseSelectColumnCss;
+  locals: CourseSelectColumnCssNamespace.ICourseSelectColumnCss;
 };
 
 export = CourseSelectColumnCssModule;

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/AvailabilityCard/AvailabilityCard.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/AvailabilityCard/AvailabilityCard.css.d.ts
@@ -1,13 +1,13 @@
-declare namespace AvailabilityCardCssModule {
+declare namespace AvailabilityCardCssNamespace {
   export interface IAvailabilityCardCss {
     container: string;
     icon: string;
   }
 }
 
-declare const AvailabilityCardCssModule: AvailabilityCardCssModule.IAvailabilityCardCss & {
+declare const AvailabilityCardCssModule: AvailabilityCardCssNamespace.IAvailabilityCardCss & {
   /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
-  locals: AvailabilityCardCssModule.IAvailabilityCardCss;
+  locals: AvailabilityCardCssNamespace.IAvailabilityCardCss;
 };
 
 export = AvailabilityCardCssModule;

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/HoveredTime/HoveredTime.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/HoveredTime/HoveredTime.css.d.ts
@@ -1,4 +1,4 @@
-declare namespace HoveredTimeCssModule {
+declare namespace HoveredTimeCssNamespace {
   export interface IHoveredTimeCss {
     container: string;
     label: string;
@@ -6,9 +6,9 @@ declare namespace HoveredTimeCssModule {
   }
 }
 
-declare const HoveredTimeCssModule: HoveredTimeCssModule.IHoveredTimeCss & {
+declare const HoveredTimeCssModule: HoveredTimeCssNamespace.IHoveredTimeCss & {
   /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
-  locals: HoveredTimeCssModule.IHoveredTimeCss;
+  locals: HoveredTimeCssNamespace.IHoveredTimeCss;
 };
 
 export = HoveredTimeCssModule;

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/InstructionsDialog/InstructionsDialog.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/InstructionsDialog/InstructionsDialog.css
@@ -9,6 +9,7 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
+    z-index: 5;
 }
 
 .availability-dialog {

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/InstructionsDialog/InstructionsDialog.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/InstructionsDialog/InstructionsDialog.css.d.ts
@@ -1,4 +1,4 @@
-declare namespace InstructionsDialogCssModule {
+declare namespace InstructionsDialogCssNamespace {
   export interface IInstructionsDialogCss {
     "availability-dialog": string;
     availabilityDialog: string;
@@ -9,9 +9,9 @@ declare namespace InstructionsDialogCssModule {
   }
 }
 
-declare const InstructionsDialogCssModule: InstructionsDialogCssModule.IInstructionsDialogCss & {
+declare const InstructionsDialogCssModule: InstructionsDialogCssNamespace.IInstructionsDialogCss & {
   /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
-  locals: InstructionsDialogCssModule.IInstructionsDialogCss;
+  locals: InstructionsDialogCssNamespace.IInstructionsDialogCss;
 };
 
 export = InstructionsDialogCssModule;

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/Schedule.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/Schedule.css.d.ts
@@ -1,4 +1,4 @@
-declare namespace ScheduleCssModule {
+declare namespace ScheduleCssNamespace {
   export interface IScheduleCss {
     "calendar-body": string;
     "calendar-container": string;
@@ -22,9 +22,9 @@ declare namespace ScheduleCssModule {
   }
 }
 
-declare const ScheduleCssModule: ScheduleCssModule.IScheduleCss & {
+declare const ScheduleCssModule: ScheduleCssNamespace.IScheduleCss & {
   /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
-  locals: ScheduleCssModule.IScheduleCss;
+  locals: ScheduleCssNamespace.IScheduleCss;
 };
 
 export = ScheduleCssModule;

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/ScheduleCard/ScheduleCard.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/ScheduleCard/ScheduleCard.css
@@ -11,7 +11,6 @@
     border-radius: 4px;
     box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
     box-sizing: border-box;
-    z-index: 3;
 }
 
 .schedule-card:hover {

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/ScheduleCard/ScheduleCard.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/ScheduleCard/ScheduleCard.css.d.ts
@@ -1,4 +1,4 @@
-declare namespace ScheduleCardCssModule {
+declare namespace ScheduleCardCssNamespace {
   export interface IScheduleCardCss {
     "drag-handle": string;
     "drag-handle-bot": string;
@@ -15,9 +15,9 @@ declare namespace ScheduleCardCssModule {
   }
 }
 
-declare const ScheduleCardCssModule: ScheduleCardCssModule.IScheduleCardCss & {
+declare const ScheduleCardCssModule: ScheduleCardCssNamespace.IScheduleCardCss & {
   /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
-  locals: ScheduleCardCssModule.IScheduleCardCss;
+  locals: ScheduleCardCssNamespace.IScheduleCardCss;
 };
 
 export = ScheduleCardCssModule;

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/ScheduleCard/ScheduleCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/ScheduleCard/ScheduleCard.tsx
@@ -73,6 +73,7 @@ const ScheduleCard: React.FC<ScheduleCardProps> = ({
       backgroundColor}, ${backgroundColor} 5px, white 5px, white 20px)` : undefined,
     backgroundColor: backgroundStripes ? undefined : backgroundColor,
     border: `2px solid ${borderColor || backgroundColor}`,
+    zIndex: onDragHandleDown ? 4 : 3,
   };
   const timeLabelStyle = {
     borderColor,

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/MiniSchedule/MiniSchedule.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/MiniSchedule/MiniSchedule.css.d.ts
@@ -1,4 +1,4 @@
-declare namespace MiniScheduleCssModule {
+declare namespace MiniScheduleCssNamespace {
   export interface IMiniScheduleCss {
     "aspect-ratio-box": string;
     aspectRatioBox: string;
@@ -14,9 +14,9 @@ declare namespace MiniScheduleCssModule {
   }
 }
 
-declare const MiniScheduleCssModule: MiniScheduleCssModule.IMiniScheduleCss & {
+declare const MiniScheduleCssModule: MiniScheduleCssNamespace.IMiniScheduleCss & {
   /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
-  locals: MiniScheduleCssModule.IMiniScheduleCss;
+  locals: MiniScheduleCssNamespace.IMiniScheduleCss;
 };
 
 export = MiniScheduleCssModule;

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css.d.ts
@@ -1,4 +1,4 @@
-declare namespace SchedulePreviewCssModule {
+declare namespace SchedulePreviewCssNamespace {
   export interface ISchedulePreviewCss {
     "card-header": string;
     cardHeader: string;
@@ -19,9 +19,9 @@ declare namespace SchedulePreviewCssModule {
   }
 }
 
-declare const SchedulePreviewCssModule: SchedulePreviewCssModule.ISchedulePreviewCss & {
+declare const SchedulePreviewCssModule: SchedulePreviewCssNamespace.ISchedulePreviewCss & {
   /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
-  locals: SchedulePreviewCssModule.ISchedulePreviewCss;
+  locals: SchedulePreviewCssNamespace.ISchedulePreviewCss;
 };
 
 export = SchedulePreviewCssModule;

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulingPage.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulingPage.css.d.ts
@@ -1,4 +1,4 @@
-declare namespace SchedulingPageCssModule {
+declare namespace SchedulingPageCssNamespace {
   export interface ISchedulingPageCss {
     "course-card-column-container": string;
     courseCardColumnContainer: string;
@@ -13,9 +13,9 @@ declare namespace SchedulingPageCssModule {
   }
 }
 
-declare const SchedulingPageCssModule: SchedulingPageCssModule.ISchedulingPageCss & {
+declare const SchedulingPageCssModule: SchedulingPageCssNamespace.ISchedulingPageCss & {
   /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
-  locals: SchedulingPageCssModule.ISchedulingPageCss;
+  locals: SchedulingPageCssNamespace.ISchedulingPageCss;
 };
 
 export = SchedulingPageCssModule;

--- a/autoscheduler/frontend/src/components/UnknownRoutePage/UnknownRoutePage.css.d.ts
+++ b/autoscheduler/frontend/src/components/UnknownRoutePage/UnknownRoutePage.css.d.ts
@@ -1,13 +1,13 @@
-declare namespace UnknownRoutePageCssModule {
+declare namespace UnknownRoutePageCssNamespace {
   export interface IUnknownRoutePageCss {
     "fill-page": string;
     fillPage: string;
   }
 }
 
-declare const UnknownRoutePageCssModule: UnknownRoutePageCssModule.IUnknownRoutePageCss & {
+declare const UnknownRoutePageCssModule: UnknownRoutePageCssNamespace.IUnknownRoutePageCss & {
   /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
-  locals: UnknownRoutePageCssModule.IUnknownRoutePageCss;
+  locals: UnknownRoutePageCssNamespace.IUnknownRoutePageCss;
 };
 
 export = UnknownRoutePageCssModule;


### PR DESCRIPTION
## Description

Fix Z index for dialog and availability card

## Rationale

I also had to update the CSS `.d.ts` files built by our CSS loader, most likely due to an updating the package back in #351 

## How to test

To test dialog, clear local storage. Reload. Add JAPN 201 for term Fall 2020. Include Full sections. Generate. Availability instructions dialog should cover classes.

To test availability cards, generate any schedule. Hover over meeting time in schedule. Move cursor to the start time label. Click and begin dragging. Stop dragging at end time label. Availability should be covering classes the entire time.