### PR TITLE
Save schedules

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css
@@ -69,3 +69,9 @@
 .no-flex-shrink {
     flex-shrink: 0;
 }
+
+.schedules-loading-indicator {
+    display: flex;
+    align-items: center;
+    height: 100%;
+}

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css.d.ts
@@ -22,6 +22,8 @@ declare namespace SchedulePreviewCssNamespace {
     scheduleHeader: string;
     scheduleNameContainer: string;
     scheduleNameText: string;
+    "schedules-loading-indicator": string;
+    schedulesLoadingIndicator: string;
     "section-label-row": string;
     sectionLabelRow: string;
   }

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
@@ -11,6 +11,7 @@ import { setSchedules } from '../../../redux/actions/schedules';
 import createThrottleFunction from '../../../utils/createThrottleFunction';
 import { parseAllMeetings } from '../../../redux/actions/courseCards';
 import SmallFastProgress from '../../SmallFastProgress';
+import { SaveSchedulesRequest, SerializedSchedule } from '../../../types/APIRequests';
 
 const throttle = createThrottleFunction();
 
@@ -62,7 +63,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({
 
     // Serialize schedules and make API call
     const saveSchedules = (): void => {
-      const serializedSchedules = schedules.filter(
+      const serializedSchedules: SerializedSchedule[] = schedules.filter(
         // Filter out unsaved schedules
         (schedule) => schedule.saved,
       ).map((schedule) => ({
@@ -71,13 +72,15 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({
         sections: [...new Set(schedule.meetings.map((m) => m.section.id))],
       }));
 
+      const request: SaveSchedulesRequest = { term, schedules: serializedSchedules }
+
       fetch('sessions/save_schedules', {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
           'X-CSRFToken': Cookies.get('csrftoken'),
         },
-        body: JSON.stringify({ term, schedules: serializedSchedules }),
+        body: JSON.stringify(request),
       });
     };
 

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
@@ -62,22 +62,14 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({
 
     // Serialize schedules and make API call
     const saveSchedules = (): void => {
-      let serializedSchedules: { name: string; sections: number[] }[] = [];
-
-      if (schedules) {
-        if (schedules.length === 0) {
-          return;
-        }
-
-        serializedSchedules = schedules.filter(
-          // Filter out unsaved schedules
-          (schedule) => schedule.saved,
-        ).map((schedule) => ({
-          name: schedule.name,
-          // Get a list of the section IDs that are in this schedule
-          sections: [...new Set(schedule.meetings.map((m) => m.section.id))],
-        }));
-      }
+      const serializedSchedules = schedules.filter(
+        // Filter out unsaved schedules
+        (schedule) => schedule.saved,
+      ).map((schedule) => ({
+        name: schedule.name,
+        // Get a list of the section IDs that are in this schedule
+        sections: [...new Set(schedule.meetings.map((m) => m.section.id))],
+      }));
 
       fetch('sessions/save_schedules', {
         method: 'PUT',

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
@@ -10,6 +10,7 @@ import Schedule from '../../../types/Schedule';
 import { setSchedules } from '../../../redux/actions/schedules';
 import createThrottleFunction from '../../../utils/createThrottleFunction';
 import { parseAllMeetings } from '../../../redux/actions/courseCards';
+import SmallFastProgress from '../../SmallFastProgress';
 
 const throttle = createThrottleFunction();
 
@@ -24,6 +25,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ throttleTime = 10000 
   const dispatch = useDispatch();
   const schedules = useSelector<RootState, Schedule[]>((state) => state.schedules);
   const term = useSelector<RootState, string>((state) => state.term);
+  const [isLoadingSchedules, setIsLoadingSchedules] = React.useState(true);
 
   const scheduleListItems = schedules.length === 0
     ? <p className={styles.noSchedules}>{noSchedulesText}</p>
@@ -35,12 +37,12 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ throttleTime = 10000 
       fetch(`sessions/get_saved_schedules?term=${term}`).then(
         (res) => res.json(),
       ).then((arr: any[]): Schedule[] => arr.map((val) => ({
-        // TODO: Should we rename the schedule names if they're in the form of "Schedule #"?
         name: val.name,
         meetings: parseAllMeetings(val.sections),
         saved: true,
       }))).then((savedSchedules: Schedule[]) => {
         dispatch(setSchedules(savedSchedules));
+        setIsLoadingSchedules(false);
       });
     }
 
@@ -100,9 +102,15 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ throttleTime = 10000 
         <div id={styles.cardHeader}>Schedules</div>
       }
     >
-      <List className={styles.list} disablePadding>
-        {scheduleListItems}
-      </List>
+      {isLoadingSchedules ? (
+        <div className={styles.schedulesLoadingIndicator} aria-label="schedules-loading-indicator">
+          <SmallFastProgress size="large" />
+        </div>
+      ) : (
+        <List className={styles.list} disablePadding>
+          {scheduleListItems}
+        </List>
+      )}
     </GenericCard>
   );
 };

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
@@ -1,20 +1,89 @@
 import * as React from 'react';
-import { useSelector } from 'react-redux';
+import * as Cookies from 'js-cookie';
+import { useDispatch, useSelector } from 'react-redux';
 import { List } from '@material-ui/core';
 import GenericCard from '../../GenericCard/GenericCard';
 import { RootState } from '../../../redux/reducer';
 import * as styles from './SchedulePreview.css';
 import ScheduleListItem from './ScheduleListItem/ScheduleListItem';
 import Schedule from '../../../types/Schedule';
+import { setSchedules } from '../../../redux/actions/schedules';
+import createThrottleFunction from '../../../utils/createThrottleFunction';
+import { parseAllMeetings } from '../../../redux/actions/courseCards';
+
+const throttle = createThrottleFunction();
 
 export const noSchedulesText = "Click Generate Schedules to find schedules with the courses you've added.";
 
-const SchedulePreview: React.FC = () => {
+interface SchedulePreviewProps {
+  // Is a prop so we can set the throttle time to a really low number when testing
+  throttleTime?: number;
+}
+
+const SchedulePreview: React.FC<SchedulePreviewProps> = ({ throttleTime = 5000 }) => {
+  const dispatch = useDispatch();
   const schedules = useSelector<RootState, Schedule[]>((state) => state.schedules);
+  const term = useSelector<RootState, string>((state) => state.term);
 
   const scheduleListItems = schedules.length === 0
     ? <p className={styles.noSchedules}>{noSchedulesText}</p>
     : schedules.map((schedule, idx) => <ScheduleListItem index={idx} key={schedule.name} />);
+
+  // Whenever the term changes, fetch and load saved schedules
+  React.useEffect(() => {
+    if (term) {
+      fetch(`sessions/get_saved_schedules?term=${term}`).then(
+        (res) => res.json(),
+      ).then((arr: any[]): Schedule[] => arr.map((val) => ({
+        // TODO: Should we rename the schedule names if they're in the form of "Schedule #"?
+        name: val.name,
+        meetings: parseAllMeetings(val.sections),
+        saved: true,
+      }))).then((savedSchedules: Schedule[]) => {
+        dispatch(setSchedules(savedSchedules));
+      });
+    }
+
+    // on unmount, clear schedules
+    return (): void => {
+      dispatch(setSchedules([]));
+    };
+  }, [term, dispatch]);
+
+  // Call throttle to serialize and save the schedules anytime we make a change to the schedules
+  React.useEffect(() => {
+    if (!term) return;
+
+    // Serialize schedules and make API call
+    const saveSchedules = (): void => {
+      let serializedSchedules: { name: string; sections: number[] }[] = [];
+
+      if (schedules) {
+        if (schedules.length === 0) {
+          return;
+        }
+
+        serializedSchedules = schedules.filter(
+          // Filter out unsaved schedules
+          (schedule) => schedule.saved,
+        ).map((schedule) => ({
+          name: schedule.name,
+          // Get a list of the section IDs that are in this schedule
+          sections: [...new Set(schedule.meetings.map((m) => m.section.id))],
+        }));
+      }
+
+      fetch('sessions/save_schedules', {
+        method: 'PUT',
+        headers: {
+          'X-CSRFToken': Cookies.get('csrftoken'),
+        },
+        body: JSON.stringify({ term, schedules: serializedSchedules }),
+      });
+    };
+
+    throttle(term, saveSchedules, throttleTime, true);
+  }, [schedules, term, throttleTime]);
 
   return (
     <GenericCard

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
@@ -72,7 +72,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({
         sections: [...new Set(schedule.meetings.map((m) => m.section.id))],
       }));
 
-      const request: SaveSchedulesRequest = { term, schedules: serializedSchedules }
+      const request: SaveSchedulesRequest = { term, schedules: serializedSchedules };
 
       fetch('sessions/save_schedules', {
         method: 'PUT',

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
@@ -20,7 +20,7 @@ interface SchedulePreviewProps {
   throttleTime?: number;
 }
 
-const SchedulePreview: React.FC<SchedulePreviewProps> = ({ throttleTime = 5000 }) => {
+const SchedulePreview: React.FC<SchedulePreviewProps> = ({ throttleTime = 10000 }) => {
   const dispatch = useDispatch();
   const schedules = useSelector<RootState, Schedule[]>((state) => state.schedules);
   const term = useSelector<RootState, string>((state) => state.term);
@@ -76,6 +76,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ throttleTime = 5000 }
       fetch('sessions/save_schedules', {
         method: 'PUT',
         headers: {
+          'Content-Type': 'application/json',
           'X-CSRFToken': Cookies.get('csrftoken'),
         },
         body: JSON.stringify({ term, schedules: serializedSchedules }),
@@ -84,6 +85,13 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({ throttleTime = 5000 }
 
     throttle(term, saveSchedules, throttleTime, true);
   }, [schedules, term, throttleTime]);
+
+  // On unmount, force-call the previously called throttle functions
+  // This way when we navigate back to the homepage we can guarantee saveSchedules
+  // will have been called
+  React.useEffect(() => (): void => {
+    throttle('', () => {}, 2 ** 31 - 1, true);
+  }, []);
 
   return (
     <GenericCard

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
@@ -19,13 +19,17 @@ export const noSchedulesText = "Click Generate Schedules to find schedules with 
 interface SchedulePreviewProps {
   // Is a prop so we can set the throttle time to a really low number when testing
   throttleTime?: number;
+  // Option to to hide the loading indicator, exclusively used for tests
+  hideLoadingIndicator?: boolean;
 }
 
-const SchedulePreview: React.FC<SchedulePreviewProps> = ({ throttleTime = 10000 }) => {
+const SchedulePreview: React.FC<SchedulePreviewProps> = ({
+  throttleTime = 10000, hideLoadingIndicator = false,
+}) => {
   const dispatch = useDispatch();
   const schedules = useSelector<RootState, Schedule[]>((state) => state.schedules);
   const term = useSelector<RootState, string>((state) => state.term);
-  const [isLoadingSchedules, setIsLoadingSchedules] = React.useState(true);
+  const [isLoadingSchedules, setIsLoadingSchedules] = React.useState(!hideLoadingIndicator);
 
   const scheduleListItems = schedules.length === 0
     ? <p className={styles.noSchedules}>{noSchedulesText}</p>

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulingPage.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulingPage.tsx
@@ -8,7 +8,14 @@ import SchedulePreview from './SchedulePreview/SchedulePreview';
 import CourseSelectColumn from './CourseSelectColumn/CourseSelectColumn';
 import setTerm from '../../redux/actions/term';
 
-const SchedulingPage: React.FC<RouteComponentProps> = (): JSX.Element => {
+interface SchedulingPageProps extends RouteComponentProps {
+  // Option to hide the SchedulePreview loading indicator
+  hideSchedulesLoadingIndicator?: boolean;
+}
+
+const SchedulingPage: React.FC<SchedulingPageProps> = ({
+  hideSchedulesLoadingIndicator = false,
+}) => {
   const dispatch = useDispatch();
 
   // Set redux state on page load based on term from user session
@@ -29,7 +36,7 @@ const SchedulingPage: React.FC<RouteComponentProps> = (): JSX.Element => {
         </div>
         <div className={styles.middleColumn}>
           <ConfigureCard />
-          <SchedulePreview />
+          <SchedulePreview hideLoadingIndicator={hideSchedulesLoadingIndicator} />
         </div>
       </div>
       <div className={styles.scheduleContainer}>

--- a/autoscheduler/frontend/src/redux/actions/schedules.ts
+++ b/autoscheduler/frontend/src/redux/actions/schedules.ts
@@ -4,7 +4,7 @@ import {
   AddScheduleAction, ADD_SCHEDULE, RemoveScheduleAction, REMOVE_SCHEDULE,
   ReplaceSchedulesAction, REPLACE_SCHEDULES, SaveScheduleAction, SAVE_SCHEDULE,
   UnsaveScheduleAction, UNSAVE_SCHEDULE, RenameScheduleAction, RENAME_SCHEDULE, SET_SCHEDULES,
-  SetScheduleAction,
+  SetSchedulesAction,
 } from '../reducers/schedules';
 import Meeting from '../../types/Meeting';
 import { RootState } from '../reducer';
@@ -130,7 +130,7 @@ ThunkAction<Promise<void>, RootState, undefined, ReplaceSchedulesAction | Select
   };
 }
 
-export function setSchedules(schedules: Schedule[]): SetScheduleAction {
+export function setSchedules(schedules: Schedule[]): SetSchedulesAction {
   return {
     type: SET_SCHEDULES,
     schedules,

--- a/autoscheduler/frontend/src/redux/actions/schedules.ts
+++ b/autoscheduler/frontend/src/redux/actions/schedules.ts
@@ -3,7 +3,7 @@ import * as Cookies from 'js-cookie';
 import {
   AddScheduleAction, ADD_SCHEDULE, RemoveScheduleAction, REMOVE_SCHEDULE,
   ReplaceSchedulesAction, REPLACE_SCHEDULES, SaveScheduleAction, SAVE_SCHEDULE,
-  UnsaveScheduleAction, UNSAVE_SCHEDULE, RenameScheduleAction, RENAME_SCHEDULE,
+  UnsaveScheduleAction, UNSAVE_SCHEDULE, RenameScheduleAction, RENAME_SCHEDULE, SET_SCHEDULES, SetScheduleAction,
 } from '../reducers/schedules';
 import Meeting from '../../types/Meeting';
 import { RootState } from '../reducer';
@@ -12,6 +12,7 @@ import { CustomizationLevel } from '../../types/CourseCardOptions';
 import { parseAllMeetings } from './courseCards';
 import { SelectScheduleAction } from '../reducers/selectedSchedule';
 import selectSchedule from './selectedSchedule';
+import Schedule from '../../types/Schedule';
 
 export function addSchedule(meetings: Meeting[]): AddScheduleAction {
   return {
@@ -125,5 +126,12 @@ ThunkAction<Promise<void>, RootState, undefined, ReplaceSchedulesAction | Select
         dispatch(replaceSchedules(schedules));
         dispatch(selectSchedule(0));
       });
+  };
+}
+
+export function setSchedules(schedules: Schedule[]): SetScheduleAction {
+  return {
+    type: SET_SCHEDULES,
+    schedules,
   };
 }

--- a/autoscheduler/frontend/src/redux/actions/schedules.ts
+++ b/autoscheduler/frontend/src/redux/actions/schedules.ts
@@ -3,7 +3,8 @@ import * as Cookies from 'js-cookie';
 import {
   AddScheduleAction, ADD_SCHEDULE, RemoveScheduleAction, REMOVE_SCHEDULE,
   ReplaceSchedulesAction, REPLACE_SCHEDULES, SaveScheduleAction, SAVE_SCHEDULE,
-  UnsaveScheduleAction, UNSAVE_SCHEDULE, RenameScheduleAction, RENAME_SCHEDULE, SET_SCHEDULES, SetScheduleAction,
+  UnsaveScheduleAction, UNSAVE_SCHEDULE, RenameScheduleAction, RENAME_SCHEDULE, SET_SCHEDULES,
+  SetScheduleAction,
 } from '../reducers/schedules';
 import Meeting from '../../types/Meeting';
 import { RootState } from '../reducer';

--- a/autoscheduler/frontend/src/redux/reducers/schedules.ts
+++ b/autoscheduler/frontend/src/redux/reducers/schedules.ts
@@ -12,6 +12,7 @@ export const REPLACE_SCHEDULES = 'REPLACE_SCHEDULES';
 export const SAVE_SCHEDULE = 'SAVE_SCHEDULE';
 export const UNSAVE_SCHEDULE = 'UNSAVE_SCHEDULE';
 export const RENAME_SCHEDULE = 'RENAME_SCHEDULE';
+export const SET_SCHEDULES = 'SET_SCHEDULE';
 
 // action type interfaces
 export interface AddScheduleAction {
@@ -39,8 +40,12 @@ export interface RenameScheduleAction {
   index: number;
   name: string;
 }
+export interface SetScheduleAction {
+  type: 'SET_SCHEDULE';
+  schedules: Schedule[];
+}
 export type ScheduleAction = AddScheduleAction | RemoveScheduleAction | ReplaceSchedulesAction
-| SaveScheduleAction | UnsaveScheduleAction | RenameScheduleAction;
+| SaveScheduleAction | UnsaveScheduleAction | RenameScheduleAction | SetScheduleAction;
 
 const initialSchedules: Schedule[] = [];
 
@@ -135,6 +140,8 @@ function schedules(state: Schedule[] = initialSchedules, action: ScheduleAction)
       };
       return newState;
     }
+    case SET_SCHEDULES:
+      return action.schedules;
     default:
       return state;
   }

--- a/autoscheduler/frontend/src/redux/reducers/schedules.ts
+++ b/autoscheduler/frontend/src/redux/reducers/schedules.ts
@@ -12,7 +12,7 @@ export const REPLACE_SCHEDULES = 'REPLACE_SCHEDULES';
 export const SAVE_SCHEDULE = 'SAVE_SCHEDULE';
 export const UNSAVE_SCHEDULE = 'UNSAVE_SCHEDULE';
 export const RENAME_SCHEDULE = 'RENAME_SCHEDULE';
-export const SET_SCHEDULES = 'SET_SCHEDULE';
+export const SET_SCHEDULES = 'SET_SCHEDULES';
 
 // action type interfaces
 export interface AddScheduleAction {
@@ -40,12 +40,12 @@ export interface RenameScheduleAction {
   index: number;
   name: string;
 }
-export interface SetScheduleAction {
-  type: 'SET_SCHEDULE';
+export interface SetSchedulesAction {
+  type: 'SET_SCHEDULES';
   schedules: Schedule[];
 }
 export type ScheduleAction = AddScheduleAction | RemoveScheduleAction | ReplaceSchedulesAction
-| SaveScheduleAction | UnsaveScheduleAction | RenameScheduleAction | SetScheduleAction;
+| SaveScheduleAction | UnsaveScheduleAction | RenameScheduleAction | SetSchedulesAction;
 
 const initialSchedules: Schedule[] = [];
 

--- a/autoscheduler/frontend/src/tests/testData.ts
+++ b/autoscheduler/frontend/src/tests/testData.ts
@@ -266,6 +266,7 @@ export async function mockGetSavedSchedules(): Promise<Response> {
     max_enrollment: 0,
     honors: true,
     web: false,
+    asynchronous: false,
     instructor_name: 'Dr. Pepper',
     meetings: [{
       id: 87328,

--- a/autoscheduler/frontend/src/tests/testData.ts
+++ b/autoscheduler/frontend/src/tests/testData.ts
@@ -252,3 +252,35 @@ export async function mockFetchSchedulerGenerate(): Promise<Response> {
     [testSection1, testSection3],
   ]));
 }
+
+export async function mockGetSavedSchedules(): Promise<Response> {
+  const testSection4 = {
+    id: 830262,
+    crn: 67890,
+    subject: 'MATH',
+    course_num: '151',
+    section_num: '201',
+    min_credits: 0,
+    max_credits: 0,
+    current_enrollment: 0,
+    max_enrollment: 0,
+    honors: true,
+    web: false,
+    instructor_name: 'Dr. Pepper',
+    meetings: [{
+      id: 87328,
+      building: 'BLOC',
+      days: [false, true, false, true, false, true, false],
+      start_time: '09:10',
+      end_time: '10:00',
+      type: 'LEC',
+    }],
+  };
+
+  const ret = [{
+    name: 'Schedule 1',
+    sections: [testSection4],
+  }];
+
+  return new Response(JSON.stringify(ret));
+}

--- a/autoscheduler/frontend/src/tests/ui/SchedulePreview.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SchedulePreview.test.tsx
@@ -302,6 +302,9 @@ describe('SchedulePreview component', () => {
 
         // act
         await new Promise(setImmediate);
+        // Reset fetchMock calls to ignore the empty save_schedules fetch
+        fetchMock.mock.calls = [];
+
         store.dispatch(setSchedules(exampleSchedules));
         await new Promise(setImmediate);
 

--- a/autoscheduler/frontend/src/tests/ui/SchedulePreview.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SchedulePreview.test.tsx
@@ -19,6 +19,7 @@ import Meeting, { MeetingType } from '../../types/Meeting';
 import setTerm from '../../redux/actions/term';
 import Schedule from '../../types/Schedule';
 import { mockGetSavedSchedules } from '../testData';
+import { SaveSchedulesRequest } from '../../types/APIRequests';
 
 describe('SchedulePreview component', () => {
   describe('updates the selected schedule', () => {
@@ -286,7 +287,7 @@ describe('SchedulePreview component', () => {
         store.dispatch(setTerm(term));
 
         // Save schedules
-        const expected = {
+        const expected: SaveSchedulesRequest = {
           term,
           schedules: [{
             name: 'Schedule 1',

--- a/autoscheduler/frontend/src/tests/ui/SchedulePreview.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SchedulePreview.test.tsx
@@ -266,6 +266,7 @@ describe('SchedulePreview component', () => {
           maxEnrollment: 0,
           honors: true,
           web: false,
+          asynchronous: false,
           instructor: new Instructor({ name: 'Dr. Pepper' }),
           grades: null,
         }),

--- a/autoscheduler/frontend/src/tests/ui/SchedulePreview.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SchedulePreview.test.tsx
@@ -16,7 +16,6 @@ import { testSchedule1, testSchedule2 } from '../testSchedules';
 import Section from '../../types/Section';
 import Instructor from '../../types/Instructor';
 import Meeting, { MeetingType } from '../../types/Meeting';
-import Grades from '../../types/Grades';
 import setTerm from '../../redux/actions/term';
 import Schedule from '../../types/Schedule';
 import { mockGetSavedSchedules } from '../testData';
@@ -28,7 +27,7 @@ describe('SchedulePreview component', () => {
       const store = createStore(autoSchedulerReducer);
       const { findAllByLabelText } = render(
         <Provider store={store}>
-          <SchedulePreview />
+          <SchedulePreview hideLoadingIndicator />
         </Provider>,
       );
       store.dispatch(replaceSchedules([testSchedule1, testSchedule2]));
@@ -48,7 +47,7 @@ describe('SchedulePreview component', () => {
       const store = createStore(autoSchedulerReducer);
       const { findAllByLabelText } = render(
         <Provider store={store}>
-          <SchedulePreview />
+          <SchedulePreview hideLoadingIndicator />
         </Provider>,
       );
       store.dispatch(replaceSchedules([testSchedule1, testSchedule2]));
@@ -68,7 +67,7 @@ describe('SchedulePreview component', () => {
       const store = createStore(autoSchedulerReducer);
       const { findAllByLabelText } = render(
         <Provider store={store}>
-          <SchedulePreview />
+          <SchedulePreview hideLoadingIndicator />
         </Provider>,
       );
       store.dispatch(replaceSchedules([testSchedule1, testSchedule2]));
@@ -90,7 +89,7 @@ describe('SchedulePreview component', () => {
       const store = createStore(autoSchedulerReducer);
       const { findAllByLabelText, findByTitle } = render(
         <Provider store={store}>
-          <SchedulePreview />
+          <SchedulePreview hideLoadingIndicator />
         </Provider>,
       );
       store.dispatch(replaceSchedules([testSchedule1, testSchedule2]));
@@ -113,7 +112,7 @@ describe('SchedulePreview component', () => {
       const store = createStore(autoSchedulerReducer);
       const { findAllByLabelText, findByTitle } = render(
         <Provider store={store}>
-          <SchedulePreview />
+          <SchedulePreview hideLoadingIndicator />
         </Provider>,
       );
       store.dispatch(replaceSchedules([testSchedule1, testSchedule2]));
@@ -138,7 +137,7 @@ describe('SchedulePreview component', () => {
       const store = createStore(autoSchedulerReducer);
       const { findAllByLabelText } = render(
         <Provider store={store}>
-          <SchedulePreview />
+          <SchedulePreview hideLoadingIndicator />
         </Provider>,
       );
       store.dispatch(replaceSchedules([testSchedule1, testSchedule2]));
@@ -158,7 +157,7 @@ describe('SchedulePreview component', () => {
       const store = createStore(autoSchedulerReducer);
       const { findAllByLabelText, getByText } = render(
         <Provider store={store}>
-          <SchedulePreview />
+          <SchedulePreview hideLoadingIndicator />
         </Provider>,
       );
       store.dispatch(replaceSchedules([testSchedule1, testSchedule2]));
@@ -189,7 +188,7 @@ describe('SchedulePreview component', () => {
       const store = createStore(autoSchedulerReducer);
       const { findByLabelText, findAllByLabelText } = render(
         <Provider store={store}>
-          <SchedulePreview />
+          <SchedulePreview hideLoadingIndicator />
         </Provider>,
       );
       store.dispatch(replaceSchedules([testSchedule1, testSchedule2]));
@@ -218,7 +217,7 @@ describe('SchedulePreview component', () => {
       const store = createStore(autoSchedulerReducer);
       const { findByLabelText, findAllByLabelText } = render(
         <Provider store={store}>
-          <SchedulePreview />
+          <SchedulePreview hideLoadingIndicator />
         </Provider>,
       );
       store.dispatch(replaceSchedules([testSchedule1, testSchedule2]));
@@ -297,7 +296,7 @@ describe('SchedulePreview component', () => {
 
         render(
           <Provider store={store}>
-            <SchedulePreview throttleTime={1} />
+            <SchedulePreview throttleTime={1} hideLoadingIndicator />
           </Provider>,
         );
 
@@ -331,7 +330,7 @@ describe('SchedulePreview component', () => {
         // act
         render(
           <Provider store={store}>
-            <SchedulePreview />
+            <SchedulePreview hideLoadingIndicator />
           </Provider>,
         );
 

--- a/autoscheduler/frontend/src/tests/ui/SchedulingPage.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SchedulingPage.test.tsx
@@ -62,6 +62,8 @@ describe('Scheduling Page UI', () => {
       fetchMock.mockResponseOnce(JSON.stringify({ term: '202031' }));
       // sessions/get_saved_courses
       fetchMock.mockResponseOnce(JSON.stringify({}));
+      // sessions/get_saved_schedules
+      fetchMock.mockResponseOnce(JSON.stringify([]));
       // sessions/get_saved_availabilities
       fetchMock.mockResponseOnce(JSON.stringify([]));
 

--- a/autoscheduler/frontend/src/tests/ui/SchedulingPage.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SchedulingPage.test.tsx
@@ -170,6 +170,8 @@ describe('Scheduling Page UI', () => {
       fetchMock.mockResponseOnce(JSON.stringify({}));
       // sessions/get_saved_availabilities
       fetchMock.mockResponseOnce(JSON.stringify([]));
+      // sessions/get_saved_schedules
+      fetchMock.mockResponseOnce(JSON.stringify([]));
 
       render(
         <Provider store={store}>

--- a/autoscheduler/frontend/src/tests/ui/SchedulingPage.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SchedulingPage.test.tsx
@@ -90,7 +90,7 @@ describe('Scheduling Page UI', () => {
       // act
       const { findByText } = render(
         <Provider store={store}>
-          <SchedulingPage />
+          <SchedulingPage hideSchedulesLoadingIndicator />
         </Provider>,
       );
 
@@ -108,7 +108,7 @@ describe('Scheduling Page UI', () => {
 
       const { getByText, queryByText } = render(
         <Provider store={store}>
-          <SchedulingPage />
+          <SchedulingPage hideSchedulesLoadingIndicator />
         </Provider>,
       );
 
@@ -137,7 +137,7 @@ describe('Scheduling Page UI', () => {
         getByLabelText, getByRole, findAllByLabelText, findAllByText,
       } = render(
         <Provider store={store}>
-          <SchedulingPage />
+          <SchedulingPage hideSchedulesLoadingIndicator />
         </Provider>,
       );
 

--- a/autoscheduler/frontend/src/types/APIRequests.ts
+++ b/autoscheduler/frontend/src/types/APIRequests.ts
@@ -1,0 +1,12 @@
+// Module containing type definitions for API Reuqests
+
+export interface SaveSchedulesRequest {
+    term: string;
+    schedules: SerializedSchedule[];
+}
+
+/** The serialiazed schedule that is sent when we save schedules with session/save_schedules */
+export interface SerializedSchedule {
+    name: string;
+    sections: number[];
+}

--- a/autoscheduler/frontend/src/types/APIRequests.ts
+++ b/autoscheduler/frontend/src/types/APIRequests.ts
@@ -1,4 +1,4 @@
-// Module containing type definitions for API Reuqests
+// Module containing type definitions for API Requests
 
 export interface SaveSchedulesRequest {
     term: string;

--- a/autoscheduler/scraper/serializers.py
+++ b/autoscheduler/scraper/serializers.py
@@ -45,6 +45,10 @@ class SectionSerializer(serializers.ModelSerializer):
 
     def get_grades(self, section): # pylint: disable=no-self-use
         """ Gets the past grade distributions for this prof + course """
+        skip_grades = self.context.get('skip_grades')
+        if skip_grades:
+            return None
+
         grades = Grades.objects.instructor_performance(
             section.subject,
             section.course_num,

--- a/autoscheduler/user_sessions/tests/schedules_api_tests.py
+++ b/autoscheduler/user_sessions/tests/schedules_api_tests.py
@@ -46,7 +46,8 @@ class SchedulesAPITests(APITestCase):
         ins.save()
         sec = Section(id=1, subject='CSCE', course_num='121', section_num='500',
                       term_code=term, crn=0, min_credits=0, max_credits=0,
-                      max_enrollment=0, current_enrollment=0, instructor=ins)
+                      max_enrollment=0, current_enrollment=0, instructor=ins,
+                      asynchronous=False)
         sec.save()
         meeting = Meeting(id=11, section=sec, start_time=time(11, 0),
                           end_time=time(12, 0), meeting_days=[True] * 7,
@@ -75,6 +76,7 @@ class SchedulesAPITests(APITestCase):
                 'honors': None,
                 'web': None,
                 'grades': None,
+                'asynchronous': False,
                 'meetings': [{
                     'id': '11',
                     'start_time': '11:00',

--- a/autoscheduler/user_sessions/tests/schedules_api_tests.py
+++ b/autoscheduler/user_sessions/tests/schedules_api_tests.py
@@ -1,0 +1,94 @@
+from datetime import time
+from rest_framework.test import APITestCase
+from django.contrib.sessions.models import Session
+from scraper.models import Section, Meeting, Instructor
+
+class SchedulesAPITests(APITestCase):
+    """ Test functionality of the saved_schedules sessions api """
+    def setUp(self):
+        """ Delete sessions table and log in before each test to create a new session """
+        Session.objects.all().delete()
+        self.client.login()
+
+    def test_get_saved_schedules_gives_error_with_no_term(self):
+        """ Tests that /sessions/get_saved_schedules doesn't allow requests without a term
+        """
+        # Act
+        response = self.client.get(f'/sessions/get_saved_courses')
+
+        # Assert
+        self.assertEqual(response.status_code, 400)
+
+    def test_get_saved_schedules_defaults_with_no_schedules_for_term(self):
+        """ Tests that /sessions/get_saved_schedules gives an empty array when provided
+            with a term that has no data
+        """
+        # Arrange
+        term = '202031'
+        expected = []
+
+        # Act
+        response = self.client.get(f'/sessions/get_saved_schedules?term={term}')
+
+        # Assert
+        self.assertEqual(response.json(), expected)
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_saved_schedules_gets_schedules_for_term(self):
+        """ Tests that /sessions/get_saved_schedules correctly fetches the sections
+            and meetings for a given schedule
+        """
+        # Arrange
+        term = '202031'
+
+        # Create the models
+        ins = Instructor(id='fake name', email_address='a@b.c')
+        ins.save()
+        sec = Section(id=1, subject='CSCE', course_num='121', section_num='500',
+                      term_code=term, crn=0, min_credits=0, max_credits=0,
+                      max_enrollment=0, current_enrollment=0, instructor=ins)
+        sec.save()
+        meeting = Meeting(id=11, section=sec, start_time=time(11, 0),
+                          end_time=time(12, 0), meeting_days=[True] * 7,
+                          meeting_type='LEC', building='ONLINE')
+        meeting.save()
+
+        # Add the schedule to the session
+        session = self.client.session
+        session_input = [{'name': 'Schedule 1', 'sections': [1]}]
+        session[term] = {'schedules': session_input}
+        session.save()
+
+        expected = [{
+            'name': 'Schedule 1',
+            'sections': [{
+                'id': 1,
+                'subject': 'CSCE',
+                'course_num': '121',
+                'section_num': '500',
+                'crn': 0,
+                'min_credits': 0,
+                'max_credits': 0,
+                'max_enrollment': 0,
+                'current_enrollment': 0,
+                'instructor_name': 'fake name',
+                'honors': None,
+                'web': None,
+                'grades': None,
+                'meetings': [{
+                    'id': '11',
+                    'start_time': '11:00',
+                    'end_time': '12:00',
+                    'days': [True] * 7,
+                    'type': 'LEC',
+                    'building': 'ONLINE',
+                }]
+            }]
+        }]
+
+        # Act
+        response = self.client.get(f'/sessions/get_saved_schedules?term={term}')
+
+        # Assert
+        self.assertEqual(response.json(), expected)
+        self.assertEqual(response.status_code, 200)

--- a/autoscheduler/user_sessions/urls.py
+++ b/autoscheduler/user_sessions/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
 from user_sessions.views import(
     get_last_term, set_last_term, save_courses, get_saved_courses, get_full_name,
-    get_saved_availabilities, save_availabilities, logout
+    get_saved_availabilities, save_availabilities, get_saved_schedules, save_schedules,
+    logout, 
 )
 
 urlpatterns = [
@@ -13,5 +14,7 @@ urlpatterns = [
     path('get_full_name', get_full_name),
     path('get_saved_availabilities', get_saved_availabilities),
     path('save_availabilities', save_availabilities),
+    path('get_saved_schedules', get_saved_schedules),
+    path('save_schedules', save_schedules),
     path('logout', logout),
 ]

--- a/autoscheduler/user_sessions/urls.py
+++ b/autoscheduler/user_sessions/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 from user_sessions.views import(
     get_last_term, set_last_term, save_courses, get_saved_courses, get_full_name,
     get_saved_availabilities, save_availabilities, get_saved_schedules, save_schedules,
-    logout, 
+    logout,
 )
 
 urlpatterns = [

--- a/autoscheduler/user_sessions/views.py
+++ b/autoscheduler/user_sessions/views.py
@@ -96,7 +96,7 @@ def get_full_name(request):
 @api_view(['GET'])
 def get_saved_availabilities(request):
     """ Returns the saved availabities from the session for the requested term"""
-    availabilities = _get_state_from_session(request, 'courses')
+    availabilities = _get_state_from_session(request, 'availabilities')
 
     if availabilities is None:
         return Response(status=400)


### PR DESCRIPTION
## Description

Adds saving schedules to the session. Note that this is based off of #410 due to its addition of the abstract get/set state route functionality.

## Rationale

I set the throttle time 5 seconds since I don't expect schedules to be modified much, but we can increase it if we really want to.

## How to test

Generate schedules then save (and rename) them, refresh the page, and ensure the schedules were saved.

## Screenshots

![save-schedules-demo](https://user-images.githubusercontent.com/7295783/96643735-a0d82100-12ed-11eb-8274-165061ee3b1e.gif)

## Related tasks

Closes #267
