### PR TITLE
Section select overrides include full sections

### DIFF
--- a/autoscheduler/scheduler/create_schedules.py
+++ b/autoscheduler/scheduler/create_schedules.py
@@ -36,7 +36,7 @@ def _get_meetings(course: CourseFilter, term: str, include_full: bool,
     # Get id for each valid section to filter and order meeting data
     # Also removes full sections if include_full is False
     sections = sections.values('id', 'current_enrollment', 'max_enrollment')
-    #if manually selected don't check if section is full before adding
+    # if manually selected don't check if section is full before adding
     if course.section_nums or include_full:
         section_ids = set(section['id'] for section in sections)
     else:

--- a/autoscheduler/scheduler/create_schedules.py
+++ b/autoscheduler/scheduler/create_schedules.py
@@ -36,9 +36,13 @@ def _get_meetings(course: CourseFilter, term: str, include_full: bool,
     # Get id for each valid section to filter and order meeting data
     # Also removes full sections if include_full is False
     sections = sections.values('id', 'current_enrollment', 'max_enrollment')
-    section_ids = set(section['id'] for section in sections
-                      if include_full or
-                      section['current_enrollment'] < section['max_enrollment'])
+    #if manually selected don't check if section is full before adding
+    if course.section_nums:
+        section_ids = set(section['id'] for section in sections)
+    else:
+        section_ids = set(section['id'] for section in sections
+                          if include_full or
+                          section['current_enrollment'] < section['max_enrollment'])
     # Get meetings based on sections of the course and order them by end time
     meetings = (Meeting.objects.filter(section_id__in=section_ids)
                 # Must be ordered by section id or groupby() doesn't work

--- a/autoscheduler/scheduler/create_schedules.py
+++ b/autoscheduler/scheduler/create_schedules.py
@@ -37,12 +37,11 @@ def _get_meetings(course: CourseFilter, term: str, include_full: bool,
     # Also removes full sections if include_full is False
     sections = sections.values('id', 'current_enrollment', 'max_enrollment')
     #if manually selected don't check if section is full before adding
-    if course.section_nums:
+    if course.section_nums or include_full:
         section_ids = set(section['id'] for section in sections)
     else:
         section_ids = set(section['id'] for section in sections
-                          if include_full or
-                          section['current_enrollment'] < section['max_enrollment'])
+                          if section['current_enrollment'] < section['max_enrollment'])
     # Get meetings based on sections of the course and order them by end time
     meetings = (Meeting.objects.filter(section_id__in=section_ids)
                 # Must be ordered by section id or groupby() doesn't work

--- a/autoscheduler/scheduler/tests/scheduling_tests.py
+++ b/autoscheduler/scheduler/tests/scheduling_tests.py
@@ -508,3 +508,32 @@ class SchedulingTests(django.test.TestCase):
         print(schedules)
         print(expected_schedules)
         self.assertEqual(schedules, expected_schedules)
+
+    def test__get_meetings_manually_selected_sections_override_include_full(self):
+        """ Tests that _get_meetings does not filter full sections selected in section
+            select when include_full is false
+        """
+        # Arrange
+        # section chosen because it is full
+        section_nums = ["502"]
+        course = CourseFilter("CSCE", "121", section_nums=section_nums)
+        term = "201931"
+        include_full = False
+        unavailable_times = []
+        meetings = [
+            # Meetings for CSCE 121-502
+            Meeting(id=1, meeting_days=[True] * 7, start_time=time(12, 30),
+                    end_time=time(1, 20), meeting_type='LEC', section=self.sections[4]),
+            Meeting(id=51, meeting_days=[True] * 7, start_time=time(10),
+                    end_time=time(10, 50), meeting_type='LAB', section=self.sections[4]),
+        ]
+        Meeting.objects.bulk_create(meetings)
+        valid_sections = set((5,))
+        meetings_for_sections = {5: meetings[0:]}
+
+        # Act
+        meetings = _get_meetings(course, term, include_full, unavailable_times)
+
+        # Assert
+        self.assert_meetings_match_expected(meetings, valid_sections,
+                                            meetings_for_sections)


### PR DESCRIPTION
## Description

Previously, when selecting a full section in section select and generating a schedule when "include full sections" was not selected, the section manually selected in section select would not be included. This PR makes it so that all sections manually selected in section select can be included in schedules regardless of whether include full sections is selected or not

## How to test

Select some courses and go to section select. Select full sections for that course. After you have selected the sections and courses, make sure "include full sections" is not selected on the configure card. Generate schedules. If the schedule generated includes the full sections you manually selected, it should be working. I also added one backend test.

## Related tasks

Doesn't close anything but a temp quality of life improvement meanwhile the "include full sections" checkbox is moved into the basic select of course cards and the configure card is removed.
