### PR TITLE
Course cards without a course are no longer saved

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
@@ -55,7 +55,7 @@ const CourseSelectColumn: React.FC = () => {
       const courses: SerializedCourseCardOptions[] = [];
       for (let i = 0; i < courseCards.numCardsCreated; i++) {
         const course = courseCards[i];
-        if (course) {
+        if (course && course.course) {
           const sections = course.sections.filter(({ selected }) => selected).map((sectionSel) => (
             sectionSel.section.id
           ));


### PR DESCRIPTION
## Description

Makes it so empty course cards no longer get saved

## Rationale

I tried making a test for this for literally an hour and a half and then gave up, why do you have to do this to me jest? Good news is this PR is literally half a line so it should be pretty straightforward to see how it works

## How to test

Try saving your course cards when you have all empty/a mix of empty and filled cards, it will only keep the ones with courses. ez

## Screenshots
![wow](https://user-images.githubusercontent.com/28655462/95156662-ac0f4680-075c-11eb-802a-c93db28ce80b.gif)


## Related tasks
Closes #325.
