### PR TITLE
Fix validateDOMNesting error

### DIFF
--- a/autoscheduler/frontend/src/components/LargeTextCard/LargeTextCard.tsx
+++ b/autoscheduler/frontend/src/components/LargeTextCard/LargeTextCard.tsx
@@ -17,7 +17,7 @@ const LargeTextCard: React.FC<React.PropsWithChildren<LargeTextCardProps>> = (
         </Box>
       </Typography>
       <Box padding={2} paddingTop={1} paddingBottom={4}>
-        <Typography variant="body1" align="center">
+        <Typography component="div" variant="body1" align="center">
           {children}
         </Typography>
       </Box>


### PR DESCRIPTION
## Description

Fixes the `validateDOMNesting` error that was occurring due to a `<div>` being nested under a `<p>`. I fixed this by changing the `Typography` component from `<p>` (default) to a `<div>`

## How to test

Pretty straightforward - just build + run the website and check that it doesn't throw an error on the landing page. Can also look at the tests for `App.tsx` to show that the error doesn't occur.

## Screenshots

Screenshots showing that no change has occurred for the cards that use `LargeTextCard`

|Before|After|
|--|--|
|![chrome_sYDjUH00yp](https://user-images.githubusercontent.com/7295783/95122043-8f035500-0715-11eb-9dad-75a083ce7bfc.png)|![chrome_g4Vn3JC6Gn](https://user-images.githubusercontent.com/7295783/95122060-93c80900-0715-11eb-9dda-e2ec890cc295.png)|
|![chrome_hrpigJcE86](https://user-images.githubusercontent.com/7295783/95122088-9dea0780-0715-11eb-85f0-52efb6907de8.png)|![chrome_p1Oqr90cfM](https://user-images.githubusercontent.com/7295783/95122102-a17d8e80-0715-11eb-9496-4792ac72a757.png)|



## Related tasks

Closes #378
