### PR TITLE
Removed asyncio from requirements

### DIFF
--- a/autoscheduler/requirements.txt
+++ b/autoscheduler/requirements.txt
@@ -1,5 +1,4 @@
 aiohttp==3.6.2
-asyncio==3.4.3
 beautifulsoup4==4.8.2
 Django~=2.2.6
 djangorestframework~=3.9.2


### PR DESCRIPTION
## Description

For some reason, GCP keeps failing b/c asyncio is listed as a requirement, but it's built into Python since 3.4 (I think) so there's no need for it to be a requirement.
