### PR TITLE
Hides time cursor when hovering over availability

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/AvailabilityCard/AvailabilityCard.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/AvailabilityCard/AvailabilityCard.css
@@ -1,5 +1,9 @@
 .container {
     display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    height: 100%;
 }
 
 .icon {

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/AvailabilityCard/AvailabilityCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/AvailabilityCard/AvailabilityCard.tsx
@@ -12,6 +12,7 @@ interface AvailabilityCardProps {
     availability: Availability;
     firstHour: number;
     lastHour: number;
+    setShowTimeDisplay: (val: boolean) => void;
 }
 
 /**
@@ -36,7 +37,9 @@ function eventToTime(evt: React.MouseEvent<HTMLDivElement, MouseEvent>): number 
  * @param props include availability, firstHour, lastHour
  */
 const AvailabilityCard: React.FC<AvailabilityCardProps> = (
-  { availability, firstHour, lastHour },
+  {
+    availability, firstHour, lastHour, setShowTimeDisplay,
+  },
 ) => {
   const dispatch = useDispatch();
   const {
@@ -62,6 +65,9 @@ const AvailabilityCard: React.FC<AvailabilityCardProps> = (
     ],
   );
 
+  const handleMouseEnter = (): void => setShowTimeDisplay(false);
+  const handleMouseLeave = (): void => setShowTimeDisplay(true);
+
   return (
     <ScheduleCard
       startTimeHours={startTimeHours}
@@ -74,7 +80,11 @@ const AvailabilityCard: React.FC<AvailabilityCardProps> = (
       backgroundColor="#f4433680"
       onDragHandleDown={onDragHandleDown}
     >
-      <div className={styles.container}>
+      <div
+        className={styles.container}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
         <span style={{ color: 'black' }}>{AvailabilityType[available]}</span>
         <DeleteIcon
           htmlColor="rgba(0, 0, 0, 0.7)"

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/Schedule.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/Schedule.tsx
@@ -364,6 +364,7 @@ const Schedule: React.FC = () => {
           availability={availability}
           firstHour={FIRST_HOUR}
           lastHour={LAST_HOUR}
+          setShowTimeDisplay={setShowTimeDisplay}
           key={`${formatTime(availability.startTimeHours, availability.startTimeMinutes, true)}
           - ${formatTime(availability.endTimeHours, availability.endTimeMinutes, true)}`}
         />

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/ScheduleCard/ScheduleCard.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/ScheduleCard/ScheduleCard.css
@@ -53,3 +53,7 @@
 .drag-handle-bot {
     bottom: -5px;
 }
+
+.invisible-div {
+    display: contents;
+}

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/ScheduleCard/ScheduleCard.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/ScheduleCard/ScheduleCard.css.d.ts
@@ -8,6 +8,8 @@ declare namespace ScheduleCardCssNamespace {
     dragHandleTop: string;
     "end-time": string;
     endTime: string;
+    "invisible-div": string;
+    invisibleDiv: string;
     "schedule-card": string;
     scheduleCard: string;
     "start-time": string;

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/ScheduleCard/ScheduleCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/ScheduleCard/ScheduleCard.tsx
@@ -107,7 +107,7 @@ const ScheduleCard: React.FC<ScheduleCardProps> = ({
           />
         )
         : null}
-      <div ref={cardContent}>
+      <div ref={cardContent} className={styles.invisibleDiv}>
         {children}
       </div>
       {onDragHandleDown


### PR DESCRIPTION
## Description

Hides time cursor when hovering over availability. Primarily important because it makes the trash icon visible so you can properly delete availabilities. May also consider turning the whole availability into a delete button, but I feel that is a little unexpected.

## Rationale

No tests because a) it's crunch time, and b) I'ma keep it real with you, this is 100% testable but I hate tests

## How to test

Create an availability. Move your cursor over it. Note that it doesn't hide them when you're dragging a different availability.

## Screenshots

![hide_time_cursor](https://user-images.githubusercontent.com/10082177/97387808-b4165e00-18a4-11eb-814f-17a032db8794.gif)

## Related tasks

No issue made for this one
