### PR TITLE
Mini dividers + make instructors sticky for Course Cards

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
@@ -149,6 +149,7 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
       dense
       disableGutters
       button
+      component="li"
     >
       <ListItemIcon className={styles.myListItemIcon}>
         <Checkbox

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
@@ -145,6 +145,7 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
   const sectionDetails = (
     <ListItem
       onClick={(): void => { dispatch(toggleSelected(courseCardId, secIdx)); }}
+      className={styles.noBottomSpace}
       dense
       disableGutters
       button
@@ -158,7 +159,7 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
           className={styles.myIconButton}
         />
       </ListItemIcon>
-      <ListItemText disableTypography>
+      <ListItemText disableTypography className={styles.noBottomSpace}>
         <table className={styles.sectionDetailsTable}>
           <colgroup>
             <col width="15%" />
@@ -170,7 +171,7 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
             {meetingRows}
           </tbody>
         </table>
-        {!isLastSection && <Divider />}
+        {!isLastSection && <Divider className={styles.addBottomSpace} />}
       </ListItemText>
     </ListItem>
   );

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
@@ -16,10 +16,11 @@ interface SectionInfoProps {
     courseCardId: number;
     secIdx: number;
     addInstructorLabel: boolean;
+    isLastSection: boolean;
 }
 
 const SectionInfo: React.FC<SectionInfoProps> = ({
-  sectionData, courseCardId, secIdx, addInstructorLabel,
+  sectionData, courseCardId, secIdx, addInstructorLabel, isLastSection,
 }) => {
   const { section, meetings, selected } = sectionData;
   const dispatch = useDispatch();
@@ -169,7 +170,7 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
             {meetingRows}
           </tbody>
         </table>
-        <Divider />
+        {!isLastSection && <Divider />}
       </ListItemText>
     </ListItem>
   );

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
@@ -169,6 +169,7 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
             {meetingRows}
           </tbody>
         </table>
+        <Divider />
       </ListItemText>
     </ListItem>
   );

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
@@ -28,25 +28,27 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
     ? (
       <>
         <ListSubheader disableGutters className={styles.listSubheaderDense}>
-          <div className={styles.nameHonorsIcon}>
-            {section.instructor.name}
-            {section.honors ? (
-              <Tooltip title="Honors" placement="right">
-                <HonorsIcon data-testid="honors" />
-              </Tooltip>
-            ) : null}
+          <div className={styles.listSubheaderContent}>
+            <div className={styles.nameHonorsIcon}>
+              {section.instructor.name}
+              {section.honors ? (
+                <Tooltip title="Honors" placement="right">
+                  <HonorsIcon fontSize="small" data-testid="honors" />
+                </Tooltip>
+              ) : null}
+            </div>
+            {section.grades
+              ? <GradeDist grades={section.grades} />
+              : (
+                <div className={styles.noGradesAvailable}>
+                  No grades available
+                </div>
+              )}
           </div>
-          {section.grades
-            ? <GradeDist grades={section.grades} />
-            : (
-              <div className={styles.noGradesAvailable}>
-                    No grades available
-              </div>
-            )}
+          <div className={styles.dividerContainer}>
+            <Divider />
+          </div>
         </ListSubheader>
-        <div className={styles.dividerContainer}>
-          <Divider />
-        </div>
       </>
     )
     : null;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
@@ -57,3 +57,13 @@
 .section-details-table tr td:nth-child(2), .section-details-table tr td:nth-child(3) {
     text-align: center;
 }
+
+/* The next 2 rules move the section divider to the bottom of the ListItem */
+.no-bottom-space {
+    padding-bottom: 0px !important;
+    margin-bottom: 0px !important;
+}
+
+.add-bottom-space {
+    margin-top: 8px;
+}

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
@@ -26,9 +26,10 @@
 
 .list-subheader-dense:global(.MuiListSubheader-root) {
     line-height: inherit;
-    /* position is sticky by default, which prevents the first instructor name from scrolling 
-       with the rest of the SectionSelect */
-    position: initial;
+    background-color: white;
+}
+
+.list-subheader-content {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -37,6 +38,7 @@
 .name-honors-icon {
     display: flex;
     align-items: center;
+    min-height: 20px;
 }
 
 .no-grades-available {

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
@@ -67,3 +67,7 @@
 .add-bottom-space {
     margin-top: 8px;
 }
+
+.no-start-padding {
+    padding-inline-start: 0;
+}

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css.d.ts
@@ -6,7 +6,9 @@ declare namespace SectionSelectCssNamespace {
     dividerContainer: string;
     "gray-text": string;
     grayText: string;
+    "list-subheader-content": string;
     "list-subheader-dense": string;
+    listSubheaderContent: string;
     listSubheaderDense: string;
     "my-icon-button": string;
     "my-list-item-icon": string;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css.d.ts
@@ -20,8 +20,10 @@ declare namespace SectionSelectCssNamespace {
     nameHonorsIcon: string;
     "no-bottom-space": string;
     "no-grades-available": string;
+    "no-start-padding": string;
     noBottomSpace: string;
     noGradesAvailable: string;
+    noStartPadding: string;
     "section-details-table": string;
     "section-rows": string;
     sectionDetailsTable: string;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css.d.ts
@@ -1,5 +1,7 @@
 declare namespace SectionSelectCssNamespace {
   export interface ISectionSelectCss {
+    "add-bottom-space": string;
+    addBottomSpace: string;
     "dense-list-item": string;
     denseListItem: string;
     "divider-container": string;
@@ -16,7 +18,9 @@ declare namespace SectionSelectCssNamespace {
     myListItemIcon: string;
     "name-honors-icon": string;
     nameHonorsIcon: string;
+    "no-bottom-space": string;
     "no-grades-available": string;
+    noBottomSpace: string;
     noGradesAvailable: string;
     "section-details-table": string;
     "section-rows": string;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
@@ -27,9 +27,11 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
   const makeList = (): JSX.Element[] => {
     let lastProf: string = null;
     let lastHonors = false;
+    let currProfGroupStart = 0;
     return sections.map((sectionData, secIdx) => {
       const firstInProfGroup = lastProf !== sectionData.section.instructor.name
         || lastHonors !== sectionData.section.honors;
+      if (firstInProfGroup) currProfGroupStart = secIdx;
 
       lastProf = sectionData.section.instructor.name;
       lastHonors = sectionData.section.honors;
@@ -37,15 +39,21 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
       const lastInProfGroup = lastProf !== sections[secIdx + 1]?.section.instructor.name
         || lastHonors !== sections[secIdx + 1]?.section.honors;
 
+      if (!lastInProfGroup) return null;
+
       return (
-        <SectionInfo
-          secIdx={secIdx}
-          courseCardId={id}
-          sectionData={sectionData}
-          addInstructorLabel={firstInProfGroup}
-          isLastSection={lastInProfGroup}
-          key={sectionData.section.id}
-        />
+        <ul key={lastProf + lastHonors} className={styles.noStartPadding}>
+          {sections.slice(currProfGroupStart, secIdx + 1).map((iterSecData, offset) => (
+            <SectionInfo
+              secIdx={currProfGroupStart + offset}
+              courseCardId={id}
+              sectionData={iterSecData}
+              addInstructorLabel={offset === 0}
+              isLastSection={currProfGroupStart + offset === secIdx}
+              key={iterSecData.section.id}
+            />
+          ))}
+        </ul>
       );
     });
   };

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
@@ -24,6 +24,12 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
     );
   }
 
+  /**
+   * Makes a list of `SectionInfo` elements, one for each section of this course, by iterating over
+   * each section in `sections`. As it iterates, this function groups consecutive sections with the
+   * same professor and honors status together inside one `<ul>` and under one header. Having them
+   * all inside the same `<ul>` is important in order to get smooth transitions with sticky headers.
+   */
   const makeList = (): JSX.Element[] => {
     let lastProf: string = null;
     let lastHonors = false;
@@ -39,6 +45,7 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
       const lastInProfGroup = lastProf !== sections[secIdx + 1]?.section.instructor.name
         || lastHonors !== sections[secIdx + 1]?.section.honors;
 
+      // all sections in a group will be added at the same time
       if (!lastInProfGroup) return null;
 
       return (

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
@@ -28,18 +28,22 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
     let lastProf: string = null;
     let lastHonors = false;
     return sections.map((sectionData, secIdx) => {
-      const makeNewGroup = lastProf !== sectionData.section.instructor.name
+      const firstInProfGroup = lastProf !== sectionData.section.instructor.name
         || lastHonors !== sectionData.section.honors;
 
       lastProf = sectionData.section.instructor.name;
       lastHonors = sectionData.section.honors;
+
+      const lastInProfGroup = lastProf !== sections[secIdx + 1]?.section.instructor.name
+        || lastHonors !== sections[secIdx + 1]?.section.honors;
 
       return (
         <SectionInfo
           secIdx={secIdx}
           courseCardId={id}
           sectionData={sectionData}
-          addInstructorLabel={makeNewGroup}
+          addInstructorLabel={firstInProfGroup}
+          isLastSection={lastInProfGroup}
           key={sectionData.section.id}
         />
       );


### PR DESCRIPTION
## Description

Makes instructors sticky to make long lists more comprehensible and adds inset dividers below each section to make the space feel more organized.

## Rationale

In order to make all instructor subheaders the same height, I set the minimum height to 20px. This is because the instructor subheaders stack on top of each other when they are sticky, so if one is bigger than the others, it will stick out. There is a possibility that 20px will not work on other screens, but I doubt it since the honors icon (which is the determining factor) should always be the same size.

## How to test
Look at a course with multiple instructors and sections, like CSCE 121. No automated tests included, mainly because it's impossible.

## Screenshots

If it's a frontend change, provide screenshots of it. If possible, show the change on different
resolutions/sizes.

If you're changing a existing frontend look, provide a before and after screenshot in the table below.

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/10082177/95693628-eeb89f00-0bf2-11eb-94e8-77a82046ea83.png)|![image](https://user-images.githubusercontent.com/10082177/95693669-14de3f00-0bf3-11eb-8ffd-09b47a9591ef.png)|

## Related tasks

Closes #362 
Closes #348 