### PR TITLE
Frontend/async only filter

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicOptionRow.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicOptionRow.tsx
@@ -7,7 +7,7 @@ import * as styles from './BasicSelect.css';
 
 interface BasicOptionRowProps {
     id: number;
-    value: 'honors' | 'web';
+    value: 'honors' | 'web' | 'asynchronous';
 }
 
 /**

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicOptionRow.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicOptionRow.tsx
@@ -8,6 +8,7 @@ import * as styles from './BasicSelect.css';
 interface BasicOptionRowProps {
     id: number;
     value: 'honors' | 'web' | 'asynchronous';
+    label: 'Honors:' | 'Web:' | 'No Meeting Times:';
 }
 
 /**
@@ -15,7 +16,7 @@ interface BasicOptionRowProps {
  * @param props include id of the course card and value, which should be the name of the
  * option selected by this row, formatted as it is found in the Redux course cards
  */
-const BasicOptionRow: React.FC<BasicOptionRowProps> = ({ id, value }) => {
+const BasicOptionRow: React.FC<BasicOptionRowProps> = ({ id, value, label }) => {
   const option = useSelector<RootState, string>((state) => state.courseCards[id][value] || 'exclude');
   const dispatch = useDispatch();
 
@@ -23,7 +24,7 @@ const BasicOptionRow: React.FC<BasicOptionRowProps> = ({ id, value }) => {
     <tr>
       <td>
         <Typography variant="body1" style={{ paddingRight: 8 }} id={`${value}-${id}`}>
-          {(value === 'asynchronous' ? 'No Meeting Times:' : `${value.slice(0, 1).toUpperCase().concat(value.slice(1))}:`)}
+          {label}
         </Typography>
       </td>
       <td>

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicOptionRow.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicOptionRow.tsx
@@ -8,7 +8,7 @@ import * as styles from './BasicSelect.css';
 interface BasicOptionRowProps {
     id: number;
     value: 'honors' | 'web' | 'asynchronous';
-    label: 'Honors:' | 'Web:' | 'No Meeting Times:';
+    label: 'Honors' | 'Web' | 'No Meeting Times';
 }
 
 /**
@@ -24,7 +24,7 @@ const BasicOptionRow: React.FC<BasicOptionRowProps> = ({ id, value, label }) => 
     <tr>
       <td>
         <Typography variant="body1" style={{ paddingRight: 8 }} id={`${value}-${id}`}>
-          {label}
+          {`${label}:`}
         </Typography>
       </td>
       <td>

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicOptionRow.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicOptionRow.tsx
@@ -23,7 +23,7 @@ const BasicOptionRow: React.FC<BasicOptionRowProps> = ({ id, value }) => {
     <tr>
       <td>
         <Typography variant="body1" style={{ paddingRight: 8 }} id={`${value}-${id}`}>
-          {`${value.slice(0, 1).toUpperCase().concat(value.slice(1))}:`}
+          {(value === 'asynchronous' ? 'No Meeting Times:' : `${value.slice(0, 1).toUpperCase().concat(value.slice(1))}:`)}
         </Typography>
       </td>
       <td>

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.tsx
@@ -15,6 +15,7 @@ const BasicSelect: React.FC<BasicSelectProps> = ({ id }) => {
     (state) => state.courseCards[id].hasHonors || false,
   );
   const hasWeb = useSelector<RootState, boolean>((state) => state.courseCards[id].hasWeb || false);
+  const hasAsynchronous = useSelector<RootState, boolean>((state) => state.courseCards[id].hasAsynchronous || false);
 
   // shows placeholder text if no course is selected
   if (!course) {
@@ -26,7 +27,7 @@ const BasicSelect: React.FC<BasicSelectProps> = ({ id }) => {
   }
 
   // show placeholder message if there are no special sections to filter
-  if (!hasHonors && !hasWeb) {
+  if (!hasHonors && !hasWeb && !hasAsynchronous) {
     return (
       <Typography className={styles.grayText}>
         There are no honors or online sections for this class
@@ -44,6 +45,9 @@ const BasicSelect: React.FC<BasicSelectProps> = ({ id }) => {
             : null}
           {hasWeb
             ? <BasicOptionRow id={id} value="web" />
+            : null}
+          {hasAsynchronous
+            ? <BasicOptionRow id={id} value="asynchronous" />
             : null}
         </tbody>
       </table>

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.tsx
@@ -15,7 +15,9 @@ const BasicSelect: React.FC<BasicSelectProps> = ({ id }) => {
     (state) => state.courseCards[id].hasHonors || false,
   );
   const hasWeb = useSelector<RootState, boolean>((state) => state.courseCards[id].hasWeb || false);
-  const hasAsynchronous = useSelector<RootState, boolean>((state) => state.courseCards[id].hasAsynchronous || false);
+  const hasAsynchronous = useSelector<RootState, boolean>(
+    (state) => state.courseCards[id].hasAsynchronous || false,
+  );
 
   // shows placeholder text if no course is selected
   if (!course) {

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.tsx
@@ -43,13 +43,13 @@ const BasicSelect: React.FC<BasicSelectProps> = ({ id }) => {
       <table className={styles.tableContainer}>
         <tbody>
           {hasHonors
-            ? <BasicOptionRow id={id} value="honors" />
+            ? <BasicOptionRow id={id} value="honors" label="Honors:" />
             : null}
           {hasWeb
-            ? <BasicOptionRow id={id} value="web" />
+            ? <BasicOptionRow id={id} value="web" label="Web:" />
             : null}
           {hasAsynchronous
-            ? <BasicOptionRow id={id} value="asynchronous" />
+            ? <BasicOptionRow id={id} value="asynchronous" label="No Meeting Times:" />
             : null}
         </tbody>
       </table>

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.tsx
@@ -43,13 +43,13 @@ const BasicSelect: React.FC<BasicSelectProps> = ({ id }) => {
       <table className={styles.tableContainer}>
         <tbody>
           {hasHonors
-            ? <BasicOptionRow id={id} value="honors" label="Honors:" />
+            ? <BasicOptionRow id={id} value="honors" label="Honors" />
             : null}
           {hasWeb
-            ? <BasicOptionRow id={id} value="web" label="Web:" />
+            ? <BasicOptionRow id={id} value="web" label="Web" />
             : null}
           {hasAsynchronous
-            ? <BasicOptionRow id={id} value="asynchronous" label="No Meeting Times:" />
+            ? <BasicOptionRow id={id} value="asynchronous" label="No Meeting Times" />
             : null}
         </tbody>
       </table>

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
@@ -64,6 +64,7 @@ const CourseSelectColumn: React.FC = () => {
             customizationLevel: course.customizationLevel,
             honors: course.honors,
             web: course.web,
+            asynchronous: course.asynchronous,
             sections,
           });
         }

--- a/autoscheduler/frontend/src/redux/actions/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/actions/courseCards.ts
@@ -71,6 +71,7 @@ function parseSection(sectionData: any): Section {
     maxEnrollment: Number(sectionData.max_enrollment),
     honors: sectionData.honors,
     web: sectionData.web,
+    asynchronous: sectionData.asynchronous,
     instructor: new Instructor({ name: sectionData.instructor_name }),
     grades: sectionData.grades == null ? null : new Grades(sectionData.grades),
   });
@@ -273,6 +274,7 @@ function deserializeCourseCard(courseCard: SerializedCourseCardOptions): CourseC
     customizationLevel: courseCard.customizationLevel,
     honors: courseCard.honors,
     web: courseCard.web,
+    asynchronous: courseCard.asynchronous,
     sections: [],
     loading: true,
   };

--- a/autoscheduler/frontend/src/redux/actions/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/actions/courseCards.ts
@@ -189,11 +189,13 @@ async function fetchCourseCardFrom(
     .then((sections) => {
       const hasHonors = sections.some((section) => section.section.honors);
       const hasWeb = sections.some((section) => section.section.web);
+      const hasAsynchronous = sections.some((section) => section.section.asynchronous);
       return {
         ...courseCard,
         sections,
         hasHonors,
         hasWeb,
+        hasAsynchronous,
       };
     })
     .catch(() => undefined);

--- a/autoscheduler/frontend/src/redux/actions/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/actions/courseCards.ts
@@ -19,6 +19,7 @@ function createEmptyCourseCard(): CourseCardOptions {
     sections: [],
     web: 'no_preference',
     honors: 'exclude',
+    asynchronous: 'no_preference',
   };
 }
 

--- a/autoscheduler/frontend/src/redux/actions/schedules.ts
+++ b/autoscheduler/frontend/src/redux/actions/schedules.ts
@@ -90,6 +90,7 @@ ThunkAction<Promise<void>, RootState, undefined, ReplaceSchedulesAction | Select
           // Only send if "Basic" level
           honors: isBasic ? (courseCard.honors ?? filterDefault) : filterDefault,
           web: isBasic ? (courseCard.web ?? filterDefault) : filterDefault,
+          asynchronous: isBasic ? (courseCard.asynchronous ?? filterDefault) : filterDefault,
         });
       }
     }

--- a/autoscheduler/frontend/src/redux/reducers/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/reducers/courseCards.ts
@@ -40,7 +40,7 @@ const initialCourseCardArray: CourseCardArray = {
     customizationLevel: CustomizationLevel.BASIC,
     web: 'no_preference',
     honors: 'exclude',
-    asynchronous: 'exclude',
+    asynchronous: 'no_preference',
     sections: [],
     loading: true,
   },

--- a/autoscheduler/frontend/src/redux/reducers/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/reducers/courseCards.ts
@@ -40,6 +40,7 @@ const initialCourseCardArray: CourseCardArray = {
     customizationLevel: CustomizationLevel.BASIC,
     web: 'no_preference',
     honors: 'exclude',
+    asynchronous: 'exclude',
     sections: [],
     loading: true,
   },

--- a/autoscheduler/frontend/src/redux/testData.ts
+++ b/autoscheduler/frontend/src/redux/testData.ts
@@ -16,6 +16,7 @@ export default async function fetch(route: string): Promise<Response> {
     maxEnrollment: 0,
     honors: false,
     web: false,
+    asynchronous: false,
     instructor: new Instructor({
       name: 'Aakash Tyagi',
     }),
@@ -33,6 +34,7 @@ export default async function fetch(route: string): Promise<Response> {
     maxEnrollment: 0,
     honors: false,
     web: false,
+    asynchronous: false,
     instructor: new Instructor({
       name: 'Aakash Tyagi',
     }),
@@ -50,6 +52,7 @@ export default async function fetch(route: string): Promise<Response> {
     maxEnrollment: 0,
     honors: false,
     web: false,
+    asynchronous: false,
     instructor: new Instructor({
       name: 'Somebody Else',
     }),
@@ -67,6 +70,7 @@ export default async function fetch(route: string): Promise<Response> {
     maxEnrollment: 0,
     honors: false,
     web: false,
+    asynchronous: false,
     instructor: new Instructor({
       name: 'Dr. Pepper',
     }),

--- a/autoscheduler/frontend/src/tests/redux/CourseCards.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/CourseCards.test.ts
@@ -306,7 +306,7 @@ describe('Course Cards Redux', () => {
           customizationLevel: CustomizationLevel.BASIC,
           web: 'no_preference',
           honors: 'exclude',
-          asynchronous: 'exclude',
+          asynchronous: 'no_preference',
           sections: [],
         },
       };
@@ -332,7 +332,7 @@ describe('Course Cards Redux', () => {
           customizationLevel: CustomizationLevel.BASIC,
           web: 'no_preference',
           honors: 'exclude',
-          asynchronous: 'exclude',
+          asynchronous: 'no_preference',
         },
         numCardsCreated: 1,
       };
@@ -342,7 +342,7 @@ describe('Course Cards Redux', () => {
           customizationLevel: CustomizationLevel.BASIC,
           web: 'no_preference',
           honors: 'exclude',
-          asynchronous: 'exclude',
+          asynchronous: 'no_preference',
         },
       ];
       fetchMock.mockImplementationOnce(testFetch);

--- a/autoscheduler/frontend/src/tests/redux/CourseCards.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/CourseCards.test.ts
@@ -39,8 +39,9 @@ describe('Course Cards Redux', () => {
           current_enrollment: 0,
           max_enrollment: 1,
           instructor_name: 'Instructor Name',
-          web: false,
           honors: false,
+          web: false,
+          asynchronous: false,
           meetings: [
             {
               id: 11,
@@ -65,6 +66,7 @@ describe('Course Cards Redux', () => {
           maxEnrollment: 1,
           honors: false,
           web: false,
+          asynchronous: false,
           instructor: new Instructor({ name: 'Instructor Name' }),
           grades: new Grades(grades),
         });
@@ -101,8 +103,9 @@ describe('Course Cards Redux', () => {
           current_enrollment: 0,
           max_enrollment: 1,
           instructor_name: 'Instructor Name',
-          web: false,
           honors: false,
+          web: false,
+          asynchronous: false,
           meetings: [
             {
               id: 11,
@@ -126,6 +129,7 @@ describe('Course Cards Redux', () => {
           maxEnrollment: 1,
           honors: false,
           web: false,
+          asynchronous: false,
           instructor: new Instructor({ name: 'Instructor Name' }),
           grades: null,
         });
@@ -168,8 +172,9 @@ describe('Course Cards Redux', () => {
           current_enrollment: 0,
           max_enrollment: 1,
           instructor_name: 'Instructor Name',
-          web: false,
           honors: false,
+          web: false,
+          asynchronous: false,
           meetings: [
             {
               id: 11,
@@ -191,6 +196,7 @@ describe('Course Cards Redux', () => {
           maxEnrollment: 1,
           honors: false,
           web: false,
+          asynchronous: false,
           instructor: new Instructor({ name: 'Instructor Name' }),
           grades: null,
         });
@@ -233,8 +239,9 @@ describe('Course Cards Redux', () => {
           current_enrollment: 0,
           max_enrollment: 1,
           instructor_name: 'Instructor Name',
-          web: false,
           honors: false,
+          web: false,
+          asynchronous: false,
           meetings: [
             {
               id: 11,
@@ -259,8 +266,9 @@ describe('Course Cards Redux', () => {
           maxEnrollment: 1,
           instructor: new Instructor({ name: 'Instructor Name' }),
           grades: null as any,
-          web: false,
           honors: false,
+          web: false,
+          asynchronous: false,
         });
 
         const meetings = [
@@ -298,6 +306,7 @@ describe('Course Cards Redux', () => {
           customizationLevel: CustomizationLevel.BASIC,
           web: 'no_preference',
           honors: 'exclude',
+          asynchronous: 'exclude',
           sections: [],
         },
       };
@@ -323,6 +332,7 @@ describe('Course Cards Redux', () => {
           customizationLevel: CustomizationLevel.BASIC,
           web: 'no_preference',
           honors: 'exclude',
+          asynchronous: 'exclude',
         },
         numCardsCreated: 1,
       };
@@ -332,6 +342,7 @@ describe('Course Cards Redux', () => {
           customizationLevel: CustomizationLevel.BASIC,
           web: 'no_preference',
           honors: 'exclude',
+          asynchronous: 'exclude',
         },
       ];
       fetchMock.mockImplementationOnce(testFetch);

--- a/autoscheduler/frontend/src/tests/redux/Redux.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/Redux.test.ts
@@ -133,7 +133,7 @@ test('Initial state has one empty course card', () => {
       customizationLevel: CustomizationLevel.BASIC,
       web: 'no_preference',
       honors: 'exclude',
-      asynchronous: 'exclude',
+      asynchronous: 'no_preference',
       sections: [],
     },
     numCardsCreated: 1,

--- a/autoscheduler/frontend/src/tests/redux/Redux.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/Redux.test.ts
@@ -186,7 +186,11 @@ test('Updates course card basic filter options', () => {
 
   // act
   store.dispatch<any>(updateCourseCard(0, { web: 'exclude' }));
+  store.dispatch<any>(updateCourseCard(0, { honors: 'exclude' }));
+  store.dispatch<any>(updateCourseCard(0, { asynchronous: 'exclude' }));
 
   // assert
   expect(store.getState().courseCards[0].web).toBe('exclude');
+  expect(store.getState().courseCards[0].honors).toBe('exclude');
+  expect(store.getState().courseCards[0].asynchronous).toBe('exclude');
 });

--- a/autoscheduler/frontend/src/tests/redux/Redux.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/Redux.test.ts
@@ -21,6 +21,7 @@ const testSection = new Section({
   maxEnrollment: 0,
   honors: false,
   web: false,
+  asynchronous: false,
   instructor: new Instructor({
     name: 'Aakash Tyagi',
   }),
@@ -132,6 +133,7 @@ test('Initial state has one empty course card', () => {
       customizationLevel: CustomizationLevel.BASIC,
       web: 'no_preference',
       honors: 'exclude',
+      asynchronous: 'exclude',
       sections: [],
     },
     numCardsCreated: 1,

--- a/autoscheduler/frontend/src/tests/redux/Schedule.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/Schedule.test.ts
@@ -20,6 +20,7 @@ const testSectionA = new Section({
   maxEnrollment: 24,
   honors: false,
   web: false,
+  asynchronous: false,
   instructor: new Instructor({
     name: 'Aakash Tyagi',
   }),
@@ -38,6 +39,7 @@ const testSectionB = new Section({
   maxEnrollment: 25,
   honors: false,
   web: false,
+  asynchronous: false,
   instructor: new Instructor({
     name: 'Bad Bunny',
   }),
@@ -56,6 +58,7 @@ const testSectionC = new Section({
   maxEnrollment: 25,
   honors: false,
   web: false,
+  asynchronous: false,
   instructor: new Instructor({
     name: 'Creed Cratton',
   }),

--- a/autoscheduler/frontend/src/tests/testData.ts
+++ b/autoscheduler/frontend/src/tests/testData.ts
@@ -68,6 +68,22 @@ export default async function testFetch(route: string): Promise<Response> {
     asynchronous: false,
     instructor_name: 'Dr. Pepper',
   };
+  // for asynchronous testing
+  const testSection5 = {
+    id: 810262,
+    crn: 65890,
+    subject,
+    course_num,
+    section_num: '301',
+    min_credits: 0,
+    max_credits: 0,
+    current_enrollment: 0,
+    max_enrollment: 0,
+    honors: false,
+    web: false,
+    asynchronous: true,
+    instructor_name: 'Coca Cola',
+  };
 
   // test that different sections do different things
   if (subject === 'MATH') {
@@ -76,6 +92,22 @@ export default async function testFetch(route: string): Promise<Response> {
       meetings: [{
         id: 87328,
         building: 'BLOC',
+        days: [false, true, false, true, false, true, false],
+        start: '09:10',
+        end: '10:00',
+        type: 'LEC',
+        section: null,
+      }],
+    }]));
+  }
+
+  // for asynchronous testing
+  if (subject === 'ENGR') {
+    return new Response(JSON.stringify([{
+      ...testSection5,
+      meetings: [{
+        id: 81328,
+        building: 'ZACH',
         days: [false, true, false, true, false, true, false],
         start: '09:10',
         end: '10:00',

--- a/autoscheduler/frontend/src/tests/testData.ts
+++ b/autoscheduler/frontend/src/tests/testData.ts
@@ -20,6 +20,7 @@ export default async function testFetch(route: string): Promise<Response> {
     max_enrollment: 25,
     honors: false,
     web: false,
+    asynchronous: false,
     instructor_name: 'Aakash Tyagi',
   };
   const testSection2 = {
@@ -34,6 +35,7 @@ export default async function testFetch(route: string): Promise<Response> {
     max_enrollment: 25,
     honors: false,
     web: false,
+    asynchronous: false,
     instructor_name: 'Aakash Tyagi',
   };
   const testSection3 = {
@@ -48,6 +50,7 @@ export default async function testFetch(route: string): Promise<Response> {
     max_enrollment: 25,
     honors: false,
     web: false,
+    asynchronous: false,
     instructor_name: 'Somebody Else',
   };
   const testSection4 = {
@@ -62,6 +65,7 @@ export default async function testFetch(route: string): Promise<Response> {
     max_enrollment: 0,
     honors: true,
     web: false,
+    asynchronous: false,
     instructor_name: 'Dr. Pepper',
   };
 
@@ -163,6 +167,7 @@ export async function mockFetchSchedulerGenerate(): Promise<Response> {
     }],
     honors: false,
     web: false,
+    asynchronous: false,
   };
 
   // common values for testSection2 & 3
@@ -176,6 +181,7 @@ export async function mockFetchSchedulerGenerate(): Promise<Response> {
     instructor_name: 'Aakash Tyagi',
     honors: false,
     web: false,
+    asynchronous: false,
   };
 
   const testSection2 = {

--- a/autoscheduler/frontend/src/tests/testSchedules.ts
+++ b/autoscheduler/frontend/src/tests/testSchedules.ts
@@ -17,6 +17,7 @@ const testSection1 = new Section({
   maxEnrollment: 56,
   honors: false,
   web: false,
+  asynchronous: false,
   instructor: new Instructor({
     name: 'Aakash Tyagi',
   }),
@@ -35,6 +36,7 @@ const testSection2 = new Section({
   maxEnrollment: 67,
   honors: false,
   web: false,
+  asynchronous: false,
   instructor: new Instructor({
     name: 'James Pennington',
   }),
@@ -53,6 +55,7 @@ const testSection3 = new Section({
   maxEnrollment: 24,
   honors: false,
   web: false,
+  asynchronous: false,
   instructor: new Instructor({
     name: 'William Cohn',
   }),
@@ -119,6 +122,7 @@ const testSectionA = new Section({
   maxEnrollment: 1,
   honors: false,
   web: false,
+  asynchronous: false,
   instructor: new Instructor({ name: 'Deborah Seagle' }),
   grades: null,
 });
@@ -158,6 +162,7 @@ const testSectionB = new Section({
   maxEnrollment: 24,
   honors: false,
   web: false,
+  asynchronous: false,
   instructor: new Instructor({ name: 'Donald Trump' }),
   grades: null,
 });
@@ -186,6 +191,7 @@ const testSectionC = new Section({
   maxEnrollment: 24,
   honors: false,
   web: false,
+  asynchronous: false,
   instructor: new Instructor({ name: 'Harley Quinn' }),
   grades: null,
 });
@@ -214,6 +220,7 @@ const testSectionD = new Section({
   maxEnrollment: 24,
   honors: false,
   web: false,
+  asynchronous: false,
   instructor: new Instructor({ name: 'Naruto Uchiha' }),
   grades: null,
 });
@@ -242,6 +249,7 @@ const testSectionE = new Section({
   maxEnrollment: 24,
   honors: false,
   web: false,
+  asynchronous: false,
   instructor: new Instructor({ name: 'Shawn Lupoli' }),
   grades: null,
 });
@@ -270,6 +278,7 @@ const testSectionF = new Section({
   maxEnrollment: 24,
   honors: false,
   web: false,
+  asynchronous: false,
   instructor: new Instructor({ name: 'Albert Einstein' }),
   grades: null,
 });
@@ -298,6 +307,7 @@ const testSectionG = new Section({
   maxEnrollment: 24,
   honors: false,
   web: false,
+  asynchronous: false,
   instructor: new Instructor({ name: 'Leonardo DiCaprio' }),
   grades: null,
 });
@@ -326,6 +336,7 @@ const testSectionH = new Section({
   maxEnrollment: 24,
   honors: false,
   web: false,
+  asynchronous: false,
   instructor: new Instructor({ name: 'Morgan Freeman' }),
   grades: null,
 });

--- a/autoscheduler/frontend/src/tests/types/Meeting.test.ts
+++ b/autoscheduler/frontend/src/tests/types/Meeting.test.ts
@@ -25,6 +25,7 @@ const correctArgs: Indexable = {
     maxEnrollment: 56,
     honors: false,
     web: false,
+    asynchronous: false,
     instructor: new Instructor({
       name: 'Aakash Tyagi',
     }),

--- a/autoscheduler/frontend/src/tests/types/Section.test.ts
+++ b/autoscheduler/frontend/src/tests/types/Section.test.ts
@@ -15,6 +15,7 @@ const correctArgs: Indexable = {
   maxEnrollment: 56,
   honors: false,
   web: false,
+  asynchronous: false,
   instructor: new Instructor({
     name: 'Aakash Tyagi',
   }),

--- a/autoscheduler/frontend/src/tests/ui/BasicSelect.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/BasicSelect.test.tsx
@@ -19,6 +19,7 @@ describe('BasicSelect', () => {
             customizationLevel: CustomizationLevel.BASIC,
             hasHonors: true,
             hasWeb: true,
+            hasAsynchronous: true,
           },
         },
       }, applyMiddleware(thunk));
@@ -45,6 +46,7 @@ describe('BasicSelect', () => {
             customizationLevel: CustomizationLevel.BASIC,
             hasHonors: true,
             hasWeb: true,
+            hasAsynchronous: true,
           },
         },
       }, applyMiddleware(thunk));

--- a/autoscheduler/frontend/src/tests/ui/BasicSelect.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/BasicSelect.test.tsx
@@ -64,5 +64,32 @@ describe('BasicSelect', () => {
       // assert
       expect(getByLabelText('Web:')).toHaveTextContent('Only');
     });
+    test('when the user changes Asynchronous to Only', async () => {
+      // arrange
+      const store = createStore(autoSchedulerReducer, {
+        courseCards: {
+          0: {
+            course: 'MATH 151',
+            customizationLevel: CustomizationLevel.BASIC,
+            hasHonors: true,
+            hasWeb: true,
+            hasAsynchronous: true,
+          },
+        },
+      }, applyMiddleware(thunk));
+      const { queryByRole, getByLabelText, findByText } = render(
+        <Provider store={store}>
+          <BasicSelect id={0} />
+        </Provider>,
+      );
+
+      // act
+      UserEvent.click(getByLabelText('Asynchronous:'));
+      fireEvent.click(await findByText('Only'));
+      await waitFor(() => { expect(queryByRole('presentation')).not.toBeInTheDocument(); });
+
+      // assert
+      expect(getByLabelText('Asynchronous:')).toHaveTextContent('Only');
+    });
   });
 });

--- a/autoscheduler/frontend/src/tests/ui/BasicSelect.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/BasicSelect.test.tsx
@@ -84,12 +84,12 @@ describe('BasicSelect', () => {
       );
 
       // act
-      UserEvent.click(getByLabelText('Asynchronous:'));
+      UserEvent.click(getByLabelText('No Meeting Times:'));
       fireEvent.click(await findByText('Only'));
       await waitFor(() => { expect(queryByRole('presentation')).not.toBeInTheDocument(); });
 
       // assert
-      expect(getByLabelText('Asynchronous:')).toHaveTextContent('Only');
+      expect(getByLabelText('No Meeting Times:')).toHaveTextContent('Only');
     });
   });
 });

--- a/autoscheduler/frontend/src/tests/ui/ConfigureCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/ConfigureCard.test.tsx
@@ -72,6 +72,7 @@ describe('ConfigureCard component', () => {
         customizationLevel: CustomizationLevel.SECTION,
         honors: 'include',
         web: 'include',
+        asynchronous: 'exclude',
         course: 'CSCE 121',
       }, '201931'));
       const { getByText } = render(
@@ -125,6 +126,7 @@ describe('ConfigureCard component', () => {
         customizationLevel: CustomizationLevel.SECTION,
         honors: 'include',
         web: 'include',
+        asynchronous: 'exclude',
         course: 'CSCE 121',
       }, '201931'));
 
@@ -171,6 +173,7 @@ describe('ConfigureCard component', () => {
         customizationLevel: CustomizationLevel.BASIC,
         honors: 'exclude',
         web: 'exclude',
+        asynchronous: 'exclude',
         // Add a selected section so its added to selectedSections internally
         course: 'CSCE 121',
       }, '201931'));

--- a/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
@@ -29,6 +29,7 @@ const dummySectionArgs = {
   max_enrollment: 0,
   honors: false,
   web: false,
+  asynchronous: false,
   instructor_name: 'Aakash Tyagi',
   meetings: [{
     id: 11,

--- a/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
@@ -672,6 +672,36 @@ describe('Course Select Card UI', () => {
       expect(queryByText(placeholder)).not.toBeInTheDocument();
     });
 
+    test('when the customization filter is Basic and there are asynchronous sections', async () => {
+      // arrange
+      fetchMock.mockResponseOnce(JSON.stringify({ // api/course/search
+        results: ['CSCE 121', 'CSCE 221', 'CSCE 312', 'ENGR 301'],
+      }));
+      fetchMock.mockImplementationOnce(testFetch); // api/sections
+
+      const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
+      store.dispatch(setTerm('201931'));
+      const {
+        getByText, getByLabelText, queryByText, findByText,
+      } = render(
+        <Provider store={store}><CourseSelectCard id={0} /></Provider>,
+      );
+
+      // act
+      // fill in course
+      const courseEntry = getByLabelText('Course') as HTMLInputElement;
+      fireEvent.click(courseEntry);
+      fireEvent.change(courseEntry, { target: { value: 'M' } });
+      fireEvent.click(await findByText('ENGR 301'));
+
+      fireEvent.click(getByText('Section'));
+      await waitFor(() => {});
+
+      // assert
+      const placeholder = 'There are no honors or online courses for this class';
+      expect(queryByText(placeholder)).not.toBeInTheDocument();
+    });
+
     test('when the customization filter is Section and there are sections', async () => {
       // arrange
       fetchMock.mockResponseOnce(JSON.stringify({ // api/course/search

--- a/autoscheduler/frontend/src/tests/ui/MeetingCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/MeetingCard.test.tsx
@@ -22,6 +22,7 @@ const testSection = new Section({
   maxEnrollment: 0,
   honors: false,
   web: false,
+  asynchronous: false,
   instructor: new Instructor({
     name: 'Aakash Tyagi',
   }),

--- a/autoscheduler/frontend/src/tests/ui/Schedule.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/Schedule.test.tsx
@@ -25,6 +25,7 @@ const testSection = new Section({
   maxEnrollment: 0,
   honors: false,
   web: false,
+  asynchronous: false,
   instructor: new Instructor({
     name: 'Aakash Tyagi',
   }),

--- a/autoscheduler/frontend/src/tests/ui/SectionSelect.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SectionSelect.test.tsx
@@ -24,6 +24,7 @@ const dummySection: Section = {
   maxEnrollment: 25,
   web: false,
   honors: false,
+  asynchronous: false,
   instructor: new Instructor({ name: 'Dr. Doofenschmirtz' }),
   grades: null,
 };
@@ -151,6 +152,7 @@ describe('SectionSelect', () => {
         }),
         honors: false,
         web: true,
+        asynchronous: false,
         grades: null,
       });
       const testMeeting = new Meeting({
@@ -203,6 +205,7 @@ describe('SectionSelect', () => {
         }),
         honors: false,
         web: true,
+        asynchronous: false,
         grades: null,
       });
       const testMeeting = new Meeting({
@@ -260,6 +263,7 @@ describe('SectionSelect', () => {
         }),
         honors: false,
         web: true,
+        asynchronous: false,
         grades: null,
       });
       const testMeeting = new Meeting({
@@ -320,6 +324,7 @@ describe('SectionSelect', () => {
         }),
         honors: false,
         web: true,
+        asynchronous: false,
         grades: null,
       });
       const testMeeting1 = new Meeting({
@@ -440,6 +445,7 @@ describe('SectionSelect', () => {
         }),
         honors: false,
         web: true,
+        asynchronous: false,
         grades: null,
       });
       const testMeeting = new Meeting({
@@ -494,6 +500,7 @@ describe('SectionSelect', () => {
         }),
         honors: false,
         web: false,
+        asynchronous: false,
         grades: null,
       });
       const testMeeting = new Meeting({
@@ -604,6 +611,7 @@ describe('SectionSelect', () => {
         }),
         honors: false,
         web: true,
+        asynchronous: false,
         grades: null,
       });
       const testMeeting = new Meeting({
@@ -658,6 +666,7 @@ describe('SectionSelect', () => {
         }),
         honors: false,
         web: false,
+        asynchronous: false,
         grades: null,
       });
       const testMeeting = new Meeting({
@@ -714,6 +723,7 @@ describe('SectionSelect', () => {
         }),
         honors: false,
         web: true,
+        asynchronous: false,
         grades: null,
       });
       const testMeeting = new Meeting({

--- a/autoscheduler/frontend/src/tests/ui/SectionSelect.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SectionSelect.test.tsx
@@ -556,6 +556,7 @@ describe('SectionSelect', () => {
         honors: false,
         web: true,
         grades: null,
+        asynchronous: false,
       });
       const testMeeting = new Meeting({
         id: 1,

--- a/autoscheduler/frontend/src/types/CourseCardOptions.ts
+++ b/autoscheduler/frontend/src/types/CourseCardOptions.ts
@@ -21,8 +21,10 @@ export interface CourseCardOptions {
   customizationLevel?: CustomizationLevel;
   web?: string;
   honors?: string;
+  asynchronous?: string;
   hasHonors?: boolean;
   hasWeb? : boolean;
+  hasAsynchronous?: boolean;
   sections?: SectionSelected[];
   loading?: boolean;
 }
@@ -34,6 +36,7 @@ export interface SerializedCourseCardOptions {
   customizationLevel?: CustomizationLevel;
   web?: string;
   honors?: string;
+  asynchronous?: string;
   sections?: number[];
 }
 

--- a/autoscheduler/frontend/src/types/Section.ts
+++ b/autoscheduler/frontend/src/types/Section.ts
@@ -13,6 +13,7 @@ export default class Section {
   maxEnrollment: number;
   honors: boolean;
   web: boolean;
+  asynchronous: boolean;
   instructor: Instructor;
   grades: Grades;
 
@@ -28,6 +29,7 @@ export default class Section {
       maxEnrollment: number;
       honors: boolean;
       web: boolean;
+      asynchronous: boolean;
       instructor: Instructor;
       grades: Grades;
     }) {
@@ -53,6 +55,9 @@ export default class Section {
     }
     if (src.web == null) {
       throw Error('Section.web is undefined or null');
+    }
+    if (src.asynchronous == null) {
+      throw Error('Section.asynchronous is undefined or null');
     }
     if (!src.instructor) { throw Error(`Section.instructor is invalid: ${src.instructor}`); }
 


### PR DESCRIPTION
## Description

Adds the frontend option to filter applicable courses by the "asynchronous" option.

## How to test

Any class which has asynchronous classes should display the option. Ex: ARTS 150, COMM 691. Automatic tests through Jest are also setup for the frontend.

## Screenshots

![image](https://user-images.githubusercontent.com/49422137/95664502-9d7eb180-0b05-11eb-95fe-e44a16384619.png)
![image](https://user-images.githubusercontent.com/49422137/95664503-aa030a00-0b05-11eb-8d5f-ad8b8a9d0dc2.png)
![image](https://user-images.githubusercontent.com/49422137/95664506-bb4c1680-0b05-11eb-95f8-85a335817358.png)

## Related tasks

Depends on #388 

Closes #389 
Resolves #355 
