### PR TITLE
Fixed mini schedule sizing problems

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/MiniSchedule/MiniSchedule.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/MiniSchedule/MiniSchedule.css
@@ -11,7 +11,7 @@
 
 .hour-marker {
     flex-grow: 1;
-    border-bottom: 1px solid darkgray;
+    border-top: 1px solid darkgray;
     height: 0;
     align-self: stretch;
     position: relative;
@@ -45,7 +45,7 @@
     border-top-left-radius: 4px;
     border-top-right-radius: 4px;
     height: 10px;
-    background: linear-gradient(#500000 0px, #500000 9px, #ffffff 9px, #ffffff 10px);
+    background: #500000;
 }
 
 .mini-schedule-container {

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/MiniSchedule/MiniSchedule.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/MiniSchedule/MiniSchedule.tsx
@@ -17,7 +17,7 @@ const DAYS_OF_WEEK = [DayOfWeek.MON, DayOfWeek.TUE, DayOfWeek.WED, DayOfWeek.THU
 
 // build rows from first and last hour
 const HOURS_OF_DAY = [];
-for (let h = FIRST_HOUR; h <= LAST_HOUR; h++) { HOURS_OF_DAY.push(h); }
+for (let h = FIRST_HOUR; h < LAST_HOUR; h++) { HOURS_OF_DAY.push(h); }
 const hourBars = HOURS_OF_DAY.map((hour) => (
   <div className={parentStyles.calendarRow} key={hour}>
     <div className={styles.hourMarker} style={{ top: 0 }} />


### PR DESCRIPTION
## Description

There was a weird 1-px margin at the top of the mini schedules, and when I went to fix that, I realized that the times didn't quite match up for classes later in the day. Consequently, I also included the fix to that bug as well.

## Rationale

Removing the random 1px margin should help make the border look better. Also, tbh, I no longer remember what its original purpose was. And fixing the bug is good because it makes the mini schedules more accurate, although tbf, users probably wouldn't look hard enough to notice.

## How to test

Generate a schedule. Zoom in on the mini schedule. Look if there is any space between the maroon headera and the 8:00 bar. Then, count out the hours to a class in the middle of the day. Make sure it matches what you see in the big schedule.

## Screenshots

The dark green class is KINE 199-242, which should go from 4:15 to 5:05. On the old mini schedule, it looks like it starts at 5.

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/10082177/97917139-a4ba6900-1d19-11eb-8fe8-1db2216b3d41.png)|![image](https://user-images.githubusercontent.com/10082177/97917313-eba85e80-1d19-11eb-9f25-2f653af5db60.png)|
