### PR TITLE
Add Google Analytics script

### DIFF
--- a/autoscheduler/frontend/templates/index.html
+++ b/autoscheduler/frontend/templates/index.html
@@ -21,7 +21,7 @@
             gtag('js', new Date());
 
             gtag('config', 'UA-179924187-1');
-        </script>        
+        </script>
     </head>
     <body>
         <div id="root"></div>

--- a/autoscheduler/frontend/templates/index.html
+++ b/autoscheduler/frontend/templates/index.html
@@ -13,6 +13,15 @@
                 background-color:#c2c2c2;
             }
         </style>
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-179924187-1"></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', 'UA-179924187-1');
+        </script>        
     </head>
     <body>
         <div id="root"></div>


### PR DESCRIPTION
## Description

As discussed in the last meeting, we'll be adding Google Analytics to the site so we can track hitcounts and the like.

Note that if you have an adblocker (uBlock origin, etc) it'll block this script.

I've invited everyone to the Google analytics account, which you can view at http://analytics.google.com, but here's what the homepage looks like:

![chrome_Gx0HHeSM8O](https://user-images.githubusercontent.com/7295783/95807097-f0579500-0cce-11eb-9ba8-ad1a3ce58b79.png)

## Related tasks

Per this addition, I made a task (#408) for adding a privacy policy page.
