### PR TITLE
Frontend/full height course cards

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/CollapsedCourseCard/CollapsedCourseCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/CollapsedCourseCard/CollapsedCourseCard.tsx
@@ -23,7 +23,7 @@ const CollapsedCourseCard: React.FC<CollapsedCourseCardProps> = ({ onExpand, id 
       aria-label="Expand"
       onClick={(): void => onExpand()}
     >
-      <div className={styles.customBox}>
+      <div className={styles.customBox} aria-label="Remove">
         <IconButton
           style={{ color: 'white' }}
           size="small"

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/CourseSelectCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/CourseSelectCard.tsx
@@ -1,22 +1,30 @@
 import * as React from 'react';
 import ExpandedCourseCard from './ExpandedCourseCard/ExpandedCourseCard';
 import CollapsedCourseCard from './CollapsedCourseCard/CollapsedCourseCard';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from '../../../../redux/reducer';
+import { updateCourseCard } from '../../../../redux/actions/courseCards';
 
 interface CourseSelectCardProps {
   id: number;
 }
 
 const CourseSelectCard: React.FC<CourseSelectCardProps> = ({ id }) => {
-  const [collapsed, setCollapsed] = React.useState(false);
+  const collapsed = useSelector<RootState, boolean>((state) => state.courseCards[id].collapsed);
+  const dispatch = useDispatch();
+
+  const toggleCollapsed = (): void => {
+    dispatch(updateCourseCard(id, { collapsed: !collapsed }));
+  };
 
   return collapsed ? (
     <CollapsedCourseCard
-      onExpand={(): void => { setCollapsed(false); }}
+      onExpand={toggleCollapsed}
       id={id}
     />
   ) : (
     <ExpandedCourseCard
-      onCollapse={(): void => { setCollapsed(true); }}
+      onCollapse={toggleCollapsed}
       id={id}
     />
   );

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/CourseSelectCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/CourseSelectCard.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import ExpandedCourseCard from './ExpandedCourseCard/ExpandedCourseCard';
 import CollapsedCourseCard from './CollapsedCourseCard/CollapsedCourseCard';
-import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '../../../../redux/reducer';
 import { updateCourseCard } from '../../../../redux/actions/courseCards';
 

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.css
@@ -1,10 +1,16 @@
+.card {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
 .container {
-    margin-top: 16px; /* DEBUG */
+    margin-top: 16px;
     display: inline-flex;
     flex-direction: column;
     align-items: center;
     font-family: "Roboto", Arial, Helvetica, sans-serif;
-    border-radius: 4px; 
+    border-radius: 4px;
     min-width: 300px;
     background-color: white;
     box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
@@ -14,6 +20,7 @@
     background-color: #500000;
     color: white;
     display: flex;
+    flex-shrink: 0;
     flex-direction: row;
     justify-content: space-between;
     width: 100%;
@@ -34,6 +41,8 @@
 .content {
     margin-top: 8px;
     margin-left: 8px;
+    overflow: auto;
+    flex-shrink: 1;
     align-self: stretch;
     display: flex;
     flex-direction: column;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.css.d.ts
@@ -1,5 +1,6 @@
 declare namespace ExpandedCourseCardCssNamespace {
   export interface IExpandedCourseCardCss {
+    card: string;
     "center-progress": string;
     centerProgress: string;
     container: string;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.tsx
@@ -92,6 +92,7 @@ const ExpandedCourseCard: React.FC<ExpandedCourseCardProps> = ({
             dispatch(removeCourseCard(id));
             evt.stopPropagation();
           }}
+          aria-label="Remove"
         >
           <RemoveIcon />
           Remove

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.tsx
@@ -72,7 +72,7 @@ const ExpandedCourseCard: React.FC<ExpandedCourseCardProps> = ({
   }, [course, customizationLevel, id, loading]);
 
   return (
-    <Card>
+    <Card className={styles.card}>
       <div
         className={styles.header}
         onClick={(): void => onCollapse(course)}

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
@@ -9,7 +9,6 @@
 
 .section-rows {
     overflow: auto;
-    max-height: 300px;
 }
 
 .my-icon-button {

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.css
@@ -1,5 +1,6 @@
 .container {
-    width: calc(100% - 8px);
+    box-sizing: border-box;
+    width: 100%;
     height: 100%;
     display: flex;
     flex-direction: column;
@@ -13,21 +14,30 @@
 .column-wrapper {
     position: relative;
     width: 100%;
+    height: 100%;
     flex-grow: 1;
     margin-bottom: 8px;
 }
 
 .course-select-column {
     position: absolute;
+    display: flex;
+    flex-direction: column;
     top: 0px;
     bottom: 0px;
     overflow-y: auto;
     width: 100%;
+    height: 100%;
 }
 
 .row {
-    padding-bottom: 8px;
+    padding-top: 8px;
     padding-right: 8px;
+    box-sizing: border-box;
+}
+
+.expanded-row {
+    min-height: 500px;
 }
 
 #add-course-button {
@@ -37,7 +47,6 @@
 #button-container {
     position: sticky;
     bottom: 0;
-    padding-bottom: 8px;
     padding-right: 8px;
     background-color: #c2c2c2;
     z-index: 2;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.css
@@ -30,10 +30,6 @@
     padding-right: 8px;
 }
 
-.row:nth-last-of-type(2) {
-    padding-bottom: 0px;
-}
-
 #add-course-button {
     width: 100%;
 }
@@ -41,7 +37,7 @@
 #button-container {
     position: sticky;
     bottom: 0;
-    padding-top: 8px;
+    padding-bottom: 8px;
     padding-right: 8px;
     background-color: #c2c2c2;
     z-index: 2;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.css.d.ts
@@ -9,6 +9,8 @@ declare namespace CourseSelectColumnCssNamespace {
     container: string;
     "course-select-column": string;
     courseSelectColumn: string;
+    "expanded-row": string;
+    expandedRow: string;
     row: string;
   }
 }

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
@@ -65,6 +65,7 @@ const CourseSelectColumn: React.FC = () => {
             honors: course.honors,
             web: course.web,
             sections,
+            collapsed: course.collapsed,
           });
         }
       }

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import * as Cookies from 'js-cookie';
 import { Button } from '@material-ui/core';
+import AddIcon from '@material-ui/icons/Add';
 import * as styles from './CourseSelectColumn.css';
 import { RootState } from '../../../redux/reducer';
 import { CourseCardArray, SerializedCourseCardOptions } from '../../../types/CourseCardOptions';
@@ -105,13 +106,13 @@ const CourseSelectColumn: React.FC = () => {
     <div className={styles.container}>
       <div className={styles.columnWrapper}>
         <div className={styles.courseSelectColumn} id="course-select-container">
-          {rows}
           <div id={styles.buttonContainer}>
             <Button
               color="primary"
               size="medium"
               variant="contained"
               id={styles.addCourseButton}
+              startIcon={<AddIcon />}
               onClick={(): void => {
                 dispatch(addCourseCard());
               }}
@@ -119,6 +120,7 @@ const CourseSelectColumn: React.FC = () => {
             Add Course
             </Button>
           </div>
+          {rows}
         </div>
       </div>
     </div>

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
@@ -5,7 +5,7 @@ import { Button } from '@material-ui/core';
 import AddIcon from '@material-ui/icons/Add';
 import * as styles from './CourseSelectColumn.css';
 import { RootState } from '../../../redux/reducer';
-import { CourseCardArray, SerializedCourseCardOptions } from '../../../types/CourseCardOptions';
+import { CourseCardArray, CustomizationLevel, SerializedCourseCardOptions } from '../../../types/CourseCardOptions';
 import CourseSelectCard from './CourseSelectCard/CourseSelectCard';
 import { addCourseCard, replaceCourseCards, clearCourseCards } from '../../../redux/actions/courseCards';
 import createThrottleFunction from '../../../utils/createThrottleFunction';
@@ -87,10 +87,19 @@ const CourseSelectColumn: React.FC = () => {
 
   // Add all of the course cards to rows to be displayed
   for (let i = 0; i < courseCards.numCardsCreated; i++) {
-    if (courseCards[i]) {
+    const card = courseCards[i];
+    if (card) {
+      // Apply min-height if this card is focused and in section view so that
+      // it can be viewed properly on low resolutions
+      let className = styles.row;
+      if (card.collapsed === false
+        && !card.loading
+        && card.course
+        && card.customizationLevel === CustomizationLevel.SECTION
+      ) className = `${styles.row} ${styles.expandedRow}`;
       rows.push(
         <div
-          className={styles.row}
+          className={className}
           key={`courseSelectCardRow-${i}`}
         >
           <CourseSelectCard

--- a/autoscheduler/frontend/src/redux/actions/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/actions/courseCards.ts
@@ -222,7 +222,7 @@ function updateCourseCardAsync(
    * @param courseCard the options to update
    */
 export function updateCourseCard(index: number, courseCard: CourseCardOptions, term = ''):
-    ThunkAction<void, RootState, undefined, UpdateCourseAction> {
+    ThunkAction<void, RootState, undefined, CourseCardAction> {
   return (dispatch): void => {
     // if the course has changed, fetch new sections to display
     if (courseCard.course) {
@@ -255,6 +255,7 @@ function deserializeCourseCard(courseCard: SerializedCourseCardOptions): CourseC
     customizationLevel: courseCard.customizationLevel,
     honors: courseCard.honors,
     web: courseCard.web,
+    collapsed: courseCard.collapsed,
     sections: [],
     loading: true,
   };

--- a/autoscheduler/frontend/src/tests/ui/CourseSelectColumn.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/CourseSelectColumn.test.tsx
@@ -49,7 +49,7 @@ describe('CourseSelectColumn', () => {
       // sessions/get_saved_courses
       fetchMock.mockResponseOnce(JSON.stringify({}));
 
-      const { getByText, getAllByText } = render(
+      const { getByText, getAllByLabelText } = render(
         <Provider store={store}>
           <CourseSelectColumn />
         </Provider>,
@@ -60,7 +60,7 @@ describe('CourseSelectColumn', () => {
       act(() => { fireEvent.click(getByText('Add Course')); });
 
       // Get the course cards
-      const cardsCount = getAllByText('Remove').length;
+      const cardsCount = getAllByLabelText('Remove').length;
 
       // assert
       // There should be now be two since it defaults to one at the beginning
@@ -118,7 +118,7 @@ describe('CourseSelectColumn', () => {
       fetchMock.mockResponseOnce(JSON.stringify({}));
 
       const {
-        getAllByText, getAllByLabelText, findByText,
+        getByText, getByLabelText, findByText,
       } = render(
         <Provider store={store}>
           <CourseSelectColumn />
@@ -134,13 +134,13 @@ describe('CourseSelectColumn', () => {
       fireEvent.click(await findByText('Add Course'));
 
       // fill in course
-      const courseEntry = getAllByLabelText('Course')[1] as HTMLInputElement;
+      const courseEntry = getByLabelText('Course') as HTMLInputElement;
       fireEvent.click(courseEntry);
       fireEvent.change(courseEntry, { target: { value: 'C' } });
       fireEvent.click(await findByText('CSCE 121'));
 
       // switch to section select and select section 501
-      fireEvent.click(getAllByText('Section')[1]);
+      fireEvent.click(getByText('Section'));
       fireEvent.click(
         await findByText((content, element) => ignoreInvisible(content, element, '501')),
       );

--- a/autoscheduler/frontend/src/types/CourseCardOptions.ts
+++ b/autoscheduler/frontend/src/types/CourseCardOptions.ts
@@ -36,6 +36,7 @@ export interface SerializedCourseCardOptions {
   web?: string;
   honors?: string;
   sections?: number[];
+  collapsed?: boolean;
 }
 
 /**

--- a/autoscheduler/frontend/src/types/CourseCardOptions.ts
+++ b/autoscheduler/frontend/src/types/CourseCardOptions.ts
@@ -25,6 +25,7 @@ export interface CourseCardOptions {
   hasWeb? : boolean;
   sections?: SectionSelected[];
   loading?: boolean;
+  collapsed?: boolean;
 }
 
 // Represents a course card when saved and serialized, sections are saved as strings


### PR DESCRIPTION
## Description

Moves expand/collapse for course cards to redux, only one can be expanded at a time, and the expanded card will fill as much height as possible (with a minimum height roughly equal to what it was previously). No tests right now because I wanted some input on if we like how this works, specific behavior, etc.

## Rationale
The only thing in this branch that isn't how I imagined it is the extra height when the currently selected card is in section view and only has a couple sections. I couldn't think of any way to keep the fit-to-height behavior as well as having a minimum height without making this compromise (despite spending 4 hours in CSS hell), but I still think that in the vast majority of use cases this is a lot nicer.

## How to test
Make some cards, the expanded one will fit to your screen size (unless you're Adel and have a screen made for ants, in which case I've made it so this works basically the same way as before)

## Screenshots
I think that 7 course cards is about as high as most users will go, so here are some example sizes:

| Old appearance (always 300px) | 1080, 5 cards (417px) | 1080p, 7 cards (340px) |
|--|--|--|
| ![image](https://user-images.githubusercontent.com/28655462/95519833-8d42c700-098b-11eb-92fa-19a1d77e1638.png) | ![image](https://user-images.githubusercontent.com/28655462/95518834-861ab980-0989-11eb-8fb5-353c052de7f3.png) | ![image](https://user-images.githubusercontent.com/28655462/95518794-713e2600-0989-11eb-876b-42cf7451c5f1.png) |

| 1440p, 7 cards (697px) | 720p (314px, any more than 3 cards makes it scroll) |
|--|--|
| ![image](https://user-images.githubusercontent.com/28655462/95519611-0db4f800-098b-11eb-8c24-0172b8f01265.png) | ![image](https://user-images.githubusercontent.com/28655462/95520319-9f713500-098c-11eb-900a-69384691fa63.png) |

Finally, here's the one case I don't really like the appearance of. If you're on the section select and there are only 1 or 2 sections, there will be some extra empty space that I couldn't find any way to avoid even using refs:
![image](https://user-images.githubusercontent.com/28655462/95520472-fc6ceb00-098c-11eb-95c3-ce3087ff9873.png)
It looks normal on basic select though since I check if you're on section select with a course selected before giving a minimum height:
![image](https://user-images.githubusercontent.com/28655462/95520530-1b6b7d00-098d-11eb-8fbb-479b0f5a80c6.png)

## Related tasks

Closes #377.
