### PR TITLE
Meeting type is once again hidden if card is small

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/MeetingCard/MeetingCard.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/MeetingCard/MeetingCard.css
@@ -44,5 +44,5 @@
     overflow: hidden;
     text-overflow: ellipsis;
     width: 100%;
-    height: 100%;
+    flex-shrink: 0;
 }

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/MeetingCard/MeetingCard.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/MeetingCard/MeetingCard.css
@@ -38,3 +38,11 @@
 .meeting-card:hover .start-time, .meeting-card:hover .end-time {
     display: block;
 }
+
+.meeting-card-text {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: 100%;
+    height: 100%;
+}

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/MeetingCard/MeetingCard.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/MeetingCard/MeetingCard.css.d.ts
@@ -1,17 +1,19 @@
-declare namespace MeetingCardCssModule {
+declare namespace MeetingCardCssNamespace {
   export interface IMeetingCardCss {
     "end-time": string;
     endTime: string;
     "meeting-card": string;
+    "meeting-card-text": string;
     meetingCard: string;
+    meetingCardText: string;
     "start-time": string;
     startTime: string;
   }
 }
 
-declare const MeetingCardCssModule: MeetingCardCssModule.IMeetingCardCss & {
+declare const MeetingCardCssModule: MeetingCardCssNamespace.IMeetingCardCss & {
   /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
-  locals: MeetingCardCssModule.IMeetingCardCss;
+  locals: MeetingCardCssNamespace.IMeetingCardCss;
 };
 
 export = MeetingCardCssModule;

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/MeetingCard/MeetingCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/MeetingCard/MeetingCard.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Typography } from '@material-ui/core';
-
+import * as styles from './MeetingCard.css';
 import Meeting, { MeetingType } from '../../../../types/Meeting';
 import ScheduleCard from '../ScheduleCard/ScheduleCard';
 
@@ -43,17 +43,18 @@ const MeetingCard: React.FC<MeetingCardProps> = ({
       backgroundColor={bgColor}
       borderColor={bgColor}
     >
-      <Typography variant="body2" data-testid="meeting-card-primary-content">
+      <Typography variant="body2" data-testid="meeting-card-primary-content" className={styles.meetingCardText}>
         {`${section.subject} ${section.courseNum}`}
         {isBig
           ? `-${section.sectionNum}`
           : (
             <Typography variant="subtitle2" component="span">
-              {` ${MeetingType[meetingType]}`}
+              &nbsp;
+              {`${MeetingType[meetingType]}`}
             </Typography>
           )}
       </Typography>
-      <Typography variant="subtitle2" hidden={!isBig}>
+      <Typography variant="subtitle2" style={{ display: isBig ? 'block' : 'none' }}>
         {MeetingType[meetingType]}
       </Typography>
     </ScheduleCard>

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/MeetingCard/MeetingCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/MeetingCard/MeetingCard.tsx
@@ -44,13 +44,21 @@ const MeetingCard: React.FC<MeetingCardProps> = ({
       borderColor={bgColor}
     >
       <Typography variant="body2" data-testid="meeting-card-primary-content">
-        {`${section.subject} ${section.courseNum} `}
-        <Typography variant="subtitle2" component="span">
-          {`${MeetingType[meetingType]}`}
-        </Typography>
+        {`${section.subject} ${section.courseNum}`}
+        {isBig
+          ? (
+            <Typography variant="body2" component="span">
+              {`-${section.sectionNum}`}
+            </Typography>
+          )
+          : (
+            <Typography variant="subtitle2" component="span">
+              {` ${MeetingType[meetingType]}`}
+            </Typography>
+          )}
       </Typography>
-      <Typography variant="body2" hidden={!isBig}>
-        {section.sectionNum}
+      <Typography variant="subtitle2" hidden={!isBig}>
+        {MeetingType[meetingType]}
       </Typography>
     </ScheduleCard>
   );

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/MeetingCard/MeetingCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/MeetingCard/MeetingCard.tsx
@@ -46,11 +46,7 @@ const MeetingCard: React.FC<MeetingCardProps> = ({
       <Typography variant="body2" data-testid="meeting-card-primary-content">
         {`${section.subject} ${section.courseNum}`}
         {isBig
-          ? (
-            <Typography variant="body2" component="span">
-              {`-${section.sectionNum}`}
-            </Typography>
-          )
+          ? `-${section.sectionNum}`
           : (
             <Typography variant="subtitle2" component="span">
               {` ${MeetingType[meetingType]}`}

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/MeetingCard/MeetingCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/MeetingCard/MeetingCard.tsx
@@ -44,10 +44,13 @@ const MeetingCard: React.FC<MeetingCardProps> = ({
       borderColor={bgColor}
     >
       <Typography variant="body2" data-testid="meeting-card-primary-content">
-        {`${section.subject} ${section.courseNum}-${section.sectionNum}`}
+        {`${section.subject} ${section.courseNum} `}
+        <Typography variant="subtitle2" component="span">
+          {`${MeetingType[meetingType]}`}
+        </Typography>
       </Typography>
-      <Typography variant="subtitle2" hidden={!isBig}>
-        {MeetingType[meetingType]}
+      <Typography variant="body2" hidden={!isBig}>
+        {section.sectionNum}
       </Typography>
     </ScheduleCard>
   );

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/ScheduleCard/ScheduleCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/ScheduleCard/ScheduleCard.tsx
@@ -47,10 +47,16 @@ const ScheduleCard: React.FC<ScheduleCardProps> = ({
   const cardContent = React.useRef<HTMLDivElement>(null);
   React.useEffect(() => {
     const handleResize = (): void => {
+      // add up heights of children
+      let currContentHeight = 0;
+      for (let i = 0; i < cardContent.current.childElementCount; i++) {
+        currContentHeight += cardContent.current.children[i].clientHeight;
+      }
       // set initial height for future use
-      contentHeight = contentHeight || cardContent.current.clientHeight;
+      contentHeight = contentHeight || currContentHeight;
       // notify the parent component
-      onResizeWindow(contentHeight, cardRoot.current.clientHeight);
+      const heightAvailable = cardContent.current.parentElement.clientHeight;
+      onResizeWindow(contentHeight, heightAvailable);
     };
 
     // only attach the listener if the parent component cares to listen

--- a/autoscheduler/frontend/src/tests/testData.ts
+++ b/autoscheduler/frontend/src/tests/testData.ts
@@ -243,7 +243,7 @@ export async function mockFetchSchedulerGenerate(): Promise<Response> {
       days: [false, true, false, true, false, false, false], // TR
       start: '11:10',
       end: '12:25',
-      type: 'LEC',
+      type: 'LAB',
     }],
   };
 

--- a/autoscheduler/frontend/src/tests/ui/ConfigureCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/ConfigureCard.test.tsx
@@ -55,7 +55,6 @@ describe('ConfigureCard component', () => {
 
       // act
       fireEvent.click(getByText('Generate Schedules'));
-      await new Promise(setImmediate);
       const loadingSpinner = await findByRole('progressbar');
 
       // assert

--- a/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
@@ -405,7 +405,6 @@ describe('Course Select Card UI', () => {
       fetchMock.mockResponseOnce(JSON.stringify({
         results: ['MATH 151'],
       }));
-      fetchMock.mockImplementationOnce(testFetch);
 
       const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
       store.dispatch(setTerm('201931'));
@@ -431,9 +430,8 @@ describe('Course Select Card UI', () => {
       const loadingSpinner = await findByRole('progressbar');
 
       // assert
-      // the loading spinner was shown at one point, but is now hidden
+      // the loading spinner should be shown because we never resolved the last fetch
       expect(loadingSpinner).toBeTruthy();
-      expect(loadingSpinner).not.toBeInTheDocument();
     });
   });
 

--- a/autoscheduler/frontend/src/tests/ui/MeetingCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/MeetingCard.test.tsx
@@ -43,7 +43,7 @@ const testMeeting = new Meeting({
 
 function ignoreInvisible(query: string | RegExp): Matcher {
   return (content: string, element: HTMLElement): boolean => {
-    if (element.style.visibility === 'hidden') return false;
+    if (element.hidden) return false;
     return content.match(query) && content.match(query).length > 0;
   };
 }
@@ -54,7 +54,7 @@ beforeAll(() => { store = createStore(autoSchedulerReducer); });
 
 describe('Meeting Card', () => {
   describe('displays subject, course number, and meeting type', () => {
-    test('when given meeting and color as props, ', () => {
+    test('when given meeting and color as props', () => {
       const { container, getByText } = render(
         <Provider store={store}>
           <MeetingCard

--- a/autoscheduler/frontend/src/tests/ui/MeetingCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/MeetingCard.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { Matcher, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import * as React from 'react';
 
@@ -41,6 +41,13 @@ const testMeeting = new Meeting({
   section: testSection,
 });
 
+function ignoreInvisible(query: string | RegExp): Matcher {
+  return (content: string, element: HTMLElement): boolean => {
+    if (element.style.visibility === 'hidden') return false;
+    return content.match(query) && content.match(query).length > 0;
+  };
+}
+
 let store: Store = null;
 
 beforeAll(() => { store = createStore(autoSchedulerReducer); });
@@ -61,7 +68,7 @@ describe('Meeting Card', () => {
       expect(container).toBeTruthy();
       expect(getByText(/CSCE/)).toBeTruthy();
       expect(getByText(/121/)).toBeTruthy();
-      expect(getByText(/LEC/i)).toBeTruthy();
+      expect(getByText(ignoreInvisible(/LEC/i))).toBeTruthy();
     });
   });
 });

--- a/autoscheduler/frontend/src/tests/ui/MeetingCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/MeetingCard.test.tsx
@@ -43,7 +43,7 @@ const testMeeting = new Meeting({
 
 function ignoreInvisible(query: string | RegExp): Matcher {
   return (content: string, element: HTMLElement): boolean => {
-    if (element.hidden) return false;
+    if (element.style.display === 'none') return false;
     return content.match(query) && content.match(query).length > 0;
   };
 }

--- a/autoscheduler/frontend/src/tests/ui/Schedule.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/Schedule.test.tsx
@@ -115,7 +115,8 @@ describe('Schedule UI', () => {
 
         return {
           backgroundColor: coloredEl.style.backgroundColor,
-          textContent: card.textContent,
+          // select only the course name and number
+          textContent: card.textContent.match(/\w+ \d+/)[0],
         };
       });
 

--- a/autoscheduler/frontend/src/tests/ui/SchedulingPage.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SchedulingPage.test.tsx
@@ -153,11 +153,12 @@ describe('Scheduling Page UI', () => {
       const calendarDay = getByLabelText('Tuesday');
 
       // assert
-      // Schedule 1 has section 501 in it
-      // Schedule 2 has section 200 instead
+      // Schedule 1 has section 501 (LEC) in it
+      // Schedule 2 has section 200 (LAB) instead
       // we check Tuesday to avoid selecting the equivalent text in SchedulePreview
-      expect(queryContainerByText(calendarDay, /CSCE 121-501.*/)).toBeFalsy();
-      expect(queryContainerByText(calendarDay, /CSCE 121-200.*/)).toBeTruthy();
+      const selectedCSCE = queryContainerByText(calendarDay, /CSCE 121.*/);
+      expect(queryContainerByText(selectedCSCE, 'LEC')).toBeFalsy();
+      expect(queryContainerByText(selectedCSCE, 'LAB')).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
## Description

Fixes the bug where the meeting type was being shown regardless of card size.

## Rationale

Turns out the bug was caused by my setting one of the `ScheduleCard` div's to use `display: contents;` in #438. I still think we need that CSS rule, so instead I just adapated the JS that we use to determine the height of all of the text in the card and the height of the card available.

## How to test

Add a small class to your schedule

## Screenshots

On a side note, the color scheme for this is literally awful after seeing how it looks on #463 

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/10082177/99754919-1848ce00-2aaf-11eb-9359-c9bbef1f2c84.png)|![image](https://user-images.githubusercontent.com/10082177/99754836-e59ed580-2aae-11eb-912d-5158fa5f127b.png)|

## Related tasks

Closes #458 
Makes it easier to implement instructional method icons in the future