### PR TITLE
Frontend/am pm

### DIFF
--- a/autoscheduler/frontend/src/utils/timeUtil.ts
+++ b/autoscheduler/frontend/src/utils/timeUtil.ts
@@ -11,10 +11,7 @@ export const LAST_HOUR = 22;
 export function formatTime(h: number, m: number, use24Hour = false, padZeroes = false): string {
   let amOrpm = '';
   if (!use24Hour) {
-    amOrpm = 'AM';
-    if (h >= 12) {
-      amOrpm = 'PM';
-    }
+    amOrpm = h < 12 ? 'AM' : 'PM';
   }
 
   const formattedHours = use24Hour ? h : (h - 1) % 12 + 1;

--- a/autoscheduler/frontend/src/utils/timeUtil.ts
+++ b/autoscheduler/frontend/src/utils/timeUtil.ts
@@ -9,9 +9,17 @@ export const LAST_HOUR = 22;
  * @param use24Hour if true, applies 24-hour format instead of the default 12-hour format
  */
 export function formatTime(h: number, m: number, use24Hour = false, padZeroes = false): string {
+  let amOrpm = '';
+  if (!use24Hour) {
+    amOrpm = 'AM';
+    if (h >= 12) {
+      amOrpm = 'PM';
+    }
+  }
+
   const formattedHours = use24Hour ? h : (h - 1) % 12 + 1;
   const padZero = new Intl.NumberFormat('en-US', { minimumIntegerDigits: 2 });
-  return `${padZeroes ? padZero.format(formattedHours) : formattedHours}:${padZero.format(m)}`;
+  return `${padZeroes ? padZero.format(formattedHours) : formattedHours}:${padZero.format(m)}${amOrpm}`;
 }
 
 /**


### PR DESCRIPTION
## Description

This shows the AM - PM within the meetings.

## Rationale

This is necessary because people may get confused if the class is in the morning or in the evening. 

## How to test

The best way to test this is to see the AM and PM that was added when adding the classes that are being displayed. 

## Screenshots

Before
![image](https://user-images.githubusercontent.com/60300948/97385497-c0e48300-189f-11eb-8984-ff7d9a732867.png)

After
![image](https://user-images.githubusercontent.com/60300948/97385313-76fb9d00-189f-11eb-93a2-780e2ece8525.png)

## Related tasks

Closes #371 
