### PR TITLE
Made height apply correctly on macOS Safari

### DIFF
--- a/autoscheduler/frontend/src/components/App/App.css
+++ b/autoscheduler/frontend/src/components/App/App.css
@@ -8,3 +8,9 @@
 .app-container > div:nth-child(2) {
     flex-grow: 1;
 }
+
+.router {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}

--- a/autoscheduler/frontend/src/components/App/App.css.d.ts
+++ b/autoscheduler/frontend/src/components/App/App.css.d.ts
@@ -2,6 +2,7 @@ declare namespace AppCssNamespace {
   export interface IAppCss {
     "app-container": string;
     appContainer: string;
+    router: string;
   }
 }
 

--- a/autoscheduler/frontend/src/components/App/App.tsx
+++ b/autoscheduler/frontend/src/components/App/App.tsx
@@ -14,7 +14,7 @@ const App: React.SFC = function App() {
     <div className={styles.appContainer}>
       <ThemeProvider theme={theme}>
         <NavBar />
-        <Router>
+        <Router className={styles.router}>
           {/* One component for each page/route goes in here */}
           <LandingPage path="/" />
           <SchedulingPage path="/schedule" />


### PR DESCRIPTION
## Description

Makes the full height of the page apply correctly on macOS Safari. Tbh only like 6% of our users use macOS Safari (36.51% use Safari, but only 15% of those are macOS) but still it's unusable without this.

## How to test

Just build it and make sure it doesn't regress anything on y'all's end

## Screenshots

Landing page
|Before|After|
|--|--|
|<img width="1680" alt="Screen Shot 2020-11-10 at 8 34 53 PM" src="https://user-images.githubusercontent.com/7295783/98759328-7b8f7d80-2396-11eb-937f-5748139beaaf.png">|<img width="1680" alt="Screen Shot 2020-11-10 at 8 35 00 PM" src="https://user-images.githubusercontent.com/7295783/98759358-8cd88a00-2396-11eb-9114-6fa14cb3b784.png">|

Schedule page
|Before|After|
|--|--|
|<img width="1680" alt="Screen Shot 2020-11-10 at 8 35 17 PM" src="https://user-images.githubusercontent.com/7295783/98759383-982bb580-2396-11eb-8f45-c99a600888e2.png">|<img width="1680" alt="Screen Shot 2020-11-10 at 8 35 09 PM" src="https://user-images.githubusercontent.com/7295783/98759391-9c57d300-2396-11eb-8795-ece78b77f091.png">|

## Related tasks

Closes #459
