### PR TITLE
Keep route on login

### DIFF
--- a/autoscheduler/frontend/src/components/NavBar/LoginButton.tsx
+++ b/autoscheduler/frontend/src/components/NavBar/LoginButton.tsx
@@ -80,7 +80,7 @@ const LoginButton: React.FC = () => {
       <Button
         color="inherit"
         onClick={(): void => {
-          window.open('/login/google-oauth2/', '_self');
+          window.open(`/login/google-oauth2/?next=${window.location.href}`, '_self');
         }}
       >
         Login With Google

--- a/autoscheduler/frontend/src/tests/ui/NavBar.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/NavBar.test.tsx
@@ -91,7 +91,8 @@ describe('login button', () => {
     act(() => { fireEvent.click(loginButton); });
 
     // assert
-    expect(window.open).toHaveBeenCalledWith('/login/google-oauth2/', '_self');
+    const loginURL = expect.stringMatching(/\/login\/google-oauth2\/.*/);
+    expect(window.open).toHaveBeenCalledWith(loginURL, '_self');
   });
 });
 


### PR DESCRIPTION
## Description

Redirects you back to your current page when logging in

## Rationale

We had said we wanted this functionality but didn't know how to do it, so I decided to implement it after seeing the solution looking up an unrelated problem

## How to test

Try logging in from the homepage, scheduling page, some 404 page, etc.

## Screenshots
![owen wilson](https://user-images.githubusercontent.com/28655462/97753566-ff5a8780-1ac3-11eb-9e83-9ac828ae4dbb.gif)

## Related tasks
n/a
