### PR TITLE
Backend/400error

### DIFF
--- a/autoscheduler/user_sessions/tests/name_api_tests.py
+++ b/autoscheduler/user_sessions/tests/name_api_tests.py
@@ -50,7 +50,7 @@ class UsersFullNameAPITests(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), expected)
 
-    def test_get_full_name_returns_400_if_not_logged_in(self):
+    def test_get_full_name_returns_200_if_not_logged_in(self):
         """ Tests that /sessions/get_last_term response returns error code 400
             when user is not logged in
         """
@@ -61,4 +61,4 @@ class UsersFullNameAPITests(APITestCase):
         response = self.client.get('/sessions/get_full_name')
 
         # Assert
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 200)

--- a/autoscheduler/user_sessions/views.py
+++ b/autoscheduler/user_sessions/views.py
@@ -88,7 +88,7 @@ def get_full_name(request):
     """
     user_id = request.session.get('_auth_user_id')
     if user_id is None:
-        return Response(status=400)
+        return Response(status=200)
     user = User.objects.get(pk=user_id)
     response = {'fullName': user.get_full_name()}
     return Response(response)


### PR DESCRIPTION
## Description

Changes the 400 to a 200 

## Rationale

This makes it since the default is not logged in it returns a 200 

## How to test

Check the console when the website is rendered and see there is no 400 error 

## Screenshots

Before 
![image](https://user-images.githubusercontent.com/60300948/97390018-d65eaa80-18a9-11eb-9dce-2aedfd9f40f9.png)

After
![image](https://user-images.githubusercontent.com/60300948/97389997-cba41580-18a9-11eb-8940-35f9b9191f0e.png)


## Related tasks

Closes #358 
