### PR TITLE
CTA Buttons are now gold

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/ConfigureCard/ConfigureCard.tsx
@@ -136,7 +136,7 @@ const ConfigureCard: React.FC = () => {
         </ListItem>
         <Button
           variant="contained"
-          color="primary"
+          color="secondary"
           onClick={fetchSchedules}
           disabled={loading}
         >

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
@@ -107,7 +107,7 @@ const CourseSelectColumn: React.FC = () => {
           {rows}
           <div id={styles.buttonContainer}>
             <Button
-              color="primary"
+              color="secondary"
               size="medium"
               variant="contained"
               id={styles.addCourseButton}

--- a/autoscheduler/frontend/src/theme.ts
+++ b/autoscheduler/frontend/src/theme.ts
@@ -5,7 +5,7 @@ import grey from '@material-ui/core/colors/grey';
 
 const palette = {
   primary: { main: '#500000', contrastText: '#ffffff' },
-  secondary: { main: '#ffffff', contrastText: '#000000' },
+  secondary: { main: '#edc840', contrastText: '#000000' },
   text: { secondary: grey[700] },
 };
 


### PR DESCRIPTION
## Description

In order to draw attention to the Add Course and Generate Schedules buttons, I have made them golden.

## Rationale

Based on user study that said our website had too much maroon

## How to test

Open both the landing page and the schedule page. This change also affects the Select Term button.

## Screenshots

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/10082177/97502174-9eef0d00-1940-11eb-8009-e11933078eac.png)|![image](https://user-images.githubusercontent.com/10082177/97502021-4d468280-1940-11eb-8a4e-0dc8f5ff4581.png)|

## Related tasks

Closes #403 
