### PR TITLE
Fixed text for no honors or web-based sections

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.css
@@ -17,5 +17,5 @@
 .gray-text {
     color: rgba(0, 0, 0, 0.56);
     padding-bottom: 8px;
-    padding-right: 0.5vw;
+    padding-right: 8px;
 }

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.css
@@ -17,4 +17,5 @@
 .gray-text {
     color: rgba(0, 0, 0, 0.56);
     padding-bottom: 8px;
+    padding-right: 0.5vw;
 }

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.tsx
@@ -29,7 +29,7 @@ const BasicSelect: React.FC<BasicSelectProps> = ({ id }) => {
   if (!hasHonors && !hasWeb) {
     return (
       <Typography className={styles.grayText}>
-        There are no honors or online courses for this class
+        There are no honors or online sections for this class
       </Typography>
     );
   }

--- a/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
@@ -588,7 +588,7 @@ describe('Course Select Card UI', () => {
         fireEvent.click(courseEntry);
         fireEvent.change(courseEntry, { target: { value: 'C' } });
         fireEvent.click(await findByText('CSCE 121'));
-        const placeholder = await findByText('There are no honors or online courses for this class');
+        const placeholder = await findByText('There are no honors or online sections for this class');
 
         // assert
         expect(placeholder).toBeInTheDocument();
@@ -667,7 +667,7 @@ describe('Course Select Card UI', () => {
       await waitFor(() => {});
 
       // assert
-      const placeholder = 'There are no honors or online courses for this class';
+      const placeholder = 'There are no honors or online sections for this class';
       expect(queryByText(placeholder)).not.toBeInTheDocument();
     });
 


### PR DESCRIPTION
## Description

Changed "there are no honors or online courses" to "sections" and added right padding.

## How to test

Make sure "There are no honors or online sections for this class" shows up under "Customization Level" when "Basic" is selected.

## Screenshots

### Before
<img width="352" alt="Screen Shot 2020-10-04 at 10 27 03 PM" src="https://user-images.githubusercontent.com/26681493/95037666-57eb6000-0691-11eb-8646-15288e38aad2.png">

### After
<img width="351" alt="Screen Shot 2020-10-04 at 10 27 14 PM" src="https://user-images.githubusercontent.com/26681493/95037676-6cc7f380-0691-11eb-8d59-3698a11615d9.png">

Issue #356 