### PR TITLE
Thunkified generateSchedules

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import {
-  Button, Checkbox, ListItem, ListItemIcon, ListItemText, Snackbar, IconButton,
+  Button, Checkbox, ListItem, ListItemIcon, ListItemText,
 } from '@material-ui/core';
-import CloseIcon from '@material-ui/icons/Close';
 import { useDispatch } from 'react-redux';
 import GenericCard from '../../GenericCard/GenericCard';
 import SmallFastProgress from '../../SmallFastProgress';
@@ -16,7 +15,6 @@ import { generateSchedules } from '../../../redux/actions/schedules';
 const ConfigureCard: React.FC = () => {
   const [includeFull, setIncludeFull] = React.useState(false);
   const [loading, setLoading] = React.useState(false);
-  const [showSnackbar, setShowSnackbar] = React.useState(false);
 
   const dispatch = useDispatch();
 
@@ -25,12 +23,6 @@ const ConfigureCard: React.FC = () => {
   React.useEffect((): VoidFunction => (): void => {
     isMounted.current = false;
   }, []);
-
-  // closes the snackbar if the user presses the close icon, but not if they click away
-  const handleSnackbarClose = (_event: any, reason: string): void => {
-    if (reason === 'clickaway') return;
-    setShowSnackbar(false);
-  };
 
   const fetchSchedules = React.useCallback(() => {
     // show loading indicator
@@ -69,17 +61,6 @@ const ConfigureCard: React.FC = () => {
             : 'Generate Schedules'}
         </Button>
       </div>
-      <Snackbar
-        open={showSnackbar}
-        autoHideDuration={5000}
-        message="No schedules found. Try widening your criteria."
-        onClose={handleSnackbarClose}
-        action={(
-          <IconButton aria-label="close" onClick={(): void => setShowSnackbar(false)}>
-            <CloseIcon fontSize="small" style={{ color: 'white' }} />
-          </IconButton>
-        )}
-      />
     </GenericCard>
   );
 };

--- a/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
@@ -3,20 +3,11 @@ import {
   Button, Checkbox, ListItem, ListItemIcon, ListItemText, Snackbar, IconButton,
 } from '@material-ui/core';
 import CloseIcon from '@material-ui/icons/Close';
-import * as Cookies from 'js-cookie';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import GenericCard from '../../GenericCard/GenericCard';
 import SmallFastProgress from '../../SmallFastProgress';
 import * as styles from './ConfigureCard.css';
-import { replaceSchedules } from '../../../redux/actions/schedules';
-import selectSchedule from '../../../redux/actions/selectedSchedule';
-import Meeting from '../../../types/Meeting';
-import { parseAllMeetings } from '../../../redux/actions/courseCards';
-// DEBUG
-import { RootState } from '../../../redux/reducer';
-import { CourseCardArray, CustomizationLevel } from '../../../types/CourseCardOptions';
-import Availability from '../../../types/Availability';
-import { formatTime } from '../../../utils/timeUtil';
+import { generateSchedules } from '../../../redux/actions/schedules';
 
 /**
  * Allows the user to configure global options for schedule generation. Includes a checkbox to
@@ -27,9 +18,6 @@ const ConfigureCard: React.FC = () => {
   const [loading, setLoading] = React.useState(false);
   const [showSnackbar, setShowSnackbar] = React.useState(false);
 
-  const courseCards = useSelector<RootState, CourseCardArray>((state) => state.courseCards);
-  const term = useSelector<RootState, string>((state) => state.term);
-  const avsList = useSelector<RootState, Availability[]>((state) => state.availability);
   const dispatch = useDispatch();
 
   // Holds a reference to the DOM element to check if the component is still mounted
@@ -37,11 +25,6 @@ const ConfigureCard: React.FC = () => {
   React.useEffect((): VoidFunction => (): void => {
     isMounted.current = false;
   }, []);
-
-  const checkIfEmpty = (schedules: Meeting[][]): Meeting[][] => {
-    if (isMounted.current && schedules.length === 0) setShowSnackbar(true);
-    return schedules;
-  };
 
   // closes the snackbar if the user presses the close icon, but not if they click away
   const handleSnackbarClose = (_event: any, reason: string): void => {
@@ -53,67 +36,8 @@ const ConfigureCard: React.FC = () => {
     // show loading indicator
     setLoading(true);
 
-    // make courses object
-    const courses = [];
-    for (let i = 0; i < courseCards.numCardsCreated; i++) {
-      if (courseCards[i] && courseCards[i].course) {
-        const courseCard = courseCards[i];
-
-        // Iterate through the sections and only choose the ones that are selected
-        const selectedSections = courseCard.sections
-          .filter((sectionSel) => sectionSel.selected)
-          .map((sectionSel) => sectionSel.section.sectionNum);
-
-        const [subject, courseNum] = courseCard.course.split(' ');
-        const isBasic = courseCard.customizationLevel === CustomizationLevel.BASIC;
-
-        // The default option for honors and web when the Section customization level is selected
-        const filterDefault = 'no_preference';
-
-        courses.push({
-          subject,
-          courseNum,
-          sections: isBasic ? [] : selectedSections, // Only send if "Section" customization level
-          // Only send if "Basic" level
-          honors: isBasic ? (courseCard.honors ?? filterDefault) : filterDefault,
-          web: isBasic ? (courseCard.web ?? filterDefault) : filterDefault,
-        });
-      }
-    }
-    // make availabilities object
-    const availabilities = avsList.map((avl) => ({
-      startTime: formatTime(avl.startTimeHours, avl.startTimeMinutes, true, true).replace(':', ''),
-      endTime: formatTime(avl.endTimeHours, avl.endTimeMinutes, true, true).replace(':', ''),
-      day: avl.dayOfWeek,
-    }));
-
-    // make request to generate schedules and update redux, will also save availabilities
-    fetch('scheduler/generate', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRFToken': Cookies.get('csrftoken'),
-      },
-      body: JSON.stringify({
-        term,
-        includeFull,
-        courses,
-        availabilities,
-      }),
-    }).then(
-      (res) => res.json(),
-    ).then(
-      (generatedSchedules: any[][]) => generatedSchedules.map(parseAllMeetings),
-    )
-      .then(
-        checkIfEmpty,
-      )
-      .then((schedules: Meeting[][]) => {
-        dispatch(replaceSchedules(schedules));
-        dispatch(selectSchedule(0));
-        if (isMounted.current) setLoading(false);
-      });
-  }, [avsList, courseCards, dispatch, includeFull, term]);
+    dispatch(generateSchedules(includeFull));
+  }, [dispatch, includeFull]);
 
   return (
     <GenericCard

--- a/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
@@ -31,14 +31,14 @@ const ConfigureCard: React.FC = () => {
     setSnackbarMessage('');
   };
 
-  const fetchSchedules = React.useCallback(() => {
+  const fetchSchedules = (): void => {
     // show loading indicator
     setLoading(true);
 
     dispatch(generateSchedules(includeFull))
       .catch((e: Error) => setSnackbarMessage(e.message))
       .finally(() => setLoading(false));
-  }, [dispatch, includeFull]);
+  };
 
   return (
     <GenericCard

--- a/autoscheduler/frontend/src/hooks/useThunkDispatch.ts
+++ b/autoscheduler/frontend/src/hooks/useThunkDispatch.ts
@@ -1,0 +1,8 @@
+import { useDispatch } from 'react-redux';
+import { AnyAction } from 'redux';
+import { ThunkDispatch } from 'redux-thunk';
+import { RootState } from '../redux/reducer';
+
+export default function useThunkDispatch(): ThunkDispatch<RootState, undefined, AnyAction> {
+  return useDispatch();
+}

--- a/autoscheduler/frontend/src/hooks/useThunkDispatch.ts
+++ b/autoscheduler/frontend/src/hooks/useThunkDispatch.ts
@@ -3,6 +3,12 @@ import { AnyAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { RootState } from '../redux/reducer';
 
+/**
+ * Casts the return type for Redux dispatches into ThunkDispatches. The key difference
+ * is that Thunk Dispatches are asynchronous, and they can be `.then`ed and `.catch`ed
+ *
+ * https://www.reddit.com/r/typescript/comments/c04mjt/how_to_type_reduxthunks_with_the_new_usedispatch/
+ */
 export default function useThunkDispatch(): ThunkDispatch<RootState, undefined, AnyAction> {
   return useDispatch();
 }

--- a/autoscheduler/frontend/src/redux/actions/schedules.ts
+++ b/autoscheduler/frontend/src/redux/actions/schedules.ts
@@ -1,9 +1,17 @@
+import { ThunkAction } from 'redux-thunk';
+import * as Cookies from 'js-cookie';
 import {
   AddScheduleAction, ADD_SCHEDULE, RemoveScheduleAction, REMOVE_SCHEDULE,
   ReplaceSchedulesAction, REPLACE_SCHEDULES, SaveScheduleAction, SAVE_SCHEDULE,
   UnsaveScheduleAction, UNSAVE_SCHEDULE, RenameScheduleAction, RENAME_SCHEDULE,
 } from '../reducers/schedules';
 import Meeting from '../../types/Meeting';
+import { RootState } from '../reducer';
+import { formatTime } from '../../utils/timeUtil';
+import { CustomizationLevel } from '../../types/CourseCardOptions';
+import { parseAllMeetings } from './courseCards';
+import { SelectScheduleAction } from '../reducers/selectedSchedule';
+import selectSchedule from './selectedSchedule';
 
 export function addSchedule(meetings: Meeting[]): AddScheduleAction {
   return {
@@ -45,5 +53,70 @@ export function renameSchedule(index: number, name: string): RenameScheduleActio
     type: RENAME_SCHEDULE,
     index,
     name,
+  };
+}
+
+export function generateSchedules(includeFull: boolean):
+ThunkAction<void, RootState, undefined, ReplaceSchedulesAction | SelectScheduleAction> {
+  return (dispatch, getState): void => {
+    const { courseCards, availability, term } = getState();
+
+    // make courses object
+    const courses = [];
+    for (let i = 0; i < courseCards.numCardsCreated; i++) {
+      if (courseCards[i] && courseCards[i].course) {
+        const courseCard = courseCards[i];
+
+        // Iterate through the sections and only choose the ones that are selected
+        const selectedSections = courseCard.sections
+          .filter((sectionSel) => sectionSel.selected)
+          .map((sectionSel) => sectionSel.section.sectionNum);
+
+        const [subject, courseNum] = courseCard.course.split(' ');
+        const isBasic = courseCard.customizationLevel === CustomizationLevel.BASIC;
+
+        // The default option for honors and web when the Section customization level is selected
+        const filterDefault = 'no_preference';
+
+        courses.push({
+          subject,
+          courseNum,
+          sections: isBasic ? [] : selectedSections, // Only send if "Section" customization level
+          // Only send if "Basic" level
+          honors: isBasic ? (courseCard.honors ?? filterDefault) : filterDefault,
+          web: isBasic ? (courseCard.web ?? filterDefault) : filterDefault,
+        });
+      }
+    }
+    // make availabilities object
+    const availabilities = availability.map((avl) => ({
+      startTime: formatTime(avl.startTimeHours, avl.startTimeMinutes, true, true).replace(':', ''),
+      endTime: formatTime(avl.endTimeHours, avl.endTimeMinutes, true, true).replace(':', ''),
+      day: avl.dayOfWeek,
+    }));
+
+    // make request to generate schedules and update redux, will also save availabilities
+    fetch('scheduler/generate', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': Cookies.get('csrftoken'),
+      },
+      body: JSON.stringify({
+        term,
+        includeFull,
+        courses,
+        availabilities,
+      }),
+    }).then(
+      (res) => res.json(),
+    ).then(
+      (generatedSchedules: any[][]) => generatedSchedules.map(parseAllMeetings),
+    )
+      // WARNING: Deleted snackbar when no schedules are generated
+      .then((schedules: Meeting[][]) => {
+        dispatch(replaceSchedules(schedules));
+        dispatch(selectSchedule(0));
+      });
   };
 }

--- a/autoscheduler/frontend/src/tests/ui/ConfigureCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/ConfigureCard.test.tsx
@@ -23,7 +23,7 @@ describe('ConfigureCard component', () => {
       // arrange
       fetchMock.mockOnce('[]');
 
-      const store = createStore(autoSchedulerReducer);
+      const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
       const { getByText } = render(
         <Provider store={store}>
           <ConfigureCard />
@@ -41,7 +41,7 @@ describe('ConfigureCard component', () => {
   describe('shows a loading spinner', () => {
     test('when the user clicks Fetch Schedules', async () => {
       // arrange
-      const store = createStore(autoSchedulerReducer);
+      const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
       const { getByText, findByRole } = render(
         <Provider store={store}>
           <ConfigureCard />
@@ -197,49 +197,6 @@ describe('ConfigureCard component', () => {
 
       // assert
       expect(sections.length).toEqual(0);
-    });
-  });
-
-  describe('shows an error snackbar', () => {
-    test('when the backend returns no schedules', async () => {
-      // arrange
-      const store = createStore(autoSchedulerReducer);
-      const { getByText, findByText } = render(
-        <Provider store={store}>
-          <ConfigureCard />
-        </Provider>,
-      );
-
-      fetchMock.mockResponseOnce(JSON.stringify([]));
-
-      // act
-      fireEvent.click(getByText('Generate Schedules'));
-      const errorMessage = await findByText('No schedules found. Try widening your criteria.');
-
-      // assert
-      expect(errorMessage).toBeInTheDocument();
-    });
-  });
-
-  describe('does not show an error snackbar', () => {
-    test('when the backend returns schedules', async () => {
-      // arrange
-      const store = createStore(autoSchedulerReducer);
-      const { queryByText, findByRole } = render(
-        <Provider store={store}>
-          <ConfigureCard />
-        </Provider>,
-      );
-
-      fetchMock.mockResponseOnce(JSON.stringify([[], []]));
-
-      // act
-      fireEvent.click(queryByText('Generate Schedules'));
-      await findByRole('progressbar');
-      const errorMessage = queryByText('No schedules found. Try widening your criteria.');
-
-      // assert
-      expect(errorMessage).not.toBeInTheDocument();
     });
   });
 });

--- a/autoscheduler/frontend/src/tests/ui/SchedulingPage.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SchedulingPage.test.tsx
@@ -38,7 +38,7 @@ describe('Scheduling Page UI', () => {
   describe('adds schedules to the Schedule Preview', () => {
     test('when the user clicks Generate Schedules', async () => {
       // arrange
-      const store = createStore(autoSchedulerReducer);
+      const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
 
       // sessions/get_last_term
       fetchMock.mockResponseOnce(JSON.stringify({}));
@@ -54,7 +54,7 @@ describe('Scheduling Page UI', () => {
 
       // act
       fireEvent.click(getByText('Generate Schedules'));
-      await waitFor(() => {});
+      await new Promise(setImmediate);
 
       // assert
       expect(queryByText('No schedules available')).toBeFalsy();
@@ -65,7 +65,7 @@ describe('Scheduling Page UI', () => {
   describe('changes the meetings shown in the Schedule', () => {
     test('when the user clicks on a different schedule in the Schedule Preview', async () => {
       // arrange
-      const store = createStore(autoSchedulerReducer);
+      const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
 
       // sessions/get_last_term
       fetchMock.mockResponseOnce(JSON.stringify({}));


### PR DESCRIPTION
## Description

Multi day availabilities were very laggy, so I did some profiling and realized that the ConfigureCard was being re-rendered very frequently. This occurred because the ConfigureCard needed access to the most up-to-date availabilities list, which was constantly being updated. By extracting the `generateSchedules` functionality to a Thunk Action, I can simply request the most up-to-date availabilities list once, at the time of schedule fetching, rather than asking for it constantly via `useSelector`.

## Rationale

I got rid of the "no schedules generated snackbar" because it would be a hassle to pass information back from Redux to the UI, and we can deal with that problem later, since we have to replace the snakcbar with a dialog anyway.

## How to test

Automated tests are note possible for this bug, as it deals with lag. To test, create multi-day availabilities as you normally would when using the site. There should be noticeably less lag than there is on master, which you can test by opening [revregistration.com](https://revregistration.com) in another tab. To stress test, start a click in the middle of the schedule, then drag around in circles. The availabilities should follow your mouse quickly. Again, you can compare to master to verify that these changes have actually made a difference.
