### PR TITLE
Database access optimization for /api/sections

### DIFF
--- a/autoscheduler/scraper/models/section.py
+++ b/autoscheduler/scraper/models/section.py
@@ -41,7 +41,11 @@ class Meeting(models.Model):
     start_time = models.TimeField(null=True)
     end_time = models.TimeField(null=True)
     meeting_type = models.CharField(max_length=4) # Meeting types: LEC, LAB, REC, INS, etc
-    section = models.ForeignKey(Section, on_delete=models.CASCADE)
+    section = models.ForeignKey(
+        Section,
+        on_delete=models.CASCADE,
+        related_name='meetings'
+    )
 
     class Meta:
         db_table = "meetings"

--- a/autoscheduler/scraper/serializers.py
+++ b/autoscheduler/scraper/serializers.py
@@ -1,6 +1,6 @@
 from datetime import time
 from rest_framework import serializers
-from scraper.models import Course, Section, Meeting, Department, Grades
+from scraper.models import Course, Section, Department, Grades
 
 def format_time(time_obj: time) -> str:
     """ Formats a time object to a string HH:MM, for use with section serializer """
@@ -24,20 +24,16 @@ class SectionSerializer(serializers.ModelSerializer):
                   'meetings', 'instructor_name', 'min_credits', 'max_credits',
                   'current_enrollment', 'max_enrollment', 'grades',]
 
-    def get_instructor_name(self, obj): # pylint: disable=no-self-use
+    def get_instructor_name(self, section): # pylint: disable=no-self-use
         """ Get the name (id) of this section's instructor.
             This function is used to compute the value of the instructor_name field.
         """
-        if obj.instructor is None:
-            return 'TBA'
+        return section.instructor.id if section.instructor else 'TBA'
 
-        return obj.instructor.id
-
-    def get_meetings(self, obj): # pylint: disable=no-self-use
+    def get_meetings(self, section): # pylint: disable=no-self-use
         """ Gets meeting information for this section
             This function is used to compute the value of the meetings field.
         """
-        meetings = Meeting.objects.filter(section__id=obj.id)
         return [{
             'id': str(meeting.id),
             'building': meeting.building,
@@ -45,14 +41,17 @@ class SectionSerializer(serializers.ModelSerializer):
             'start_time': format_time(meeting.start_time),
             'end_time': format_time(meeting.end_time),
             'type': meeting.meeting_type,
-        } for meeting in meetings]
+        } for meeting in section.meetings.all()]
 
-    def get_grades(self, obj): # pylint: disable=no-self-use
+    def get_grades(self, section): # pylint: disable=no-self-use
         """ Gets the past grade distributions for this prof + course """
-        grades = Grades.objects.instructor_performance(obj.subject, obj.course_num,
-                                                       obj.instructor)
+        grades = Grades.objects.instructor_performance(
+            section.subject,
+            section.course_num,
+            section.instructor
+        )
         # If GPA is none, then there weren't any grades for this course & professor
-        if grades.get("gpa") is None or obj.instructor is None:
+        if grades.get("gpa") is None or section.instructor is None:
             return None
 
         return grades

--- a/autoscheduler/scraper/views.py
+++ b/autoscheduler/scraper/views.py
@@ -32,7 +32,7 @@ class ListSectionView(generics.ListAPIView):
         term = self.request.query_params.get('term')
         return Section.objects.filter(
             subject=dept, course_num=course_num, term_code=term
-        ).order_by('id')
+        ).order_by('id').prefetch_related('instructor', 'meetings')
 
 class RetrieveTermView(generics.ListAPIView):
     """ API endpoint for viewing terms, used by /api/terms.

--- a/autoscheduler/scraper/views.py
+++ b/autoscheduler/scraper/views.py
@@ -32,7 +32,7 @@ class ListSectionView(generics.ListAPIView):
         term = self.request.query_params.get('term')
         return Section.objects.filter(
             subject=dept, course_num=course_num, term_code=term
-        ).order_by('id').prefetch_related('instructor', 'meetings')
+        ).order_by('id').select_related('instructor').prefetch_related('meetings')
 
 class RetrieveTermView(generics.ListAPIView):
     """ API endpoint for viewing terms, used by /api/terms.


### PR DESCRIPTION
## Description
Prefetches instructors and meetings in `/api/sections`, which solves the [N+1 selects problem](https://stackoverflow.com/questions/97197/what-is-the-n1-selects-problem-in-orm-object-relational-mapping) that made us use far more queries than necessary to fetch section data.

## Rationale
I also reorganized some parts of the section serializer to be easier to read (rename `obj` to `section`, ternary for instructor name), and added `related_name='meetings'` to meetings so that we can get meetings for a section with `section.meetings`.

Note that getting grades still takes a query for each section, I couldn't figure out a way to optimize it since `instructor_performance` performs a query and with the way that serializers work in DRF, the only way to stop this is with caching (which should be done in a different PR). Fixing this should dramatically improve performance.

## How to test
Just fetch sections and you'll see that it's ~10-20% faster now, here are some more concrete examples:
KINE 199 (course with the most sections)
| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/28655462/94722190-8cbb8800-031c-11eb-9695-4bb1052a5406.png) | ![image](https://user-images.githubusercontent.com/28655462/94722116-731a4080-031c-11eb-8ca6-5241771db57d.png) |

CSCE 121 (decent number of sections)
| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/28655462/94722248-a4930c00-031c-11eb-907e-6912fc8ad4d3.png) | ![image](https://user-images.githubusercontent.com/28655462/94722362-d4daaa80-031c-11eb-9b30-ab1913fbd586.png) |

## Related tasks

No issue for this, I just noticed that we could be performing queries more efficiently when I was working on APIs for a couple of my classes
