### PR TITLE
Memoized SectionInfo component

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
@@ -20,6 +20,7 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
   sectionData, secIdx, addInstructorLabel, toggleSelected,
 }) => {
   const { section, meetings, selected } = sectionData;
+
   const instructorLabel = addInstructorLabel
     ? (
       <>
@@ -145,6 +146,7 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
       <ListItemIcon className={styles.myListItemIcon}>
         <Checkbox
           checked={selected}
+          value={selected ? 'on' : 'off'}
           color="primary"
           size="small"
           className={styles.myIconButton}

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
@@ -3,6 +3,8 @@ import {
 } from '@material-ui/core';
 import HonorsIcon from '@material-ui/icons/School';
 import * as React from 'react';
+import { useDispatch } from 'react-redux';
+import { toggleSelected } from '../../../../../../redux/actions/courseCards';
 import { SectionSelected } from '../../../../../../types/CourseCardOptions';
 import Meeting, { MeetingType } from '../../../../../../types/Meeting';
 import { formatTime } from '../../../../../../utils/timeUtil';
@@ -11,15 +13,16 @@ import * as styles from './SectionSelect.css';
 
 interface SectionInfoProps {
     sectionData: SectionSelected;
+    courseCardId: number;
     secIdx: number;
     addInstructorLabel: boolean;
-    toggleSelected: (idx: number) => void;
 }
 
 const SectionInfo: React.FC<SectionInfoProps> = ({
-  sectionData, secIdx, addInstructorLabel, toggleSelected,
+  sectionData, courseCardId, secIdx, addInstructorLabel,
 }) => {
   const { section, meetings, selected } = sectionData;
+  const dispatch = useDispatch();
 
   const instructorLabel = addInstructorLabel
     ? (
@@ -138,7 +141,7 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
   // makes a list of the meetings in this section, along with one checkbox for all of them
   const sectionDetails = (
     <ListItem
-      onClick={(): void => toggleSelected(secIdx)}
+      onClick={(): void => { dispatch(toggleSelected(courseCardId, secIdx)); }}
       dense
       disableGutters
       button
@@ -179,6 +182,7 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
 const propsAreEqual = (
   prevProps: React.PropsWithChildren<SectionInfoProps>,
   nextProps: React.PropsWithChildren<SectionInfoProps>,
-): boolean => prevProps.sectionData.selected === nextProps.sectionData.selected;
+): boolean => prevProps.sectionData.selected === nextProps.sectionData.selected
+  && prevProps.courseCardId === nextProps.courseCardId;
 
 export default React.memo(SectionInfo, propsAreEqual);

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
@@ -1,0 +1,182 @@
+import {
+  ListSubheader, ListItemText, Divider, Tooltip, Typography, Checkbox, ListItem, ListItemIcon,
+} from '@material-ui/core';
+import HonorsIcon from '@material-ui/icons/School';
+import * as React from 'react';
+import { SectionSelected } from '../../../../../../types/CourseCardOptions';
+import Meeting, { MeetingType } from '../../../../../../types/Meeting';
+import { formatTime } from '../../../../../../utils/timeUtil';
+import GradeDist from './GradeDist/GradeDist';
+import * as styles from './SectionSelect.css';
+
+interface SectionInfoProps {
+    sectionData: SectionSelected;
+    secIdx: number;
+    addInstructorLabel: boolean;
+    toggleSelected: (idx: number) => void;
+}
+
+const SectionInfo: React.FC<SectionInfoProps> = ({
+  sectionData, secIdx, addInstructorLabel, toggleSelected,
+}) => {
+  const { section, meetings, selected } = sectionData;
+  const instructorLabel = addInstructorLabel
+    ? (
+      <>
+        <ListSubheader disableGutters className={styles.listSubheaderDense}>
+          <div className={styles.nameHonorsIcon}>
+            {section.instructor.name}
+            {section.honors ? (
+              <Tooltip title="Honors" placement="right">
+                <HonorsIcon data-testid="honors" />
+              </Tooltip>
+            ) : null}
+          </div>
+          {section.grades
+            ? <GradeDist grades={section.grades} />
+            : (
+              <div className={styles.noGradesAvailable}>
+                    No grades available
+              </div>
+            )}
+        </ListSubheader>
+        <div className={styles.dividerContainer}>
+          <Divider />
+        </div>
+      </>
+    )
+    : null;
+
+  const formatMeetingDays = (meeting: Meeting): string => {
+    const DAYS_OF_WEEK = ['M', 'T', 'W', 'R', 'F', 'S', 'U'];
+    return meeting.meetingDays.reduce((acc, curr, idx) => (curr ? acc + DAYS_OF_WEEK[idx] : acc), '');
+  };
+
+  const getMeetingTimeText = (mtg: Meeting): string => {
+    if (mtg.startTimeHours === 0) {
+      // If the time is 00:00, then it's meeting time is not applicable
+      return 'N/A';
+    }
+
+    // Returns it in the format 12:00 - 1:00
+    return `${formatTime(mtg.startTimeHours, mtg.startTimeMinutes)}
+        - ${formatTime(mtg.endTimeHours, mtg.endTimeMinutes)}`;
+  };
+
+  /**
+     * Accepts an array of meetings and returns a filtered array without duplicate meetings.
+     * Meetings are considered to be duplicates if they are of the same type, meet on the same days,
+     * and start at the same time. Meetings that are the same by all of these criteria but
+     * differ only in the end times will still be considered duplicates
+     * @param arr
+     */
+  const filterDuplicateMeetings = (arr: Meeting[]): Meeting[] => {
+    // helper function to merge two meetings
+    const mergeMeetings = (mtg1: Meeting, mtg2: Meeting): Meeting => {
+      if (!mtg2) return mtg1;
+
+      // choose the later end time
+      const [laterEndHours, laterEndMinutes] = mtg2.endTimeHours > mtg1.endTimeHours
+        ? [mtg2.endTimeHours, mtg2.endTimeMinutes]
+        : [mtg1.endTimeHours, mtg1.endTimeMinutes];
+        // merge the days array by logical OR of each element
+      const days = mtg1.meetingDays.map((hasMeeting, idx) => hasMeeting || mtg2.meetingDays[idx]);
+      return {
+        ...mtg1,
+        endTimeHours: laterEndHours,
+        endTimeMinutes: laterEndMinutes,
+        meetingDays: days,
+      };
+    };
+
+    // add all meetings to a map, then get the values of the map
+    const uniqueMeetings = new Map<string, Meeting>();
+    arr.forEach((mtg) => {
+      const key = `${mtg.meetingType}${mtg.startTimeHours}${mtg.startTimeMinutes}`;
+      uniqueMeetings.set(key, mergeMeetings(mtg, uniqueMeetings.get(key)));
+    });
+    return [...uniqueMeetings.values()];
+  };
+
+  // builds a div containing the section's number and available/max enrollment
+  const remainingSeats = section.maxEnrollment - section.currentEnrollment;
+  const remainingSeatsColor = remainingSeats > 0 ? 'black' : 'red';
+  // show section number and remaining seats if this is the first meeting for a section
+  const sectionHeader = (
+    <Typography className={styles.denseListItem} component="tr">
+      <td>
+        {section.sectionNum}
+      </td>
+      <td
+        style={{ color: remainingSeatsColor, textAlign: 'right' }}
+        colSpan={3}
+      >
+        {`${remainingSeats}/${section.maxEnrollment} seats left`}
+      </td>
+    </Typography>
+  );
+
+  const renderMeeting = (mtg: Meeting, showSectionNum: boolean): JSX.Element => (
+    <React.Fragment key={mtg.id}>
+      {showSectionNum ? sectionHeader : null }
+      <Typography className={styles.denseListItem} color="textSecondary" component="tr">
+        <td>{MeetingType[mtg.meetingType]}</td>
+        <td>{mtg.building || 'ONLINE'}</td>
+        <td>{formatMeetingDays(mtg)}</td>
+        <td>{getMeetingTimeText(mtg)}</td>
+      </Typography>
+    </React.Fragment>
+  );
+
+  // filters and then builds UI elements for the meetings that match this section
+  const meetingRows = filterDuplicateMeetings(
+    meetings.filter((mtg) => mtg.section.id === section.id),
+  ).map((mtg, mtgIdx) => renderMeeting(mtg, mtgIdx === 0));
+
+
+  // makes a list of the meetings in this section, along with one checkbox for all of them
+  const sectionDetails = (
+    <ListItem
+      onClick={(): void => toggleSelected(secIdx)}
+      dense
+      disableGutters
+      button
+    >
+      <ListItemIcon className={styles.myListItemIcon}>
+        <Checkbox
+          checked={selected}
+          color="primary"
+          size="small"
+          className={styles.myIconButton}
+        />
+      </ListItemIcon>
+      <ListItemText disableTypography>
+        <table className={styles.sectionDetailsTable}>
+          <colgroup>
+            <col width="15%" />
+            <col width="20%" />
+            <col width="20%" />
+            <col width="45%" />
+          </colgroup>
+          <tbody>
+            {meetingRows}
+          </tbody>
+        </table>
+      </ListItemText>
+    </ListItem>
+  );
+
+  return (
+    <React.Fragment key={section.sectionNum}>
+      {instructorLabel}
+      {sectionDetails}
+    </React.Fragment>
+  );
+};
+
+const propsAreEqual = (
+  prevProps: React.PropsWithChildren<SectionInfoProps>,
+  nextProps: React.PropsWithChildren<SectionInfoProps>,
+): boolean => prevProps.sectionData.selected === nextProps.sectionData.selected;
+
+export default React.memo(SectionInfo, propsAreEqual);

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { List, Typography } from '@material-ui/core';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { SectionSelected } from '../../../../../../types/CourseCardOptions';
 import { RootState } from '../../../../../../redux/reducer';
 import * as styles from './SectionSelect.css';
@@ -13,19 +13,8 @@ interface SectionSelectProps {
 
 const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
   const sections = useSelector<RootState, SectionSelected[]>(
-    (state) => state.courseCards[id].sections,
+    (state) => state.courseCards[id].sections, (left, right) => left === right,
   );
-  const dispatch = useDispatch();
-
-  const toggleSelected = React.useCallback((i: number): void => {
-    dispatch(updateCourseCard(id, {
-      sections: sections.map((sec, idx) => (idx !== i ? sec : {
-        section: sec.section,
-        selected: !sec.selected,
-        meetings: sec.meetings,
-      })),
-    }));
-  }, [dispatch, id, sections]);
 
   // show placeholder text if there are no sections
   if (sections.length === 0) {
@@ -49,9 +38,9 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
       return (
         <SectionInfo
           secIdx={secIdx}
+          courseCardId={id}
           sectionData={sectionData}
           addInstructorLabel={makeNewGroup}
-          toggleSelected={toggleSelected}
           key={sectionData.section.id}
         />
       );

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
@@ -1,18 +1,11 @@
 import * as React from 'react';
-import {
-  List, ListItemText, ListItem, Checkbox, ListItemIcon, Typography, ListSubheader,
-  Tooltip, Divider,
-} from '@material-ui/core';
-import HonorsIcon from '@material-ui/icons/School';
+import { List, Typography } from '@material-ui/core';
 import { useSelector, useDispatch } from 'react-redux';
-import Meeting, { MeetingType } from '../../../../../../types/Meeting';
-import Section from '../../../../../../types/Section';
-import { formatTime } from '../../../../../../utils/timeUtil';
 import { SectionSelected } from '../../../../../../types/CourseCardOptions';
 import { RootState } from '../../../../../../redux/reducer';
 import * as styles from './SectionSelect.css';
 import { updateCourseCard } from '../../../../../../redux/actions/courseCards';
-import GradeDist from './GradeDist/GradeDist';
+import SectionInfo from './SectionInfo';
 
 interface SectionSelectProps {
   id: number;
@@ -24,6 +17,16 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
   );
   const dispatch = useDispatch();
 
+  const toggleSelected = React.useCallback((i: number): void => {
+    dispatch(updateCourseCard(id, {
+      sections: sections.map((sec, idx) => (idx !== i ? sec : {
+        section: sec.section,
+        selected: !sec.selected,
+        meetings: sec.meetings,
+      })),
+    }));
+  }, [dispatch, id, sections]);
+
   // show placeholder text if there are no sections
   if (sections.length === 0) {
     return (
@@ -33,174 +36,24 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
     );
   }
 
-  const toggleSelected = (i: number): void => {
-    dispatch(updateCourseCard(id, {
-      sections: sections.map((sec, idx) => (idx !== i ? sec : {
-        section: sec.section,
-        selected: !sec.selected,
-        meetings: sec.meetings,
-      })),
-    }));
-  };
-
-  const formatMeetingDays = (meeting: Meeting): string => {
-    const DAYS_OF_WEEK = ['M', 'T', 'W', 'R', 'F', 'S', 'U'];
-    return meeting.meetingDays.reduce((acc, curr, idx) => (curr ? acc + DAYS_OF_WEEK[idx] : acc), '');
-  };
-
-  const getMeetingTimeText = (mtg: Meeting): string => {
-    if (mtg.startTimeHours === 0) {
-      // If the time is 00:00, then it's meeting time is not applicable
-      return 'N/A';
-    }
-
-    // Returns it in the format 12:00 - 1:00
-    return `${formatTime(mtg.startTimeHours, mtg.startTimeMinutes)}
-      - ${formatTime(mtg.endTimeHours, mtg.endTimeMinutes)}`;
-  };
-
-  /**
-   * Accepts an array of meetings and returns a filtered array without duplicate meetings.
-   * Meetings are considered to be duplicates if they are of the same type, meet on the same days,
-   * and start at the same time. Meetings that are the same by all of these criteria but
-   * differ only in the end times will still be considered duplicates
-   * @param arr
-   */
-  const filterDuplicateMeetings = (arr: Meeting[]): Meeting[] => {
-    // helper function to merge two meetings
-    const mergeMeetings = (mtg1: Meeting, mtg2: Meeting): Meeting => {
-      if (!mtg2) return mtg1;
-
-      // choose the later end time
-      const [laterEndHours, laterEndMinutes] = mtg2.endTimeHours > mtg1.endTimeHours
-        ? [mtg2.endTimeHours, mtg2.endTimeMinutes]
-        : [mtg1.endTimeHours, mtg1.endTimeMinutes];
-      // merge the days array by logical OR of each element
-      const days = mtg1.meetingDays.map((hasMeeting, idx) => hasMeeting || mtg2.meetingDays[idx]);
-      return {
-        ...mtg1,
-        endTimeHours: laterEndHours,
-        endTimeMinutes: laterEndMinutes,
-        meetingDays: days,
-      };
-    };
-
-    // add all meetings to a map, then get the values of the map
-    const uniqueMeetings = new Map<string, Meeting>();
-    arr.forEach((mtg) => {
-      const key = `${mtg.meetingType}${mtg.startTimeHours}${mtg.startTimeMinutes}`;
-      uniqueMeetings.set(key, mergeMeetings(mtg, uniqueMeetings.get(key)));
-    });
-    return [...uniqueMeetings.values()];
-  };
-
-  // returns a div containing the section's number and available/max enrollment
-  const createSectionHeader = (section: Section): JSX.Element => {
-    const remainingSeats = section.maxEnrollment - section.currentEnrollment;
-    const remainingSeatsColor = remainingSeats > 0 ? 'black' : 'red';
-    // show section number and remaining seats if this is the first meeting for a section
-    return (
-      <Typography className={styles.denseListItem} component="tr">
-        <td>
-          {section.sectionNum}
-        </td>
-        <td
-          style={{ color: remainingSeatsColor, textAlign: 'right' }}
-          colSpan={3}
-        >
-          {`${remainingSeats}/${section.maxEnrollment} seats left`}
-        </td>
-      </Typography>
-    );
-  };
-
-  const renderMeeting = (mtg: Meeting, showSectionNum: boolean): JSX.Element => (
-    <React.Fragment key={mtg.id}>
-      {showSectionNum ? createSectionHeader(mtg.section) : null }
-      <Typography className={styles.denseListItem} color="textSecondary" component="tr">
-        <td>{MeetingType[mtg.meetingType]}</td>
-        <td>{mtg.building || 'ONLINE'}</td>
-        <td>{formatMeetingDays(mtg)}</td>
-        <td>{getMeetingTimeText(mtg)}</td>
-      </Typography>
-    </React.Fragment>
-  );
-
   const makeList = (): JSX.Element[] => {
     let lastProf: string = null;
     let lastHonors = false;
-    return sections.map(({ section, selected, meetings }, secIdx) => {
-      const makeNewGroup = lastProf !== section.instructor.name || lastHonors !== section.honors;
-      const instructorLabel = makeNewGroup
-        ? (
-          <>
-            <ListSubheader disableGutters className={styles.listSubheaderDense}>
-              <div className={styles.nameHonorsIcon}>
-                {section.instructor.name}
-                {section.honors ? (
-                  <Tooltip title="Honors" placement="right">
-                    <HonorsIcon data-testid="honors" />
-                  </Tooltip>
-                ) : null}
-              </div>
-              {section.grades
-                ? <GradeDist grades={section.grades} />
-                : (
-                  <div className={styles.noGradesAvailable}>
-                    No grades available
-                  </div>
-                )}
-            </ListSubheader>
-            <div className={styles.dividerContainer}>
-              <Divider />
-            </div>
-          </>
-        )
-        : null;
-      lastProf = section.instructor.name;
-      lastHonors = section.honors;
+    return sections.map((sectionData, secIdx) => {
+      const makeNewGroup = lastProf !== sectionData.section.instructor.name
+        || lastHonors !== sectionData.section.honors;
 
-      // filters and then builds UI elements for the meetings that match this section
-      const meetingRows = filterDuplicateMeetings(
-        meetings.filter((mtg) => mtg.section.id === section.id),
-      ).map((mtg, mtgIdx) => renderMeeting(mtg, mtgIdx === 0));
+      lastProf = sectionData.section.instructor.name;
+      lastHonors = sectionData.section.honors;
 
-      // makes a list of the meetings in this section, along with one checkbox for all of them
-      const sectionDetails = (
-        <ListItem
-          onClick={(): void => toggleSelected(secIdx)}
-          dense
-          disableGutters
-          button
-        >
-          <ListItemIcon className={styles.myListItemIcon}>
-            <Checkbox
-              checked={selected}
-              color="primary"
-              size="small"
-              className={styles.myIconButton}
-            />
-          </ListItemIcon>
-          <ListItemText disableTypography>
-            <table className={styles.sectionDetailsTable}>
-              <colgroup>
-                <col width="15%" />
-                <col width="20%" />
-                <col width="20%" />
-                <col width="45%" />
-              </colgroup>
-              <tbody>
-                {meetingRows}
-              </tbody>
-            </table>
-          </ListItemText>
-        </ListItem>
-      );
       return (
-        <React.Fragment key={section.sectionNum}>
-          {instructorLabel}
-          {sectionDetails}
-        </React.Fragment>
+        <SectionInfo
+          secIdx={secIdx}
+          sectionData={sectionData}
+          addInstructorLabel={makeNewGroup}
+          toggleSelected={toggleSelected}
+          key={sectionData.section.id}
+        />
       );
     });
   };

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
 import { List, Typography } from '@material-ui/core';
-import { useSelector, useDispatch, shallowEqual } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { SectionSelected } from '../../../../../../types/CourseCardOptions';
 import { RootState } from '../../../../../../redux/reducer';
 import * as styles from './SectionSelect.css';
-import { updateCourseCard } from '../../../../../../redux/actions/courseCards';
 import SectionInfo from './SectionInfo';
 
 interface SectionSelectProps {

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
@@ -12,7 +12,7 @@ interface SectionSelectProps {
 
 const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
   const sections = useSelector<RootState, SectionSelected[]>(
-    (state) => state.courseCards[id].sections, (left, right) => left === right,
+    (state) => state.courseCards[id].sections,
   );
 
   // show placeholder text if there are no sections

--- a/autoscheduler/frontend/src/redux/actions/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/actions/courseCards.ts
@@ -239,6 +239,22 @@ export function updateCourseCard(index: number, courseCard: CourseCardOptions, t
   };
 }
 
+export function toggleSelected(courseCardId: number, secIdx: number):
+ThunkAction<void, RootState, undefined, UpdateCourseAction> {
+  return (dispatch, getState): void => {
+    dispatch(updateCourseCard(courseCardId, {
+      sections: getState().courseCards[courseCardId].sections.map(
+        (sec, idx) => (idx !== secIdx ? sec : {
+          section: sec.section,
+          selected: !sec.selected,
+          meetings: sec.meetings,
+        }),
+      ),
+    }));
+  };
+}
+
+
 export function clearCourseCards(): ClearCourseCardsAction {
   return { type: CLEAR_COURSE_CARDS };
 }

--- a/autoscheduler/frontend/src/tests/ui/SectionSelect.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SectionSelect.test.tsx
@@ -127,62 +127,6 @@ describe('SectionSelect', () => {
     });
   });
 
-  describe('shows ONLINE', () => {
-    test('for 00:00 meeting times & online section', () => {
-      // arrange
-      const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
-
-      const {
-        getByText,
-      } = render(
-        <Provider store={store}><SectionSelect id={0} /></Provider>,
-      );
-
-      const testSection = new Section({
-        id: 0,
-        crn: 0,
-        subject: 'CSCE',
-        courseNum: '121',
-        sectionNum: '200',
-        minCredits: 3,
-        maxCredits: null,
-        currentEnrollment: 0,
-        maxEnrollment: 0,
-        instructor: new Instructor({
-          name: 'Test',
-        }),
-        honors: false,
-        web: true,
-        grades: null,
-      });
-      const testMeeting = new Meeting({
-        id: 1,
-        building: '',
-        meetingDays: new Array(7).fill(true),
-        startTimeHours: 0,
-        startTimeMinutes: 0,
-        endTimeHours: 0,
-        endTimeMinutes: 0,
-        meetingType: MeetingType.LEC,
-        section: testSection,
-      });
-
-      const sectionSelected = {
-        section: testSection,
-        meetings: [testMeeting],
-        selected: false,
-      };
-
-      // Add the SectionSelected type to the store so it shows up in the SectionSelect component
-      store.dispatch<any>(updateCourseCard(0, {
-        sections: [sectionSelected],
-      }, '201931'));
-
-      // assert
-      expect(getByText('ONLINE')).toBeTruthy();
-    });
-  });
-
   describe('shows a single meeting time', () => {
     test('for duplicate exam times', () => {
       // arrange
@@ -560,6 +504,60 @@ describe('SectionSelect', () => {
         startTimeMinutes: 0,
         endTimeHours: 8,
         endTimeMinutes: 50,
+        meetingType: MeetingType.LEC,
+        section: testSection,
+      });
+
+      const sectionSelected = {
+        section: testSection,
+        meetings: [testMeeting],
+        selected: false,
+      };
+
+      // Add the SectionSelected type to the store so it shows up in the SectionSelect component
+      store.dispatch<any>(updateCourseCard(0, {
+        sections: [sectionSelected],
+      }, '201931'));
+
+      // assert
+      expect(getByText('ONLINE')).toBeTruthy();
+    });
+
+    test('for 00:00 meeting times & online section', () => {
+      // arrange
+      const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
+
+      const {
+        getByText,
+      } = render(
+        <Provider store={store}><SectionSelect id={0} /></Provider>,
+      );
+
+      const testSection = new Section({
+        id: 0,
+        crn: 0,
+        subject: 'CSCE',
+        courseNum: '121',
+        sectionNum: '200',
+        minCredits: 3,
+        maxCredits: null,
+        currentEnrollment: 0,
+        maxEnrollment: 0,
+        instructor: new Instructor({
+          name: 'Test',
+        }),
+        honors: false,
+        web: true,
+        grades: null,
+      });
+      const testMeeting = new Meeting({
+        id: 1,
+        building: '',
+        meetingDays: new Array(7).fill(true),
+        startTimeHours: 0,
+        startTimeMinutes: 0,
+        endTimeHours: 0,
+        endTimeMinutes: 0,
         meetingType: MeetingType.LEC,
         section: testSection,
       });

--- a/autoscheduler/frontend/src/tests/ui/SectionSelect.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SectionSelect.test.tsx
@@ -750,7 +750,9 @@ describe('SectionSelect', () => {
       // arrange
       const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
       store.dispatch(setTerm('201931'));
-      store.dispatch<any>(updateCourseCard(0, makeCourseCard({ sectionNum: '201' }, { sectionNum: '202' })));
+      store.dispatch<any>(updateCourseCard(0, makeCourseCard(
+        { sectionNum: '201', id: 123456 }, { sectionNum: '202', id: 123457 },
+      )));
       const {
         getByText, getAllByDisplayValue,
       } = render(

--- a/autoscheduler/frontend/src/tests/ui/SectionSelect.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SectionSelect.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
-import { render, queryByTitle as queryByTitleIn } from '@testing-library/react';
+import { render, queryByTitle as queryByTitleIn, fireEvent } from '@testing-library/react';
 import { CourseCardOptions } from '../../types/CourseCardOptions';
 import Section from '../../types/Section';
 import Instructor from '../../types/Instructor';
@@ -742,6 +742,28 @@ describe('SectionSelect', () => {
       // assert
       expect(queryByText('ONLINE')).not.toBeInTheDocument();
       expect(queryByText('BILD')).toBeInTheDocument();
+    });
+  });
+
+  describe('keeps the first section checked', () => {
+    test('when a second section is also selected', () => {
+      // arrange
+      const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
+      store.dispatch(setTerm('201931'));
+      store.dispatch<any>(updateCourseCard(0, makeCourseCard({ sectionNum: '201' }, { sectionNum: '202' })));
+      const {
+        getByText, getAllByDisplayValue,
+      } = render(
+        <Provider store={store}><SectionSelect id={0} /></Provider>,
+      );
+      // click the first section
+      fireEvent.click(getByText('201'));
+
+      // act
+      fireEvent.click(getByText('202'));
+
+      // assert
+      expect(getAllByDisplayValue('on')).toHaveLength(2);
     });
   });
 });


### PR DESCRIPTION
## Description

Spam-clicking a section in `SectionSelect` currently results in a really uncomfortable lag period where the UI is frozen. I originally attempted to fix this by virtualizing the list, but virtualization results ina an uncomfortable lag period where the `SectionSelect` is blank. I have found a better solution in memoization, which is basically the functional component equivalent of `shouldComponentUpdate`. Specifically, I moved the display for each section out of `SectionSelect` and into a new component called `SectionSelect`. Next, I memo-ized this `SectionInfo`, instructing it not to re-render unless it has been selected/de-selected. Significantly, this makes the assumption that none of the other fields or sub-fields in `SectionSelected` will ever change without also completely re-rendering the course card.

## Rationale

I had to make a new `ThunkAction` to toggle the selected state of each section due to some really weird behavior with JavaScript closures. If anyone thinks they understand closures, please explain how they work because apparently I don't.

## How to test

Spam-click a section. Should update quickly. Now try selecting multiple sections. Selecting a new section shouldn't un-select your previous choices.

## Screenshots

![memo](https://user-images.githubusercontent.com/10082177/94639736-84bf0200-02a2-11eb-932f-fa73f3cab68b.png)

## Related tasks

Closes #360 
