### PR TITLE
Made text when no schedules have been created more helpful

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
@@ -7,7 +7,7 @@ import * as styles from './SchedulePreview.css';
 import ScheduleListItem from './ScheduleListItem/ScheduleListItem';
 import Schedule from '../../../types/Schedule';
 
-export const noSchedulesText = "Click Generate Schedules to find schedules with the classes you've added.";
+export const noSchedulesText = "Click Generate Schedules to find schedules with the courses you've added.";
 
 const SchedulePreview: React.FC = () => {
   const schedules = useSelector<RootState, Schedule[]>((state) => state.schedules);

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
@@ -7,11 +7,13 @@ import * as styles from './SchedulePreview.css';
 import ScheduleListItem from './ScheduleListItem/ScheduleListItem';
 import Schedule from '../../../types/Schedule';
 
+export const noSchedulesText = "Click Generate Schedules to find schedules with the classes you've added.";
+
 const SchedulePreview: React.FC = () => {
   const schedules = useSelector<RootState, Schedule[]>((state) => state.schedules);
 
   const scheduleListItems = schedules.length === 0
-    ? <p className={styles.noSchedules}>No schedules available.</p>
+    ? <p className={styles.noSchedules}>{noSchedulesText}</p>
     : schedules.map((schedule, idx) => <ScheduleListItem index={idx} key={schedule.name} />);
 
   return (

--- a/autoscheduler/frontend/src/tests/ui/SchedulingPage.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SchedulingPage.test.tsx
@@ -14,6 +14,7 @@ import * as router from '@reach/router';
 import autoSchedulerReducer from '../../redux/reducer';
 import SchedulingPage from '../../components/SchedulingPage/SchedulingPage';
 import { mockFetchSchedulerGenerate } from '../testData';
+import { noSchedulesText } from '../../components/SchedulingPage/SchedulePreview/SchedulePreview';
 
 describe('Scheduling Page UI', () => {
   // setup and teardown spy function on navigate
@@ -88,7 +89,7 @@ describe('Scheduling Page UI', () => {
       );
 
       // assert
-      expect(await findByText('No schedules available.')).toBeTruthy();
+      expect(await findByText(noSchedulesText)).toBeTruthy();
     });
   });
   describe('adds schedules to the Schedule Preview', () => {
@@ -113,7 +114,7 @@ describe('Scheduling Page UI', () => {
       await new Promise(setImmediate);
 
       // assert
-      expect(queryByText('No schedules available')).toBeFalsy();
+      expect(queryByText(noSchedulesText)).toBeFalsy();
       expect(queryByText('Schedule 1')).toBeTruthy();
     });
   });


### PR DESCRIPTION
## Description

Makes the no schedules text seem less like an error and instead direct users to generate schedules.

## Rationale

I thought this wording was good because it directs users to the button and tells them that schedules will be generated using their course cards. Could change classes to course though, idk

## How to test

use ur eyes and look at the screen

## Screenshots

If it's a frontend change, provide screenshots of it. If possible, show the change on different
resolutions/sizes.

If you're changing a existing frontend look, provide a before and after screenshot in the table below.

|Before|After|
|--|--|
| ![image](https://user-images.githubusercontent.com/28655462/97505268-9a2d5780-1946-11eb-8772-0822c1d71dec.png) | ![image](https://user-images.githubusercontent.com/28655462/97505254-939ee000-1946-11eb-8850-6e5dc0e85cf4.png) |


## Related tasks
Nothing, I thought this would be helpful
