### PR TITLE
Fixed bug where cards deleted when loading are recreated

### DIFF
--- a/autoscheduler/frontend/src/redux/actions/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/actions/courseCards.ts
@@ -282,7 +282,7 @@ function getSelectedSections(
 ): SectionSelected[] {
   const selectedSections = new Set(serialized.sections);
 
-  return courseCard.sections?.map((section): SectionSelected => ({
+  return courseCard?.sections?.map((section): SectionSelected => ({
     ...section,
     selected: selectedSections.has(section.section.id),
   })) || [];
@@ -311,7 +311,7 @@ export function replaceCourseCards(
     courseCards.forEach((courseCard, idx) => {
       const deserializedCard = deserializeCourseCard(courseCard);
       deserializedCards.push(deserializedCard);
-      dispatch(updateCourseCardSync(idx, deserializedCard));
+      dispatch(addCourseCard(deserializedCard, idx));
     });
 
     // all course cards are now marked as loading (preventing courses from being overwritten

--- a/autoscheduler/frontend/src/redux/reducers/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/reducers/courseCards.ts
@@ -63,14 +63,13 @@ export default function courseCards(
         ...state,
         [action.index]: undefined,
       };
-    case UPDATE_COURSE_CARD: {
+    case UPDATE_COURSE_CARD:
       if (!state[action.index]) return state;
       return {
         ...state,
         [action.index]: { ...state[action.index], ...action.courseCard },
         numCardsCreated: Math.max(state.numCardsCreated, action.index + 1),
       };
-    }
     case CLEAR_COURSE_CARDS:
       return initialCourseCardArray;
     default:

--- a/autoscheduler/frontend/src/redux/reducers/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/reducers/courseCards.ts
@@ -63,12 +63,14 @@ export default function courseCards(
         ...state,
         [action.index]: undefined,
       };
-    case UPDATE_COURSE_CARD:
+    case UPDATE_COURSE_CARD: {
+      if (!state[action.index]) return state;
       return {
         ...state,
         [action.index]: { ...state[action.index], ...action.courseCard },
         numCardsCreated: Math.max(state.numCardsCreated, action.index + 1),
       };
+    }
     case CLEAR_COURSE_CARDS:
       return initialCourseCardArray;
     default:


### PR DESCRIPTION
## Description

Fixes the bug described in #412.

## Rationale
This can still technically happen if you delete the auto-generated card before `get_last_term` completes:
![oops](https://user-images.githubusercontent.com/28655462/96193327-8aa51c00-0f0d-11eb-99a5-6d23f92c34a7.gif)
since the term changes, causing the card you deleted to be recreated after the term changes. The only way around this would be to not recreate the initial card when `clearCourseCards` is dispatched, but I think this way is probably better since that's a bit weird and it's hard to replicate this unless you're trying to do it on purpose.

## How to test

Try to replicate this bug on master/production and see how easy it is, then try it on this branch. No tests made because there's no determinate way to replicate it (as it has to do with how async actions are ordered)

## Screenshots

![wowamazin](https://user-images.githubusercontent.com/28655462/96192847-862c3380-0f0c-11eb-9f7c-25a72697083b.gif)

## Related tasks
Closes #412.
