### PR TITLE
Added border to mini-schedule

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/MiniSchedule/MiniSchedule.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/MiniSchedule/MiniSchedule.css
@@ -1,3 +1,14 @@
+/* For mini-schedule border */
+:import("../../../Schedule/Schedule.css") {
+    calendar-row: calendar-row;
+}
+
+/* For mini-schedule border */
+.mini-schedule-container .calendar-row:nth-last-child(2) {
+    height: unset;
+    flex-grow: 1;
+}
+
 .hour-marker {
     flex-grow: 1;
     border-bottom: 1px solid darkgray;
@@ -13,6 +24,9 @@
     flex-direction: column;
     background-color: white;
     height: calc(100% - 16px);
+    /* Apply border to mini-schedule  */
+    border: 1px solid darkgray;
+    border-top: initial; /* Only want border on left/right/bottom */
 }
 
 .meetings-container {


### PR DESCRIPTION
## Description

Adds a border to the mini-schedule. Shoutout to @firejake308 for helping me undo the last-row weirdness of the schedule. Note that you'll have to change line 25 in `autoscheduler/scheduler/views.py` to `asynchronous = BasicFilter(course.get("asynchronous", BasicFilter.NO_PREFERENCE))` to make `/scheduler/generate` work.

## Rationale

It looks way better

## How to test

Generate a schedule and look at the border

## Screenshots

|Before|After|
|--|--|
|![chrome_mUuZYJ6jcE](https://user-images.githubusercontent.com/7295783/97621866-7a9f3900-19f1-11eb-86a5-f4f4e308fc4e.png)|![chrome_UrU5LGST0g](https://user-images.githubusercontent.com/7295783/97621871-7e32c000-19f1-11eb-89f3-304fa647c4ed.png)|

## Related tasks

Closing tag. Don't forget to link the issue w/ the PR in ZenHub at the bottom.

Closes #416 
