### PR TITLE
Instruction type tooltips

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
@@ -121,7 +121,7 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
   );
 
   // adds a tooltip for meeting types that aren't very obvious ex -> INS, PRL, etc.
-  const formatMeetingType = (mtg: Meeting): JSX.Element => {
+  const formatMeetingType = (mtg: Meeting): JSX.Element | String => {
     const meetingTypeDescription = MeetingTypeDescription.get(mtg.meetingType);
     if (meetingTypeDescription) {
       return (
@@ -130,7 +130,7 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
         </Tooltip>
       );
     }
-    return <>{MeetingType[mtg.meetingType]}</>;
+    return MeetingType[mtg.meetingType];
   };
 
   const renderMeeting = (mtg: Meeting, showSectionNum: boolean): JSX.Element => (

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
@@ -121,7 +121,7 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
   );
 
   // adds a tooltip for meeting types that aren't very obvious ex -> INS, PRL, etc.
-  const formatMeetingType = (mtg: Meeting): JSX.Element | String => {
+  const formatMeetingType = (mtg: Meeting): JSX.Element | string => {
     const meetingTypeDescription = MeetingTypeDescription.get(mtg.meetingType);
     if (meetingTypeDescription) {
       return (

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
@@ -130,7 +130,7 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
         </Tooltip>
       );
     }
-    return <span>{MeetingType[mtg.meetingType]}</span>;
+    return <>{MeetingType[mtg.meetingType]}</>;
   };
 
   const renderMeeting = (mtg: Meeting, showSectionNum: boolean): JSX.Element => (

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
@@ -123,7 +123,7 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
   // adds a tooltip for meeting types that aren't very obvious ex -> INS, PRL, etc.
   const formatMeetingType = (mtg: Meeting): JSX.Element => {
     const meetingTypeDescription = MeetingTypeDescription.get(mtg.meetingType);
-    if (meetingTypeDescription != null) {
+    if (meetingTypeDescription) {
       return (
         <Tooltip title={meetingTypeDescription} arrow placement="bottom" PopperProps={{ disablePortal: true }}>
           <span className={styles.meetingType}>{MeetingType[mtg.meetingType]}</span>

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
@@ -40,7 +40,7 @@
 }
 
 .meeting-type {
-    text-decoration: underline;
+    border-bottom: 1px solid rgb(221, 221, 221);
 }
 
 .no-grades-available {

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
@@ -39,6 +39,10 @@
     align-items: center;
 }
 
+.meeting-type {
+    text-decoration: underline;
+}
+
 .no-grades-available {
     margin-right: 5px;
 }

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css.d.ts
@@ -8,6 +8,8 @@ declare namespace SectionSelectCssNamespace {
     grayText: string;
     "list-subheader-dense": string;
     listSubheaderDense: string;
+    "meeting-type": string;
+    meetingType: string;
     "my-icon-button": string;
     "my-list-item-icon": string;
     myIconButton: string;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
@@ -5,7 +5,7 @@ import {
 } from '@material-ui/core';
 import HonorsIcon from '@material-ui/icons/School';
 import { useSelector, useDispatch } from 'react-redux';
-import Meeting, { MeetingType } from '../../../../../../types/Meeting';
+import Meeting, { MeetingType, MeetingTypeDescription } from '../../../../../../types/Meeting';
 import Section from '../../../../../../types/Section';
 import { formatTime } from '../../../../../../utils/timeUtil';
 import { SectionSelected } from '../../../../../../types/CourseCardOptions';
@@ -119,7 +119,7 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
       {showSectionNum ? createSectionHeader(mtg.section) : null}
       <Typography className={styles.denseListItem} color="textSecondary" component="tr">
         <td>
-          <Tooltip title={MeetingType[mtg.meetingType]} arrow PopperProps={{ disablePortal: true }}>
+          <Tooltip title={MeetingTypeDescription.get(mtg.meetingType)} arrow placement="right" PopperProps={{ disablePortal: true }}>
             <span style={{ textDecorationLine: 'underline' }}>{MeetingType[mtg.meetingType]}</span>
           </Tooltip>
         </td>

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
@@ -114,15 +114,24 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
     );
   };
 
+  // adds a tooltip for meeting types that aren't very obvious ex -> INS, PRL, etc.
+  const formatMeetingType = (mtg: Meeting): JSX.Element => {
+    const meetingTypeDescription = MeetingTypeDescription.get(mtg.meetingType);
+    if (meetingTypeDescription != null) {
+      return (
+        <Tooltip title={MeetingTypeDescription.get(mtg.meetingType)} arrow placement="right" PopperProps={{ disablePortal: true }}>
+          <span className={styles.meetingType}>{MeetingType[mtg.meetingType]}</span>
+        </Tooltip>
+      );
+    }
+    return (<span>{MeetingType[mtg.meetingType]}</span>)
+  }
+
   const renderMeeting = (mtg: Meeting, showSectionNum: boolean): JSX.Element => (
     <React.Fragment key={mtg.id}>
       {showSectionNum ? createSectionHeader(mtg.section) : null}
       <Typography className={styles.denseListItem} color="textSecondary" component="tr">
-        <td>
-          <Tooltip title={MeetingTypeDescription.get(mtg.meetingType)} arrow placement="right" PopperProps={{ disablePortal: true }}>
-            <span className={styles.meetingType}>{MeetingType[mtg.meetingType]}</span>
-          </Tooltip>
-        </td>
+        <td>{formatMeetingType(mtg)}</td>
         <td>{mtg.building || 'ONLINE'}</td>
         <td>{formatMeetingDays(mtg)}</td>
         <td>{getMeetingTimeText(mtg)}</td>

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
@@ -116,10 +116,12 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
 
   const renderMeeting = (mtg: Meeting, showSectionNum: boolean): JSX.Element => (
     <React.Fragment key={mtg.id}>
-      {showSectionNum ? createSectionHeader(mtg.section) : null }
+      {showSectionNum ? createSectionHeader(mtg.section) : null}
       <Typography className={styles.denseListItem} color="textSecondary" component="tr">
         <td>
-          <span style={{ textDecorationLine: 'underline' }}>{MeetingType[mtg.meetingType]}</span>
+          <Tooltip title={MeetingType[mtg.meetingType]} arrow PopperProps={{ disablePortal: true }}>
+            <span style={{ textDecorationLine: 'underline' }}>{MeetingType[mtg.meetingType]}</span>
+          </Tooltip>
         </td>
         <td>{mtg.building || 'ONLINE'}</td>
         <td>{formatMeetingDays(mtg)}</td>

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
@@ -124,7 +124,7 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
         </Tooltip>
       );
     }
-    return (<span>{MeetingType[mtg.meetingType]}</span>);
+    return <span>{MeetingType[mtg.meetingType]}</span>;
   };
 
   const renderMeeting = (mtg: Meeting, showSectionNum: boolean): JSX.Element => (

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
@@ -118,7 +118,9 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
     <React.Fragment key={mtg.id}>
       {showSectionNum ? createSectionHeader(mtg.section) : null }
       <Typography className={styles.denseListItem} color="textSecondary" component="tr">
-        <td>{MeetingType[mtg.meetingType]}</td>
+        <td>
+          <span style={{ textDecorationLine: 'underline' }}>{MeetingType[mtg.meetingType]}</span>
+        </td>
         <td>{mtg.building || 'ONLINE'}</td>
         <td>{formatMeetingDays(mtg)}</td>
         <td>{getMeetingTimeText(mtg)}</td>

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
@@ -120,7 +120,7 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
       <Typography className={styles.denseListItem} color="textSecondary" component="tr">
         <td>
           <Tooltip title={MeetingTypeDescription.get(mtg.meetingType)} arrow placement="right" PopperProps={{ disablePortal: true }}>
-            <span style={{ textDecorationLine: 'underline' }}>{MeetingType[mtg.meetingType]}</span>
+            <span className={styles.meetingType}>{MeetingType[mtg.meetingType]}</span>
           </Tooltip>
         </td>
         <td>{mtg.building || 'ONLINE'}</td>

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
@@ -119,7 +119,7 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
     const meetingTypeDescription = MeetingTypeDescription.get(mtg.meetingType);
     if (meetingTypeDescription != null) {
       return (
-        <Tooltip title={MeetingTypeDescription.get(mtg.meetingType)} arrow placement="right" PopperProps={{ disablePortal: true }}>
+        <Tooltip title={meetingTypeDescription} arrow placement="right" PopperProps={{ disablePortal: true }}>
           <span className={styles.meetingType}>{MeetingType[mtg.meetingType]}</span>
         </Tooltip>
       );

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
@@ -124,8 +124,8 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
         </Tooltip>
       );
     }
-    return (<span>{MeetingType[mtg.meetingType]}</span>)
-  }
+    return (<span>{MeetingType[mtg.meetingType]}</span>);
+  };
 
   const renderMeeting = (mtg: Meeting, showSectionNum: boolean): JSX.Element => (
     <React.Fragment key={mtg.id}>

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
@@ -119,7 +119,7 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
     const meetingTypeDescription = MeetingTypeDescription.get(mtg.meetingType);
     if (meetingTypeDescription != null) {
       return (
-        <Tooltip title={meetingTypeDescription} arrow placement="right" PopperProps={{ disablePortal: true }}>
+        <Tooltip title={meetingTypeDescription} arrow placement="bottom" PopperProps={{ disablePortal: true }}>
           <span className={styles.meetingType}>{MeetingType[mtg.meetingType]}</span>
         </Tooltip>
       );

--- a/autoscheduler/frontend/src/types/Meeting.ts
+++ b/autoscheduler/frontend/src/types/Meeting.ts
@@ -17,8 +17,8 @@ export const MeetingTypeDescription = new Map<number, string>([
   [MeetingType.CMP, 'Competition'],
   [MeetingType.CLAS, 'Class'],
   [MeetingType.PRL, 'Private Lesson'],
-  [MeetingType.INT, 'Internship']
-])
+  [MeetingType.INT, 'Internship'],
+]);
 
 export default class Meeting {
   id: number;

--- a/autoscheduler/frontend/src/types/Meeting.ts
+++ b/autoscheduler/frontend/src/types/Meeting.ts
@@ -4,7 +4,7 @@ export enum MeetingType {
   LEC, LAB, RES, INS, EXAM, SEM, PRAC, REC, CLD, CMP, PRL, CLAS, INT
 }
 
-export const MeetingTypeDescription = new Map<number, string>([
+export const MeetingTypeDescription = new Map<MeetingType, string>([
   [MeetingType.LEC, 'Lecture'],
   [MeetingType.LAB, 'Laboratory'],
   [MeetingType.RES, 'Research'],

--- a/autoscheduler/frontend/src/types/Meeting.ts
+++ b/autoscheduler/frontend/src/types/Meeting.ts
@@ -5,17 +5,13 @@ export enum MeetingType {
 }
 
 export const MeetingTypeDescription = new Map<MeetingType, string>([
-  [MeetingType.LEC, 'Lecture'],
-  [MeetingType.LAB, 'Laboratory'],
   [MeetingType.RES, 'Research'],
   [MeetingType.INS, 'Independent Study'],
-  [MeetingType.EXAM, 'Examination'],
   [MeetingType.SEM, 'Seminar'],
   [MeetingType.PRAC, 'Practicum'],
   [MeetingType.REC, 'Recitation'],
   [MeetingType.CLD, 'Clinic'],
   [MeetingType.CMP, 'Competition'],
-  [MeetingType.CLAS, 'Class'],
   [MeetingType.PRL, 'Private Lesson'],
   [MeetingType.INT, 'Internship'],
 ]);

--- a/autoscheduler/frontend/src/types/Meeting.ts
+++ b/autoscheduler/frontend/src/types/Meeting.ts
@@ -4,6 +4,22 @@ export enum MeetingType {
   LEC, LAB, RES, INS, EXAM, SEM, PRAC, REC, CLD, CMP, PRL, CLAS, INT
 }
 
+export const MeetingTypeDescription = new Map<number, string>([
+  [MeetingType.LEC, 'Lecture'],
+  [MeetingType.LAB, 'Laboratory'],
+  [MeetingType.RES, 'Research'],
+  [MeetingType.INS, 'Independent Study'],
+  [MeetingType.EXAM, 'Examination'],
+  [MeetingType.SEM, 'Seminar'],
+  [MeetingType.PRAC, 'Practicum'],
+  [MeetingType.REC, 'Recitation'],
+  [MeetingType.CLD, 'Clinic'],
+  [MeetingType.CMP, 'Competition'],
+  [MeetingType.CLAS, 'Class'],
+  [MeetingType.PRL, 'Private Lesson'],
+  [MeetingType.INT, 'Internship']
+])
+
 export default class Meeting {
   id: number;
   building: string | null;
@@ -16,34 +32,34 @@ export default class Meeting {
   section: Section;
 
   constructor(src: {
-      id: number;
-      building: string | null;
-      meetingDays: boolean[];
-      startTimeHours: number;
-      startTimeMinutes: number;
-      endTimeHours: number;
-      endTimeMinutes: number;
-      meetingType: MeetingType;
-      section: Section;
-    }) {
+    id: number;
+    building: string | null;
+    meetingDays: boolean[];
+    startTimeHours: number;
+    startTimeMinutes: number;
+    endTimeHours: number;
+    endTimeMinutes: number;
+    meetingType: MeetingType;
+    section: Section;
+  }) {
     // run-time type checks
     if (!Number.isInteger(src.id)) { throw Error(`Meeting.id is invalid: ${src.id}`); }
     if (src.building === undefined) { throw Error(`Meeting.building is invalid: ${src.building}`); }
     if (!src.meetingDays || src.meetingDays.length !== 7) { throw Error(`Meeting.meetingDays is invalid: ${src.meetingDays}`); }
     if (!Number.isInteger(src.startTimeHours)
-        || src.startTimeHours < 0 || src.startTimeHours > 23) {
+      || src.startTimeHours < 0 || src.startTimeHours > 23) {
       throw Error(`Meeting.startTimeHours is invalid: ${src.startTimeHours}`);
     }
     if (!Number.isInteger(src.startTimeMinutes)
-        || src.startTimeMinutes < 0 || src.startTimeMinutes > 59) {
+      || src.startTimeMinutes < 0 || src.startTimeMinutes > 59) {
       throw Error(`Meeting.startTimeMinutes is invalid: ${src.startTimeMinutes}`);
     }
     if (!Number.isInteger(src.endTimeHours)
-        || src.endTimeHours < 0 || src.endTimeHours > 23) {
+      || src.endTimeHours < 0 || src.endTimeHours > 23) {
       throw Error(`Meeting.endTimeHours is invalid: ${src.endTimeHours}`);
     }
     if (!Number.isInteger(src.endTimeMinutes)
-        || src.endTimeMinutes < 0 || src.endTimeMinutes > 60) {
+      || src.endTimeMinutes < 0 || src.endTimeMinutes > 60) {
       throw Error(`Meeting.endTimeMinutes is invalid: ${src.endTimeMinutes}`);
     }
     if (src.meetingType === null || src.meetingType === undefined) {


### PR DESCRIPTION
## Description

Adding a tooltip to the meeting type under "section select".

## How to test

Hover over a meeting type and make sure that the abbreviation matches the tooltip

## Screenshots
### Before
<img width="328" alt="Screen Shot 2020-10-03 at 10 57 33 PM" src="https://user-images.githubusercontent.com/26681493/95006595-e8f80380-05cb-11eb-8a81-a602444dd392.png">

### After
<img width="331" alt="Screen Shot 2020-10-06 at 8 52 51 PM" src="https://user-images.githubusercontent.com/26681493/95278506-f3a5d900-0815-11eb-8eb8-77b83c48b8c8.png">

Closes #298
https://app.zenhub.com/workspaces/rr-5f735a6a098ca70016574cf1/issues/aggie-coding-club/rev-registration/298
