### PR TITLE
Cleaned up code to change expanded row CSS

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.css
@@ -41,6 +41,10 @@
     min-height: 500px;
 }
 
+.expanded-row-overflow {
+    overflow-y: visible;
+}
+
 #add-course-button {
     width: 100%;
 }

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.css.d.ts
@@ -10,7 +10,9 @@ declare namespace CourseSelectColumnCssNamespace {
     "course-select-column": string;
     courseSelectColumn: string;
     "expanded-row": string;
+    "expanded-row-overflow": string;
     expandedRow: string;
+    expandedRowOverflow: string;
     row: string;
   }
 }

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-labels */
 import * as React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import * as Cookies from 'js-cookie';
@@ -24,47 +23,14 @@ const CourseSelectColumn: React.FC = () => {
   const term = useSelector<RootState, string>((state) => state.term);
   const dispatch = useDispatch();
 
-  const [styleSheetNum, setStyleSheetNum] = React.useState<number>(null);
-  const [ruleNum, setRuleNum] = React.useState<number>(null);
-  React.useLayoutEffect(() => {
-    if (styleSheetNum === null) {
-      for (let i = 0; i < document.styleSheets.length; i++) {
-        try {
-          const styleSheet = document.styleSheets[i] as CSSStyleSheet;
-          for (let j = 0; j < styleSheet.cssRules.length; j++) {
-            if (styleSheet.cssRules[j].cssText.startsWith('.expanded-row')) {
-              setStyleSheetNum(i);
-              setRuleNum(j);
-            }
-          }
-        // eslint-disable-next-line no-empty
-        } catch (e) {}
-      }
-    }
-  }, [styleSheetNum]);
-
   const expandedRowRef = React.useRef<HTMLDivElement>(null);
   React.useLayoutEffect(() => {
-    if (expandedRowRef.current?.children[0].clientHeight < 500 - 8) {
-      const styleSheet = document.styleSheets[styleSheetNum] as CSSStyleSheet;
-      if (styleSheet) {
-        styleSheet.deleteRule(ruleNum);
-        styleSheet.insertRule(
-          `.${styles.expandedRow} {
-            overflow-y: visible;
-          }`, ruleNum,
-        );
-      } else throw Error('styleSheet is undefined');
-    } else {
-      const styleSheet = document.styleSheets[styleSheetNum] as CSSStyleSheet;
-      if (styleSheet) {
-        styleSheet.deleteRule(ruleNum);
-        styleSheet.insertRule(
-          `.${styles.expandedRow} {
-            overflow-y: hidden;
-            min-height: 500px;
-          }`, ruleNum,
-        );
+    if (expandedRowRef.current) {
+      const expandedRowHeight = expandedRowRef.current.children[0].clientHeight;
+      if (expandedRowHeight < 500 - 8) {
+        expandedRowRef.current.className = `${styles.row} ${styles.expandedRowOverflow}`;
+      } else {
+        expandedRowRef.current.className = `${styles.row} ${styles.expandedRow}`;
       }
     }
   });


### PR DESCRIPTION
## Description

Uses `className` instead of CSS rules to dynamically change CSS

## Rationale

I noticed that using `className` instead of modifying CSS rules directly achieves the same thing and is a lot cleaner, so I changed it to do that instead

## How to test

Basically just check the behavior in the different cases for card sizes/remaining space, this seems to have the same effect
