### PR TITLE
Made GCP only deploy on pushes to production

### DIFF
--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -2,7 +2,7 @@ name: GCP Deploy
 on:
   push:
     branches:
-      - master
+      - production
 
 jobs:
   deploy-app-engine:


### PR DESCRIPTION
## Description

Now that we're close to launch, we don't want GCP to deploy immediately on pushes to `master`. This makes it so that GCP only deploys on pushes to the branch `production`, which I also made a protected branch (like `master` was already). This way we have to make a PR to actually deploy to GCP.