### PR TITLE
Term-select: Re-arrange redux

### DIFF
--- a/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
+++ b/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
@@ -24,7 +24,7 @@ const SelectTerm: React.FC<SelectTermProps> = ({ navBar = false }) => {
 
   // Used for retrieving the user-friendly term phrase given the term code (e.g. "202031")
   const [inverseTermMap, setInverseTermMap] = React.useState<Map<string, string>>(new Map());
-  const globalTerm = useSelector<RootState, string>((state) => state.term);
+  const globalTerm = useSelector<RootState, string>((state) => state.termData.term);
 
   let styles = defaultStyles;
 

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/CollapsedCourseCard/CollapsedCourseCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/CollapsedCourseCard/CollapsedCourseCard.tsx
@@ -15,7 +15,7 @@ interface CollapsedCourseCardProps {
 }
 
 const CollapsedCourseCard: React.FC<CollapsedCourseCardProps> = ({ onExpand, id }) => {
-  const course = useSelector<RootState, string>((state) => state.courseCards[id].course);
+  const course = useSelector<RootState, string>((state) => state.termData.courseCards[id].course);
   const dispatch = useDispatch();
   return (
     <Card

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/CourseSelectCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/CourseSelectCard.tsx
@@ -10,7 +10,9 @@ interface CourseSelectCardProps {
 }
 
 const CourseSelectCard: React.FC<CourseSelectCardProps> = ({ id }) => {
-  const collapsed = useSelector<RootState, boolean>((state) => state.courseCards[id].collapsed);
+  const collapsed = useSelector<RootState, boolean>(
+    (state) => state.termData.courseCards[id].collapsed,
+  );
   const dispatch = useDispatch();
 
   const toggleCollapsed = (): void => {

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicOptionRow.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicOptionRow.tsx
@@ -18,7 +18,9 @@ interface BasicOptionRowProps {
  * option selected by this row, formatted as it is found in the Redux course cards
  */
 const BasicOptionRow: React.FC<BasicOptionRowProps> = ({ id, value, label }) => {
-  const option = useSelector<RootState, string>((state) => state.courseCards[id][value] || 'exclude');
+  const option = useSelector<RootState, string>(
+    (state) => state.termData.courseCards[id][value] || 'exclude',
+  );
   const dispatch = useDispatch();
 
   return (

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.tsx
@@ -10,15 +10,15 @@ interface BasicSelectProps {
 }
 
 const BasicSelect: React.FC<BasicSelectProps> = ({ id }) => {
-  const course = useSelector<RootState, string>((state) => state.courseCards[id].course || '');
+  const course = useSelector<RootState, string>((state) => state.termData.courseCards[id].course || '');
   const hasHonors = useSelector<RootState, boolean>(
-    (state) => state.courseCards[id].hasHonors || false,
+    (state) => state.termData.courseCards[id].hasHonors || false,
   );
   const hasRemote = useSelector<RootState, boolean>(
-    (state) => state.courseCards[id].hasRemote || false,
+    (state) => state.termData.courseCards[id].hasRemote || false,
   );
   const hasAsynchronous = useSelector<RootState, boolean>(
-    (state) => state.courseCards[id].hasAsynchronous || false,
+    (state) => state.termData.courseCards[id].hasAsynchronous || false,
   );
 
   // shows placeholder text if no course is selected

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.tsx
@@ -24,10 +24,10 @@ const ExpandedCourseCard: React.FC<ExpandedCourseCardProps> = ({
   onCollapse, id,
 }) => {
   const courseCardOptions = useSelector<RootState, CourseCardOptions>(
-    (state) => state.courseCards[id],
+    (state) => state.termData.courseCards[id],
   );
 
-  const term = useSelector<RootState, string>((state) => state.term);
+  const term = useSelector<RootState, string>((state) => state.termData.term);
   const dispatch = useDispatch();
   const { course, customizationLevel, loading } = courseCardOptions;
 

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
@@ -12,7 +12,7 @@ interface SectionSelectProps {
 
 const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
   const sections = useSelector<RootState, SectionSelected[]>(
-    (state) => state.courseCards[id].sections,
+    (state) => state.termData.courseCards[id].sections,
   );
 
   // show placeholder text if there are no sections

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
@@ -18,9 +18,9 @@ const throttle = createThrottleFunction();
  */
 const CourseSelectColumn: React.FC = () => {
   const courseCards = useSelector<RootState, CourseCardArray>(
-    (state) => state.courseCards,
+    (state) => state.termData.courseCards,
   );
-  const term = useSelector<RootState, string>((state) => state.term);
+  const term = useSelector<RootState, string>((state) => state.termData.term);
   const dispatch = useDispatch();
 
   const expandedRowRef = React.useRef<HTMLDivElement>(null);

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
@@ -7,7 +7,7 @@ import * as styles from './CourseSelectColumn.css';
 import { RootState } from '../../../redux/reducer';
 import { CourseCardArray, CustomizationLevel, SerializedCourseCardOptions } from '../../../types/CourseCardOptions';
 import CourseSelectCard from './CourseSelectCard/CourseSelectCard';
-import { addCourseCard, replaceCourseCards, clearCourseCards } from '../../../redux/actions/courseCards';
+import { addCourseCard, replaceCourseCards } from '../../../redux/actions/courseCards';
 import createThrottleFunction from '../../../utils/createThrottleFunction';
 
 // Creates a throttle function that shares state between calls
@@ -49,9 +49,6 @@ const CourseSelectColumn: React.FC = () => {
         dispatch(replaceCourseCards(courses, term));
       });
     }
-
-    // on unmount, clear course cards
-    return (): void => { dispatch(clearCourseCards()); };
   }, [term, dispatch]);
 
   /* When courseCards are changed, create a callback to save courses in their current state.

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/InstructionsDialog/InstructionsDialog.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/InstructionsDialog/InstructionsDialog.tsx
@@ -9,7 +9,7 @@ import { RootState } from '../../../../redux/reducer';
 const InstructionsDialog: React.FC = () => {
   const [open, setOpen] = React.useState(true);
   const hasCurrentAv = useSelector<RootState, boolean>(
-    (state) => state.availability.length > 0,
+    (state) => state.termData.availability.length > 0,
   );
   // can have 1 of 3 values:
   // null -> user's first time on site

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/Schedule.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/Schedule.tsx
@@ -429,14 +429,15 @@ const Schedule: React.FC = () => {
         (res) => res.json(),
       ).then((avails: Availability[]) => {
         // We're done loading - hide the loading indicator and set the new availabilities
-        dispatch(setAvailabilities(avails));
+        dispatch(setAvailabilities(avails, term));
         setIsLoadingAvailabilities(false);
       });
     }
 
     // on unmount, clear availabilities
     return (): void => {
-      dispatch(setAvailabilities([]));
+      // Should re-show the loading indicator when we change terms
+      setIsLoadingAvailabilities(true);
     };
   }, [term, dispatch]);
 
@@ -460,7 +461,7 @@ const Schedule: React.FC = () => {
       });
     };
 
-    throttle(`${term}`, saveAvailabilities, 15000, true);
+    throttle(`${term}`, saveAvailabilities, 3000, true);
   }, [availabilityList, term, isMouseDown, isLoadingAvailabilities]);
 
   // On unmount, force-call the previously called throttle functions

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/Schedule.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/Schedule.tsx
@@ -34,9 +34,11 @@ const Schedule: React.FC = () => {
 
   // "props" derived from Redux store
   const schedule = useSelector<RootState, Meeting[]>(
-    (state) => state.schedules[state.selectedSchedule]?.meetings || emptySchedule,
+    (state) => state.termData.schedules[state.selectedSchedule]?.meetings || emptySchedule,
   );
-  const availabilityList = useSelector<RootState, Availability[]>((state) => state.availability);
+  const availabilityList = useSelector<RootState, Availability[]>(
+    (state) => state.termData.availability,
+  );
   const availabilityMode = useSelector<RootState, AvailabilityType>(
     (state) => state.availabilityMode,
   );
@@ -44,7 +46,7 @@ const Schedule: React.FC = () => {
     (state) => state.selectedAvailabilities,
   );
   // Needed for saving availabilities
-  const term = useSelector<RootState, string>((state) => state.term);
+  const term = useSelector<RootState, string>((state) => state.termData.term);
 
   const dispatch = useDispatch();
   const meetingColors = useMeetingColor();

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/meetingColors.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/meetingColors.ts
@@ -8,7 +8,7 @@ export const colors = [
 
 export default function useMeetingColor(): Map<string, string> {
   const allSectionIds = new Set(useSelector<RootState, string[]>(
-    (state) => state.schedules.reduce<string[]>(
+    (state) => state.termData.schedules.reduce<string[]>(
       (arr, schedule) => arr.concat(
         schedule.meetings.map(
           (meeting) => meeting.section.subject + meeting.section.courseNum,

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/Buttons/DeleteScheduleButton.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/Buttons/DeleteScheduleButton.tsx
@@ -16,7 +16,7 @@ const DeleteScheduleButton: React.FC<DeleteScheduleButtonProps> = ({ index }) =>
   const dispatch = useDispatch();
 
   const schedule = useSelector<RootState, Schedule>((state) => (
-    state.schedules[index]
+    state.termData.schedules[index]
   ));
 
   const [dialogOpen, setDialogOpen] = React.useState(false);

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/Buttons/SaveScheduleButton.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/Buttons/SaveScheduleButton.tsx
@@ -13,7 +13,7 @@ interface SaveScheduleButtonProps {
 const SaveScheduleButton: React.FC<SaveScheduleButtonProps> = ({ index }) => {
   const dispatch = useDispatch();
 
-  const saved = useSelector<RootState, boolean>((state) => state.schedules[index].saved);
+  const saved = useSelector<RootState, boolean>((state) => state.termData.schedules[index].saved);
 
   // TODO: Once API for saving schedules is created, call it here
   const handleClick = (event: React.MouseEvent<HTMLElement>): void => {

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/Buttons/ScheduleName.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/Buttons/ScheduleName.tsx
@@ -14,7 +14,7 @@ interface ScheduleNameProps {
 const ScheduleName: React.FC<ScheduleNameProps> = ({ index }) => {
   const dispatch = useDispatch();
 
-  const savedName = useSelector<RootState, string>((state) => state.schedules[index].name);
+  const savedName = useSelector<RootState, string>((state) => state.termData.schedules[index].name);
 
   const [renaming, setRenaming] = React.useState(false);
   const [currentName, setCurrentName] = React.useState(savedName);

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ScheduleListItem.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ScheduleListItem.tsx
@@ -24,7 +24,7 @@ const ScheduleListItem: React.FC<ScheduleListItemProps> = ({ index }) => {
   const dispatch = useDispatch();
 
   const schedule = useSelector<RootState, Schedule>((state) => (
-    state.schedules[index]
+    state.termData.schedules[index]
   ));
   const selectedSchedule = useSelector<RootState, number>((state) => state.selectedSchedule);
 

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
@@ -46,20 +46,22 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({
         meetings: parseAllMeetings(val.sections),
         saved: true,
       }))).then((savedSchedules: Schedule[]) => {
-        dispatch(setSchedules(savedSchedules));
+        dispatch(setSchedules(savedSchedules, term));
         setIsLoadingSchedules(false);
       });
     }
 
     // on unmount, clear schedules
     return (): void => {
-      dispatch(setSchedules([]));
+      // Re-show the loading indicator when we change terms
+      setIsLoadingSchedules(true);
     };
   }, [term, dispatch]);
 
   // Call throttle to serialize and save the schedules anytime we make a change to the schedules
   React.useEffect(() => {
-    if (!term) return;
+    // Don't attempt to save schedules if they're still loading (or if the term is falsy)
+    if (!term || isLoadingSchedules) return;
 
     // Serialize schedules and make API call
     const saveSchedules = (): void => {
@@ -85,7 +87,7 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({
     };
 
     throttle(term, saveSchedules, throttleTime, true);
-  }, [schedules, term, throttleTime]);
+  }, [schedules, term, throttleTime, isLoadingSchedules]);
 
   // On unmount, force-call the previously called throttle functions
   // This way when we navigate back to the homepage we can guarantee saveSchedules

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
@@ -28,8 +28,8 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({
   throttleTime = 10000, hideLoadingIndicator = false,
 }) => {
   const dispatch = useDispatch();
-  const schedules = useSelector<RootState, Schedule[]>((state) => state.schedules);
-  const term = useSelector<RootState, string>((state) => state.term);
+  const schedules = useSelector<RootState, Schedule[]>((state) => state.termData.schedules);
+  const term = useSelector<RootState, string>((state) => state.termData.term);
   const [isLoadingSchedules, setIsLoadingSchedules] = React.useState(!hideLoadingIndicator);
 
   const scheduleListItems = schedules.length === 0

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulingPage.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulingPage.tsx
@@ -18,7 +18,7 @@ const SchedulingPage: React.FC<SchedulingPageProps> = ({
   hideSchedulesLoadingIndicator = false,
 }) => {
   const dispatch = useDispatch();
-  const termCurr = useSelector<RootState, string>((state) => state.term);
+  const termCurr = useSelector<RootState, string>((state) => state.termData.term);
 
   // Set redux state on page load based on term from user session
   React.useEffect(() => {

--- a/autoscheduler/frontend/src/redux/actions/availability.ts
+++ b/autoscheduler/frontend/src/redux/actions/availability.ts
@@ -1,10 +1,9 @@
 import Availability, { AvailabilityArgs } from '../../types/Availability'; import {
   ADD_AVAILABILITY, DELETE_AVAILABILITY, UPDATE_AVAILABILITY, MERGE_AVAILABILITY,
   SET_AVAILABILITIES,
-  CLEAR_AVAILABILITIES,
 } from '../reducers/availability';
 import {
-  AddAvailabilityAction, ClearAvailabilitiesAction, DeleteAvailabilityAction,
+  AddAvailabilityAction, DeleteAvailabilityAction,
   MergeAvailabilityAction, SetAvailabilitiesAction, UpdateAvailabilityAction,
 } from './termData';
 

--- a/autoscheduler/frontend/src/redux/actions/availability.ts
+++ b/autoscheduler/frontend/src/redux/actions/availability.ts
@@ -1,8 +1,11 @@
 import Availability, { AvailabilityArgs } from '../../types/Availability'; import {
-  AddAvailabilityAction, ADD_AVAILABILITY, DeleteAvailabilityAction, DELETE_AVAILABILITY,
-  UpdateAvailabilityAction, UPDATE_AVAILABILITY, MergeAvailabilityAction, MERGE_AVAILABILITY,
-  SetAvailabilitiesAction, SET_AVAILABILITIES,
+  ADD_AVAILABILITY, DELETE_AVAILABILITY, UPDATE_AVAILABILITY, MERGE_AVAILABILITY,
+  SET_AVAILABILITIES,
 } from '../reducers/availability';
+import {
+  AddAvailabilityAction, DeleteAvailabilityAction, MergeAvailabilityAction, SetAvailabilitiesAction,
+  UpdateAvailabilityAction,
+} from './termData';
 
 export function addAvailability(availability: AvailabilityArgs): AddAvailabilityAction {
   return {

--- a/autoscheduler/frontend/src/redux/actions/availability.ts
+++ b/autoscheduler/frontend/src/redux/actions/availability.ts
@@ -1,10 +1,11 @@
 import Availability, { AvailabilityArgs } from '../../types/Availability'; import {
   ADD_AVAILABILITY, DELETE_AVAILABILITY, UPDATE_AVAILABILITY, MERGE_AVAILABILITY,
   SET_AVAILABILITIES,
+  CLEAR_AVAILABILITIES,
 } from '../reducers/availability';
 import {
-  AddAvailabilityAction, DeleteAvailabilityAction, MergeAvailabilityAction, SetAvailabilitiesAction,
-  UpdateAvailabilityAction,
+  AddAvailabilityAction, ClearAvailabilitiesAction, DeleteAvailabilityAction,
+  MergeAvailabilityAction, SetAvailabilitiesAction, UpdateAvailabilityAction,
 } from './termData';
 
 export function addAvailability(availability: AvailabilityArgs): AddAvailabilityAction {
@@ -49,9 +50,12 @@ export function mergeAvailability(numNewAvs = 1): MergeAvailabilityAction {
   };
 }
 
-export function setAvailabilities(availabilities: Availability[]): SetAvailabilitiesAction {
+export function setAvailabilities(
+  availabilities: Availability[], term: string,
+): SetAvailabilitiesAction {
   return {
     type: SET_AVAILABILITIES,
     availabilities,
+    term,
   };
 }

--- a/autoscheduler/frontend/src/redux/actions/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/actions/courseCards.ts
@@ -4,7 +4,7 @@ import {
   SectionFilter,
 } from '../../types/CourseCardOptions';
 import {
-  ADD_COURSE_CARD, REMOVE_COURSE_CARD, UPDATE_COURSE_CARD, CLEAR_COURSE_CARDS,
+  ADD_COURSE_CARD, REMOVE_COURSE_CARD, UPDATE_COURSE_CARD,
 } from '../reducers/courseCards';
 import { RootState } from '../reducer';
 import Meeting, { MeetingType } from '../../types/Meeting';
@@ -32,13 +32,11 @@ export function addCourseCard(
   courseCard = createEmptyCourseCard(),
   idx: number = undefined,
 ): AddCourseAction {
-  const card = courseCard;
-  card.term = term;
-
   return {
     type: ADD_COURSE_CARD,
-    courseCard: card,
+    courseCard,
     idx,
+    term,
   };
 }
 
@@ -53,12 +51,16 @@ export function removeCourseCard(index: number): RemoveCourseAction {
    * Helper action creator that generates plain old UpdateCourseActions
    * @param index the index of the course card to update in the CourseCardArray
    * @param courseCard the options to update
+   * @param term the current term, which defaults to undefined
    */
-function updateCourseCardSync(index: number, courseCard: CourseCardOptions): UpdateCourseAction {
+function updateCourseCardSync(
+  index: number, courseCard: CourseCardOptions, term: string = undefined,
+): UpdateCourseAction {
   return {
     type: UPDATE_COURSE_CARD,
     index,
     courseCard,
+    term,
   };
 }
 
@@ -210,7 +212,6 @@ async function fetchCourseCardFrom(
         hasHonors,
         hasRemote,
         hasAsynchronous,
-        term,
         honors,
         remote,
         asynchronous,
@@ -231,7 +232,7 @@ function updateCourseCardAsync(
   return (dispatch): Promise<void> => new Promise((resolve) => {
     fetchCourseCardFrom(courseCard, term).then((updatedCourseCard) => {
       if (updatedCourseCard) {
-        dispatch(updateCourseCardSync(index, updatedCourseCard));
+        dispatch(updateCourseCardSync(index, updatedCourseCard, term));
         resolve();
       }
     });
@@ -277,11 +278,6 @@ ThunkAction<void, RootState, undefined, UpdateCourseAction> {
   };
 }
 
-
-export function clearCourseCards(): ClearCourseCardsAction {
-  return { type: CLEAR_COURSE_CARDS };
-}
-
 /**
  * Helper function to deserialize course card, doesn't keep selected sections.
  * Also note that this sets the card as loading until its sections are retrieved.
@@ -309,7 +305,6 @@ function getSelectedSections(
 
   // courseCard can be undefined occasionally when you change terms when it's loading
   if (!courseCard) {
-    console.log('term is undefined!');
     return [];
   }
 
@@ -354,9 +349,8 @@ export function replaceCourseCards(
         const cardWithSectionsSelected = {
           sections: getSelectedSections(courseCards[idx], updatedCard),
           loading: false,
-          term,
         };
-        dispatch(updateCourseCardSync(idx, cardWithSectionsSelected));
+        dispatch(updateCourseCardSync(idx, cardWithSectionsSelected, term));
       });
     });
   };

--- a/autoscheduler/frontend/src/redux/actions/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/actions/courseCards.ts
@@ -12,7 +12,7 @@ import Section from '../../types/Section';
 import Instructor from '../../types/Instructor';
 import Grades from '../../types/Grades';
 import {
-  AddCourseAction, ClearCourseCardsAction, CourseCardAction, RemoveCourseAction, UpdateCourseAction,
+  AddCourseAction, CourseCardAction, RemoveCourseAction, UpdateCourseAction,
 } from './termData';
 
 function createEmptyCourseCard(): CourseCardOptions {

--- a/autoscheduler/frontend/src/redux/actions/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/actions/courseCards.ts
@@ -4,14 +4,16 @@ import {
   SectionFilter,
 } from '../../types/CourseCardOptions';
 import {
-  AddCourseAction, ADD_COURSE_CARD, RemoveCourseAction, REMOVE_COURSE_CARD, UpdateCourseAction,
-  UPDATE_COURSE_CARD, ClearCourseCardsAction, CLEAR_COURSE_CARDS, CourseCardAction,
+  ADD_COURSE_CARD, REMOVE_COURSE_CARD, UPDATE_COURSE_CARD, CLEAR_COURSE_CARDS,
 } from '../reducers/courseCards';
 import { RootState } from '../reducer';
 import Meeting, { MeetingType } from '../../types/Meeting';
 import Section from '../../types/Section';
 import Instructor from '../../types/Instructor';
 import Grades from '../../types/Grades';
+import {
+  AddCourseAction, ClearCourseCardsAction, CourseCardAction, RemoveCourseAction, UpdateCourseAction,
+} from './termData';
 
 function createEmptyCourseCard(): CourseCardOptions {
   return {

--- a/autoscheduler/frontend/src/redux/actions/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/actions/courseCards.ts
@@ -264,7 +264,7 @@ export function toggleSelected(courseCardId: number, secIdx: number):
 ThunkAction<void, RootState, undefined, UpdateCourseAction> {
   return (dispatch, getState): void => {
     dispatch(updateCourseCard(courseCardId, {
-      sections: getState().courseCards[courseCardId].sections.map(
+      sections: getState().termData.courseCards[courseCardId].sections.map(
         (sec, idx) => (idx !== secIdx ? sec : {
           section: sec.section,
           selected: !sec.selected,
@@ -348,7 +348,7 @@ export function replaceCourseCards(
     deserializedCards.forEach((deserializedCard, idx) => {
       dispatch(updateCourseCardAsync(idx, deserializedCard, term)).then(() => {
         // after fetching sections, re-select sections from the serialized card and finish loading
-        const updatedCard = getState().courseCards[idx];
+        const updatedCard = getState().termData.courseCards[idx];
         const cardWithSectionsSelected = {
           sections: getSelectedSections(courseCards[idx], updatedCard),
           loading: false,

--- a/autoscheduler/frontend/src/redux/actions/schedules.ts
+++ b/autoscheduler/frontend/src/redux/actions/schedules.ts
@@ -1,10 +1,8 @@
 import { ThunkAction } from 'redux-thunk';
 import * as Cookies from 'js-cookie';
 import {
-  AddScheduleAction, ADD_SCHEDULE, RemoveScheduleAction, REMOVE_SCHEDULE,
-  ReplaceSchedulesAction, REPLACE_SCHEDULES, SaveScheduleAction, SAVE_SCHEDULE,
-  UnsaveScheduleAction, UNSAVE_SCHEDULE, RenameScheduleAction, RENAME_SCHEDULE, SET_SCHEDULES,
-  SetSchedulesAction,
+  ADD_SCHEDULE, REMOVE_SCHEDULE, REPLACE_SCHEDULES, SAVE_SCHEDULE, UNSAVE_SCHEDULE, RENAME_SCHEDULE,
+  SET_SCHEDULES,
 } from '../reducers/schedules';
 import Meeting from '../../types/Meeting';
 import { RootState } from '../reducer';
@@ -15,6 +13,10 @@ import { SelectScheduleAction } from '../reducers/selectedSchedule';
 import selectSchedule from './selectedSchedule';
 import { GenerateSchedulesResponse } from '../../types/APIResponses';
 import Schedule from '../../types/Schedule';
+import {
+  AddScheduleAction, RemoveScheduleAction, RenameScheduleAction, ReplaceSchedulesAction,
+  SaveScheduleAction, SetSchedulesAction, UnsaveScheduleAction,
+} from './termData';
 
 export function addSchedule(meetings: Meeting[]): AddScheduleAction {
   return {

--- a/autoscheduler/frontend/src/redux/actions/schedules.ts
+++ b/autoscheduler/frontend/src/redux/actions/schedules.ts
@@ -69,7 +69,7 @@ export const errorGeneratingSchedulesMessage = 'There was an error generating sc
 export function generateSchedules(includeFull: boolean):
 ThunkAction<Promise<void>, RootState, undefined, ReplaceSchedulesAction | SelectScheduleAction> {
   return async (dispatch, getState): Promise<void> => {
-    const { courseCards, availability, term } = getState();
+    const { courseCards, availability, term } = getState().termData;
 
     const checkIfEmpty = (schedules: Meeting[][]): Meeting[][] => {
       if (schedules.length === 0) throw Error('No schedules found. Try widening your criteria.');

--- a/autoscheduler/frontend/src/redux/actions/schedules.ts
+++ b/autoscheduler/frontend/src/redux/actions/schedules.ts
@@ -14,8 +14,8 @@ import selectSchedule from './selectedSchedule';
 import { GenerateSchedulesResponse } from '../../types/APIResponses';
 import Schedule from '../../types/Schedule';
 import {
-  AddScheduleAction, RemoveScheduleAction, RenameScheduleAction, ReplaceSchedulesAction,
-  SaveScheduleAction, SetSchedulesAction, UnsaveScheduleAction,
+  AddScheduleAction, RemoveScheduleAction, RenameScheduleAction,
+  ReplaceSchedulesAction, SaveScheduleAction, SetSchedulesAction, UnsaveScheduleAction,
 } from './termData';
 
 export function addSchedule(meetings: Meeting[]): AddScheduleAction {
@@ -151,9 +151,10 @@ ThunkAction<Promise<void>, RootState, undefined, ReplaceSchedulesAction | Select
   };
 }
 
-export function setSchedules(schedules: Schedule[]): SetSchedulesAction {
+export function setSchedules(schedules: Schedule[], term: string): SetSchedulesAction {
   return {
     type: SET_SCHEDULES,
     schedules,
+    term,
   };
 }

--- a/autoscheduler/frontend/src/redux/actions/term.ts
+++ b/autoscheduler/frontend/src/redux/actions/term.ts
@@ -1,4 +1,5 @@
-import { SET_TERM, SetTermAction } from '../reducers/term';
+import { SET_TERM } from '../reducers/term';
+import { SetTermAction } from './termData';
 
 /**
  * Sets the current term.

--- a/autoscheduler/frontend/src/redux/actions/termData.ts
+++ b/autoscheduler/frontend/src/redux/actions/termData.ts
@@ -1,0 +1,108 @@
+/* These all have to be in the same file due to dependency cycles
+*/
+
+import Availability, { AvailabilityArgs } from '../../types/Availability';
+import { CourseCardOptions } from '../../types/CourseCardOptions';
+import Meeting from '../../types/Meeting';
+import Schedule from '../../types/Schedule';
+import { RemoveSelectedAvailabilityAction } from '../reducers/selectedAvailability';
+
+/*
+  TERM
+*/
+// action type interface
+export interface SetTermAction {
+  type: 'SET_TERM';
+  term: string;
+}
+
+/*
+  AVAILABILITIES
+*/
+// action type interfaces
+export interface AddAvailabilityAction {
+    type: 'ADD_AVAILABILITY';
+    availability: AvailabilityArgs;
+}
+export interface DeleteAvailabilityAction {
+    type: 'DELETE_AVAILABILITY';
+    availability: AvailabilityArgs;
+}
+export interface UpdateAvailabilityAction {
+    type: 'UPDATE_AVAILABILITY';
+    availability: AvailabilityArgs;
+}
+export interface MergeAvailabilityAction {
+    type: 'MERGE_AVAILABILITY';
+    numNewAvs: number;
+}
+export interface SetAvailabilitiesAction {
+  type: 'SET_AVAILABILITIES';
+  availabilities: Availability[];
+}
+export type AvailabilityAction =
+    AddAvailabilityAction | DeleteAvailabilityAction | UpdateAvailabilityAction |
+    MergeAvailabilityAction | SetAvailabilitiesAction | RemoveSelectedAvailabilityAction;
+
+/*
+    SCHEDULES
+*/
+// action type interfaces
+export interface AddScheduleAction {
+    type: 'ADD_SCHEDULE';
+    meetings: Meeting[];
+}
+export interface RemoveScheduleAction {
+    type: 'REMOVE_SCHEDULE';
+    index: number;
+}
+export interface ReplaceSchedulesAction {
+    type: 'REPLACE_SCHEDULES';
+    schedules: Meeting[][];
+}
+export interface SaveScheduleAction {
+    type: 'SAVE_SCHEDULE';
+    index: number;
+}
+export interface UnsaveScheduleAction {
+    type: 'UNSAVE_SCHEDULE';
+    index: number;
+}
+export interface RenameScheduleAction {
+  type: 'RENAME_SCHEDULE';
+  index: number;
+  name: string;
+}
+export interface SetSchedulesAction {
+  type: 'SET_SCHEDULES';
+  schedules: Schedule[];
+}
+export type ScheduleAction = AddScheduleAction | RemoveScheduleAction | ReplaceSchedulesAction
+| SaveScheduleAction | UnsaveScheduleAction | RenameScheduleAction | SetSchedulesAction;
+
+/*
+  COURSE CARDS
+*/
+// action type interfaces
+
+export interface AddCourseAction {
+    type: 'ADD_COURSE_CARD';
+    courseCard: CourseCardOptions;
+    idx?: number;
+}
+export interface RemoveCourseAction {
+    type: 'REMOVE_COURSE_CARD';
+    index: number;
+}
+export interface UpdateCourseAction {
+    type: 'UPDATE_COURSE_CARD';
+    index: number;
+    courseCard: CourseCardOptions;
+}
+export interface ClearCourseCardsAction {
+  type: 'CLEAR_COURSE_CARDS';
+}
+export type CourseCardAction = AddCourseAction | RemoveCourseAction | UpdateCourseAction
+| ClearCourseCardsAction | SetTermAction;
+
+export type TermDataAction = SetTermAction | ScheduleAction | AvailabilityAction | CourseCardAction;

--- a/autoscheduler/frontend/src/redux/actions/termData.ts
+++ b/autoscheduler/frontend/src/redux/actions/termData.ts
@@ -39,10 +39,15 @@ export interface MergeAvailabilityAction {
 export interface SetAvailabilitiesAction {
   type: 'SET_AVAILABILITIES';
   availabilities: Availability[];
+  term: string;
+}
+export interface ClearAvailabilitiesAction {
+  type: 'CLEAR_AVAILABILITIES';
 }
 export type AvailabilityAction =
     AddAvailabilityAction | DeleteAvailabilityAction | UpdateAvailabilityAction |
-    MergeAvailabilityAction | SetAvailabilitiesAction | RemoveSelectedAvailabilityAction;
+    MergeAvailabilityAction | SetAvailabilitiesAction | RemoveSelectedAvailabilityAction |
+    ClearAvailabilitiesAction;
 
 /*
     SCHEDULES
@@ -76,9 +81,14 @@ export interface RenameScheduleAction {
 export interface SetSchedulesAction {
   type: 'SET_SCHEDULES';
   schedules: Schedule[];
+  term: string;
+}
+export interface ClearSchedulesAction {
+  type: 'CLEAR_SCHEDULES';
 }
 export type ScheduleAction = AddScheduleAction | RemoveScheduleAction | ReplaceSchedulesAction
-| SaveScheduleAction | UnsaveScheduleAction | RenameScheduleAction | SetSchedulesAction;
+| SaveScheduleAction | UnsaveScheduleAction | RenameScheduleAction | SetSchedulesAction
+| ClearSchedulesAction;
 
 /*
   COURSE CARDS
@@ -89,6 +99,7 @@ export interface AddCourseAction {
     type: 'ADD_COURSE_CARD';
     courseCard: CourseCardOptions;
     idx?: number;
+    term: string;
 }
 export interface RemoveCourseAction {
     type: 'REMOVE_COURSE_CARD';
@@ -98,6 +109,7 @@ export interface UpdateCourseAction {
     type: 'UPDATE_COURSE_CARD';
     index: number;
     courseCard: CourseCardOptions;
+    term: string;
 }
 export interface ClearCourseCardsAction {
   type: 'CLEAR_COURSE_CARDS';

--- a/autoscheduler/frontend/src/redux/actions/termData.ts
+++ b/autoscheduler/frontend/src/redux/actions/termData.ts
@@ -10,7 +10,6 @@ import { RemoveSelectedAvailabilityAction } from '../reducers/selectedAvailabili
 /*
   TERM
 */
-// action type interface
 export interface SetTermAction {
   type: 'SET_TERM';
   term: string;
@@ -19,7 +18,6 @@ export interface SetTermAction {
 /*
   AVAILABILITIES
 */
-// action type interfaces
 export interface AddAvailabilityAction {
     type: 'ADD_AVAILABILITY';
     availability: AvailabilityArgs;
@@ -52,7 +50,6 @@ export type AvailabilityAction =
 /*
     SCHEDULES
 */
-// action type interfaces
 export interface AddScheduleAction {
     type: 'ADD_SCHEDULE';
     meetings: Meeting[];
@@ -93,7 +90,6 @@ export type ScheduleAction = AddScheduleAction | RemoveScheduleAction | ReplaceS
 /*
   COURSE CARDS
 */
-// action type interfaces
 
 export interface AddCourseAction {
     type: 'ADD_COURSE_CARD';

--- a/autoscheduler/frontend/src/redux/reducer.ts
+++ b/autoscheduler/frontend/src/redux/reducer.ts
@@ -14,7 +14,6 @@ const autoSchedulerReducer = combineReducers({
   meetings,
   selectedSchedule,
   availabilityMode,
-  availability,
   selectedAvailabilities,
 });
 

--- a/autoscheduler/frontend/src/redux/reducer.ts
+++ b/autoscheduler/frontend/src/redux/reducer.ts
@@ -2,7 +2,6 @@
  * Exports a combined reducer for the complete state of the app
  */
 import { combineReducers } from 'redux';
-import availability from './reducers/availability';
 import availabilityMode from './reducers/availabilityMode';
 import meetings from './reducers/meetings';
 import selectedAvailabilities from './reducers/selectedAvailability';

--- a/autoscheduler/frontend/src/redux/reducer.ts
+++ b/autoscheduler/frontend/src/redux/reducer.ts
@@ -5,21 +5,17 @@ import { combineReducers } from 'redux';
 import availability from './reducers/availability';
 import availabilityMode from './reducers/availabilityMode';
 import meetings from './reducers/meetings';
-import schedules from './reducers/schedules';
-import courseCards from './reducers/courseCards';
 import selectedAvailabilities from './reducers/selectedAvailability';
 import selectedSchedule from './reducers/selectedSchedule';
-import term from './reducers/term';
+import termData from './reducers/termData';
 
 const autoSchedulerReducer = combineReducers({
+  termData,
   meetings,
-  schedules,
   selectedSchedule,
-  courseCards,
   availabilityMode,
   availability,
   selectedAvailabilities,
-  term,
 });
 
 export default autoSchedulerReducer;

--- a/autoscheduler/frontend/src/redux/reducers/availability.ts
+++ b/autoscheduler/frontend/src/redux/reducers/availability.ts
@@ -14,13 +14,14 @@ export const DELETE_AVAILABILITY = 'DELETE_AVAILABILITY';
 export const UPDATE_AVAILABILITY = 'UPDATE_AVAILABILITY';
 export const MERGE_AVAILABILITY = 'MERGE_AVAILABILITY';
 export const SET_AVAILABILITIES = 'SET_AVAILABILITIES';
+export const CLEAR_AVAILABILITIES = 'CLEAR_AVAILABILITIES';
 
 
 // helper functions for reducer
 
 // reducer
 export default function availability(
-  state: Availability[] = [], action: TermDataAction,
+  state: Availability[] = [], action: TermDataAction, term: string,
 ): Availability[] {
   switch (action.type) {
     case ADD_AVAILABILITY:
@@ -97,7 +98,12 @@ export default function availability(
       return newState;
     }
     case SET_AVAILABILITIES:
+      // If there's a term mismatch, return the original state
+      if (action.term !== term) return state;
+
       return action.availabilities;
+    case CLEAR_AVAILABILITIES:
+      return [];
     default:
       return state;
   }

--- a/autoscheduler/frontend/src/redux/reducers/availability.ts
+++ b/autoscheduler/frontend/src/redux/reducers/availability.ts
@@ -3,10 +3,10 @@
  * unable to attend classes
  */
 import Availability, {
-  AvailabilityArgs, argsToAvailability, time1And2Mismatch, time1OnlyMismatch, getStart, getEnd,
+  argsToAvailability, time1And2Mismatch, time1OnlyMismatch, getStart, getEnd,
 } from '../../types/Availability';
-import { RemoveSelectedAvailabilityAction, REMOVE_SELECTED_AVAILABILITY } from './selectedAvailability';
-import { TermDataAction } from './termData';
+import { REMOVE_SELECTED_AVAILABILITY } from './selectedAvailability';
+import { TermDataAction } from '../actions/termData';
 
 // action type strings
 export const ADD_AVAILABILITY = 'ADD_AVAILABILITY';
@@ -15,30 +15,6 @@ export const UPDATE_AVAILABILITY = 'UPDATE_AVAILABILITY';
 export const MERGE_AVAILABILITY = 'MERGE_AVAILABILITY';
 export const SET_AVAILABILITIES = 'SET_AVAILABILITIES';
 
-// action type interfaces
-export interface AddAvailabilityAction {
-    type: 'ADD_AVAILABILITY';
-    availability: AvailabilityArgs;
-}
-export interface DeleteAvailabilityAction {
-    type: 'DELETE_AVAILABILITY';
-    availability: AvailabilityArgs;
-}
-export interface UpdateAvailabilityAction {
-    type: 'UPDATE_AVAILABILITY';
-    availability: AvailabilityArgs;
-}
-export interface MergeAvailabilityAction {
-    type: 'MERGE_AVAILABILITY';
-    numNewAvs: number;
-}
-export interface SetAvailabilitiesAction {
-  type: 'SET_AVAILABILITIES';
-  availabilities: Availability[];
-}
-export type AvailabilityAction =
-    AddAvailabilityAction | DeleteAvailabilityAction | UpdateAvailabilityAction |
-    MergeAvailabilityAction | SetAvailabilitiesAction | RemoveSelectedAvailabilityAction;
 
 // helper functions for reducer
 

--- a/autoscheduler/frontend/src/redux/reducers/availability.ts
+++ b/autoscheduler/frontend/src/redux/reducers/availability.ts
@@ -6,6 +6,7 @@ import Availability, {
   AvailabilityArgs, argsToAvailability, time1And2Mismatch, time1OnlyMismatch, getStart, getEnd,
 } from '../../types/Availability';
 import { RemoveSelectedAvailabilityAction, REMOVE_SELECTED_AVAILABILITY } from './selectedAvailability';
+import { TermDataAction } from './termData';
 
 // action type strings
 export const ADD_AVAILABILITY = 'ADD_AVAILABILITY';
@@ -37,13 +38,13 @@ export interface SetAvailabilitiesAction {
 }
 export type AvailabilityAction =
     AddAvailabilityAction | DeleteAvailabilityAction | UpdateAvailabilityAction |
-    MergeAvailabilityAction | SetAvailabilitiesAction;
+    MergeAvailabilityAction | SetAvailabilitiesAction | RemoveSelectedAvailabilityAction;
 
 // helper functions for reducer
 
 // reducer
 export default function availability(
-  state: Availability[] = [], action: AvailabilityAction | RemoveSelectedAvailabilityAction,
+  state: Availability[] = [], action: TermDataAction,
 ): Availability[] {
   switch (action.type) {
     case ADD_AVAILABILITY:

--- a/autoscheduler/frontend/src/redux/reducers/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/reducers/courseCards.ts
@@ -5,35 +5,14 @@
 import {
   CourseCardOptions, CourseCardArray, CustomizationLevel, SectionFilter,
 } from '../../types/CourseCardOptions';
-import { TermDataAction } from './termData';
-import { SetTermAction, SET_TERM } from './term';
+import { TermDataAction } from '../actions/termData';
+import { SET_TERM } from './term';
 
 // action type strings
 export const ADD_COURSE_CARD = 'ADD_COURSE_CARD';
 export const REMOVE_COURSE_CARD = 'REMOVE_COURSE_CARD';
 export const UPDATE_COURSE_CARD = 'UPDATE_COURSE_CARD';
 export const CLEAR_COURSE_CARDS = 'CLEAR_COURSE_CARDS';
-
-// action type interfaces
-export interface AddCourseAction {
-    type: 'ADD_COURSE_CARD';
-    courseCard: CourseCardOptions;
-    idx?: number;
-}
-export interface RemoveCourseAction {
-    type: 'REMOVE_COURSE_CARD';
-    index: number;
-}
-export interface UpdateCourseAction {
-    type: 'UPDATE_COURSE_CARD';
-    index: number;
-    courseCard: CourseCardOptions;
-}
-export interface ClearCourseCardsAction {
-  type: 'CLEAR_COURSE_CARDS';
-}
-export type CourseCardAction = AddCourseAction | RemoveCourseAction | UpdateCourseAction
-| ClearCourseCardsAction | SetTermAction;
 
 // initial state for courseCards
 // if no courses are saved for the term, an intial course card will be added

--- a/autoscheduler/frontend/src/redux/reducers/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/reducers/courseCards.ts
@@ -12,7 +12,6 @@ import { SET_TERM } from './term';
 export const ADD_COURSE_CARD = 'ADD_COURSE_CARD';
 export const REMOVE_COURSE_CARD = 'REMOVE_COURSE_CARD';
 export const UPDATE_COURSE_CARD = 'UPDATE_COURSE_CARD';
-export const CLEAR_COURSE_CARDS = 'CLEAR_COURSE_CARDS';
 
 // initial state for courseCards
 // if no courses are saved for the term, an intial course card will be added
@@ -61,15 +60,19 @@ function getStateAfterExpanding(
 
 // reducer
 export default function courseCards(
-  state: CourseCardArray = initialCourseCardArray, action: TermDataAction,
+  state: CourseCardArray = initialCourseCardArray, action: TermDataAction, term: string,
 ): CourseCardArray {
   switch (action.type) {
     case ADD_COURSE_CARD: {
+      // If there's a term mismatch, return the original state
+      if (term !== action.term) return state;
+
       const newCardIdx = action.idx ?? state.numCardsCreated;
       // If new card is explicitly expanded, perform necessary state changes
       if (action.courseCard.collapsed === false) {
         return getStateAfterExpanding(state, newCardIdx, action.courseCard);
       }
+
       // New card isn't supposed to be expanded, simply add it
       return {
         ...state,
@@ -111,11 +114,9 @@ export default function courseCards(
       // if card doesn't exist, don't update
       if (!state[action.index]) return state;
 
-      // If there's a term-mismatch, ignore the action's new state and return the original
-      // Note the term is only sent in the action when there's a possibility of a mismatch
-      if (action.courseCard.term && state[action.index].term !== action.courseCard.term) {
-        return state;
-      }
+      // If there's a term-mismatch, return the original state
+      // Note the term is only sent in the action when there's a possiblity of a mismatch
+      if (action.term && term !== action.term) return state;
 
       // if card was expanded, collapse other cards
       if (action.courseCard.collapsed === false && state[action.index]?.collapsed !== false) {
@@ -128,14 +129,8 @@ export default function courseCards(
         [action.index]: { ...state[action.index], ...action.courseCard },
         numCardsCreated: Math.max(state.numCardsCreated, action.index + 1),
       };
-    case CLEAR_COURSE_CARDS:
+    case SET_TERM:
       return initialCourseCardArray;
-    case SET_TERM: {
-      // Really only do this to pass the tests
-      const ret = initialCourseCardArray;
-      ret[0].term = action.term;
-      return ret;
-    }
     default:
       return state;
   }

--- a/autoscheduler/frontend/src/redux/reducers/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/reducers/courseCards.ts
@@ -5,6 +5,7 @@
 import {
   CourseCardOptions, CourseCardArray, CustomizationLevel, SectionFilter,
 } from '../../types/CourseCardOptions';
+import { TermDataAction } from './termData';
 import { SetTermAction, SET_TERM } from './term';
 
 // action type strings
@@ -81,7 +82,7 @@ function getStateAfterExpanding(
 
 // reducer
 export default function courseCards(
-  state: CourseCardArray = initialCourseCardArray, action: CourseCardAction,
+  state: CourseCardArray = initialCourseCardArray, action: TermDataAction,
 ): CourseCardArray {
   switch (action.type) {
     case ADD_COURSE_CARD: {

--- a/autoscheduler/frontend/src/redux/reducers/schedules.ts
+++ b/autoscheduler/frontend/src/redux/reducers/schedules.ts
@@ -5,6 +5,7 @@
 import Meeting from '../../types/Meeting';
 import Schedule from '../../types/Schedule';
 import { TermDataAction } from '../actions/termData';
+import { SET_TERM } from './term';
 
 // action type strings
 export const ADD_SCHEDULE = 'ADD_SCHEDULE';
@@ -14,7 +15,7 @@ export const SAVE_SCHEDULE = 'SAVE_SCHEDULE';
 export const UNSAVE_SCHEDULE = 'UNSAVE_SCHEDULE';
 export const RENAME_SCHEDULE = 'RENAME_SCHEDULE';
 export const SET_SCHEDULES = 'SET_SCHEDULES';
-
+export const CLEAR_SCHEDULES = 'CLEAR_SCHEDULES';
 
 const initialSchedules: Schedule[] = [];
 
@@ -70,7 +71,9 @@ function getUniqueSchedules(allSchedules: Schedule[]): Schedule[] {
 }
 
 // reducer
-function schedules(state: Schedule[] = initialSchedules, action: TermDataAction): Schedule[] {
+function schedules(
+  state: Schedule[] = initialSchedules, action: TermDataAction, term: string,
+): Schedule[] {
   switch (action.type) {
     case ADD_SCHEDULE: {
       return [...state, createSchedule(action.meetings, state)];
@@ -110,7 +113,12 @@ function schedules(state: Schedule[] = initialSchedules, action: TermDataAction)
       return newState;
     }
     case SET_SCHEDULES:
+      // Check for a term mismatch and return the original state if there is one
+      if (action.term !== term) return state;
+
       return action.schedules;
+    case SET_TERM:
+      return [];
     default:
       return state;
   }

--- a/autoscheduler/frontend/src/redux/reducers/schedules.ts
+++ b/autoscheduler/frontend/src/redux/reducers/schedules.ts
@@ -4,6 +4,7 @@
  */
 import Meeting from '../../types/Meeting';
 import Schedule from '../../types/Schedule';
+import { TermDataAction } from './termData';
 
 // action type strings
 export const ADD_SCHEDULE = 'ADD_SCHEDULE';
@@ -101,7 +102,7 @@ function getUniqueSchedules(allSchedules: Schedule[]): Schedule[] {
 }
 
 // reducer
-function schedules(state: Schedule[] = initialSchedules, action: ScheduleAction): Schedule[] {
+function schedules(state: Schedule[] = initialSchedules, action: TermDataAction): Schedule[] {
   switch (action.type) {
     case ADD_SCHEDULE: {
       return [...state, createSchedule(action.meetings, state)];

--- a/autoscheduler/frontend/src/redux/reducers/schedules.ts
+++ b/autoscheduler/frontend/src/redux/reducers/schedules.ts
@@ -4,7 +4,7 @@
  */
 import Meeting from '../../types/Meeting';
 import Schedule from '../../types/Schedule';
-import { TermDataAction } from './termData';
+import { TermDataAction } from '../actions/termData';
 
 // action type strings
 export const ADD_SCHEDULE = 'ADD_SCHEDULE';
@@ -15,38 +15,6 @@ export const UNSAVE_SCHEDULE = 'UNSAVE_SCHEDULE';
 export const RENAME_SCHEDULE = 'RENAME_SCHEDULE';
 export const SET_SCHEDULES = 'SET_SCHEDULES';
 
-// action type interfaces
-export interface AddScheduleAction {
-    type: 'ADD_SCHEDULE';
-    meetings: Meeting[];
-}
-export interface RemoveScheduleAction {
-    type: 'REMOVE_SCHEDULE';
-    index: number;
-}
-export interface ReplaceSchedulesAction {
-    type: 'REPLACE_SCHEDULES';
-    schedules: Meeting[][];
-}
-export interface SaveScheduleAction {
-    type: 'SAVE_SCHEDULE';
-    index: number;
-}
-export interface UnsaveScheduleAction {
-    type: 'UNSAVE_SCHEDULE';
-    index: number;
-}
-export interface RenameScheduleAction {
-  type: 'RENAME_SCHEDULE';
-  index: number;
-  name: string;
-}
-export interface SetSchedulesAction {
-  type: 'SET_SCHEDULES';
-  schedules: Schedule[];
-}
-export type ScheduleAction = AddScheduleAction | RemoveScheduleAction | ReplaceSchedulesAction
-| SaveScheduleAction | UnsaveScheduleAction | RenameScheduleAction | SetSchedulesAction;
 
 const initialSchedules: Schedule[] = [];
 

--- a/autoscheduler/frontend/src/redux/reducers/term.ts
+++ b/autoscheduler/frontend/src/redux/reducers/term.ts
@@ -2,16 +2,10 @@
  * Stores the current term
  */
 
-import { TermDataAction } from './termData';
+import { TermDataAction } from '../actions/termData';
 
 // action type string
 export const SET_TERM = 'SET_TERM';
-
-// action type interface
-export interface SetTermAction {
-  type: 'SET_TERM';
-  term: string;
-}
 
 // reducer
 export default function term(state = '', action: TermDataAction): string {

--- a/autoscheduler/frontend/src/redux/reducers/term.ts
+++ b/autoscheduler/frontend/src/redux/reducers/term.ts
@@ -2,6 +2,8 @@
  * Stores the current term
  */
 
+import { TermDataAction } from './termData';
+
 // action type string
 export const SET_TERM = 'SET_TERM';
 
@@ -12,7 +14,7 @@ export interface SetTermAction {
 }
 
 // reducer
-export default function term(state = '', action: SetTermAction): string {
+export default function term(state = '', action: TermDataAction): string {
   switch (action.type) {
     case SET_TERM:
       return action.term;

--- a/autoscheduler/frontend/src/redux/reducers/termData.ts
+++ b/autoscheduler/frontend/src/redux/reducers/termData.ts
@@ -1,0 +1,23 @@
+import TermData from '../../types/TermData';
+import availability, { AvailabilityAction } from './availability';
+import courseCards, { CourseCardAction } from './courseCards';
+import schedules, { ScheduleAction } from './schedules';
+import term, { SetTermAction } from './term';
+
+export type TermDataAction = SetTermAction | ScheduleAction | AvailabilityAction | CourseCardAction;
+
+const initialState: TermData = {
+  term: undefined,
+  availability: undefined,
+  courseCards: undefined,
+  schedules: undefined,
+};
+
+export default function termData(state: TermData = initialState, action: TermDataAction): TermData {
+  return {
+    term: term(state.term, action),
+    schedules: schedules(state.schedules, action),
+    availability: availability(state.availability, action),
+    courseCards: courseCards(state.courseCards, action),
+  };
+}

--- a/autoscheduler/frontend/src/redux/reducers/termData.ts
+++ b/autoscheduler/frontend/src/redux/reducers/termData.ts
@@ -1,10 +1,9 @@
 import TermData from '../../types/TermData';
-import availability, { AvailabilityAction } from './availability';
-import courseCards, { CourseCardAction } from './courseCards';
-import schedules, { ScheduleAction } from './schedules';
-import term, { SetTermAction } from './term';
-
-export type TermDataAction = SetTermAction | ScheduleAction | AvailabilityAction | CourseCardAction;
+import { TermDataAction } from '../actions/termData';
+import availability from './availability';
+import courseCards from './courseCards';
+import schedules from './schedules';
+import term from './term';
 
 const initialState: TermData = {
   term: undefined,

--- a/autoscheduler/frontend/src/redux/reducers/termData.ts
+++ b/autoscheduler/frontend/src/redux/reducers/termData.ts
@@ -15,8 +15,8 @@ const initialState: TermData = {
 export default function termData(state: TermData = initialState, action: TermDataAction): TermData {
   return {
     term: term(state.term, action),
-    schedules: schedules(state.schedules, action),
-    availability: availability(state.availability, action),
-    courseCards: courseCards(state.courseCards, action),
+    schedules: schedules(state.schedules, action, state.term),
+    availability: availability(state.availability, action, state.term),
+    courseCards: courseCards(state.courseCards, action, state.term),
   };
 }

--- a/autoscheduler/frontend/src/tests/redux/Availability.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/Availability.test.ts
@@ -10,6 +10,7 @@ import {
 import 'isomorphic-fetch';
 import Availability, { AvailabilityType, argsToAvailability, AvailabilityArgs } from '../../types/Availability';
 import DayOfWeek from '../../types/DayOfWeek';
+import setTerm from '../../redux/actions/term';
 
 /**
  * Converts a pair of hours and minutes into a number of minutes past midnight
@@ -464,6 +465,7 @@ describe('Availabilities', () => {
     test('when setAvailabilities is called', () => {
       // arrange
       const store = createStore(autoSchedulerReducer);
+      store.dispatch(setTerm('202031'));
       const expected: Availability[] = [{
         ...dummyArgs,
         startTimeHours: 10,
@@ -473,10 +475,32 @@ describe('Availabilities', () => {
       }];
 
       // act
-      store.dispatch(setAvailabilities(expected));
+      store.dispatch(setAvailabilities(expected, '202031'));
 
       // assert
       expect(store.getState().termData.availability).toEqual(expected);
+    });
+  });
+
+  describe('skips set availabilities', () => {
+    test("when there's a term mismatch", () => {
+      // arrange
+      const store = createStore(autoSchedulerReducer);
+      store.dispatch(setTerm('202031'));
+
+      const mismatchedAvails: Availability[] = [{
+        ...dummyArgs,
+        startTimeHours: 10,
+        startTimeMinutes: 0,
+        endTimeHours: 11,
+        endTimeMinutes: 0,
+      }];
+
+      // act
+      store.dispatch(setAvailabilities(mismatchedAvails, '201931')); // mismatched term
+
+      // assert
+      expect(store.getState().termData.availability.length).toEqual(0);
     });
   });
 });

--- a/autoscheduler/frontend/src/tests/redux/Availability.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/Availability.test.ts
@@ -51,7 +51,7 @@ describe('Availabilities', () => {
       store.dispatch(mergeAvailability());
 
       // assert
-      expect(store.getState().availability).toEqual(expected);
+      expect(store.getState().termData.availability).toEqual(expected);
     });
 
     test('if the new one starts when the old one ends', () => {
@@ -81,7 +81,7 @@ describe('Availabilities', () => {
       store.dispatch(mergeAvailability());
 
       // assert
-      expect(store.getState().availability).toEqual(expected);
+      expect(store.getState().termData.availability).toEqual(expected);
     });
 
     test('with overlaps on both ends', () => {
@@ -117,7 +117,7 @@ describe('Availabilities', () => {
       store.dispatch(mergeAvailability());
 
       // assert
-      expect(store.getState().availability).toEqual(expected);
+      expect(store.getState().termData.availability).toEqual(expected);
     });
 
     test('only once when 3 or more coincide', () => {
@@ -187,31 +187,33 @@ describe('Availabilities', () => {
       store.dispatch(mergeAvailability());
 
       // assert
-      expect(store.getState().availability).toEqual(expected);
+      expect(store.getState().termData.availability).toEqual(expected);
     });
 
     test('when dragging an old availability', () => {
       // arrrange
       const preloadedState = {
-        availability: [{
-          ...dummyArgs,
-          startTimeHours: 17,
-          startTimeMinutes: 40,
-          endTimeHours: 18,
-          endTimeMinutes: 10,
-        }, {
-          ...dummyArgs,
-          startTimeHours: 17,
-          startTimeMinutes: 40,
-          endTimeHours: 18,
-          endTimeMinutes: 50,
-        }, {
-          ...dummyArgs,
-          startTimeHours: 13,
-          startTimeMinutes: 0,
-          endTimeHours: 17,
-          endTimeMinutes: 10,
-        }],
+        termData: {
+          availability: [{
+            ...dummyArgs,
+            startTimeHours: 17,
+            startTimeMinutes: 40,
+            endTimeHours: 18,
+            endTimeMinutes: 10,
+          }, {
+            ...dummyArgs,
+            startTimeHours: 17,
+            startTimeMinutes: 40,
+            endTimeHours: 18,
+            endTimeMinutes: 50,
+          }, {
+            ...dummyArgs,
+            startTimeHours: 13,
+            startTimeMinutes: 0,
+            endTimeHours: 17,
+            endTimeMinutes: 10,
+          }],
+        },
       };
       const store = createStore(autoSchedulerReducer, preloadedState);
       const updateArgs: AvailabilityArgs = {
@@ -239,9 +241,9 @@ describe('Availabilities', () => {
       store.dispatch(mergeAvailability());
 
       // assert
-      expect(store.getState().availability).toHaveLength(2);
-      expect(store.getState().availability).toContainEqual(expectedAv1);
-      expect(store.getState().availability).toContainEqual(expectedAv2);
+      expect(store.getState().termData.availability).toHaveLength(2);
+      expect(store.getState().termData.availability).toContainEqual(expectedAv1);
+      expect(store.getState().termData.availability).toContainEqual(expectedAv2);
     });
 
     test('if multiple availabilities are created at once with a single overlap', () => {
@@ -289,7 +291,7 @@ describe('Availabilities', () => {
       store.dispatch(mergeAvailability(3));
 
       // assert - the Tuesday av is merged but monday is not
-      const finalAvailabilties = store.getState().availability;
+      const finalAvailabilties = store.getState().termData.availability;
       expect(finalAvailabilties).toContainEqual<Availability>({
         dayOfWeek: DayOfWeek.MON,
         ...unmergedAvailability,
@@ -347,7 +349,7 @@ describe('Availabilities', () => {
       };
       // helpers to make assertion easy to read
       const availabilityOn = (day: DayOfWeek):
-        Availability => store.getState().availability.find((av) => av.dayOfWeek === day);
+        Availability => store.getState().termData.availability.find((av) => av.dayOfWeek === day);
 
       // act
       store.dispatch(addAvailability({
@@ -401,7 +403,7 @@ describe('Availabilities', () => {
       store.dispatch(addAvailability(availability2));
 
       // assert
-      expect(store.getState().availability).toEqual(expected);
+      expect(store.getState().termData.availability).toEqual(expected);
     });
   });
 
@@ -420,7 +422,7 @@ describe('Availabilities', () => {
       store.dispatch(deleteAvailability(availability1));
 
       // assert
-      expect(store.getState().availability).toHaveLength(0);
+      expect(store.getState().termData.availability).toHaveLength(0);
     });
   });
 
@@ -454,7 +456,7 @@ describe('Availabilities', () => {
       }));
 
       // assert
-      expect(store.getState().availability).toEqual(expected);
+      expect(store.getState().termData.availability).toEqual(expected);
     });
   });
 
@@ -474,7 +476,7 @@ describe('Availabilities', () => {
       store.dispatch(setAvailabilities(expected));
 
       // assert
-      expect(store.getState().availability).toEqual(expected);
+      expect(store.getState().termData.availability).toEqual(expected);
     });
   });
 });

--- a/autoscheduler/frontend/src/tests/redux/CourseCards.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/CourseCards.test.ts
@@ -29,7 +29,7 @@ describe('Course Cards Redux', () => {
     const store = createStore(autoSchedulerReducer);
 
     // asssert
-    expect(store.getState().courseCards).toMatchObject({
+    expect(store.getState().termData.courseCards).toMatchObject({
       0: {
         course: '',
         customizationLevel: CustomizationLevel.BASIC,
@@ -340,7 +340,7 @@ describe('Course Cards Redux', () => {
       store.dispatch(clearCourseCards());
 
       // assert
-      expect(store.getState().courseCards).toMatchObject(expected);
+      expect(store.getState().termData.courseCards).toMatchObject(expected);
     });
   });
 
@@ -375,7 +375,7 @@ describe('Course Cards Redux', () => {
       await new Promise(setImmediate);
 
       // assert
-      expect(store.getState().courseCards).toMatchObject(expectedCourseCards);
+      expect(store.getState().termData.courseCards).toMatchObject(expectedCourseCards);
     });
 
     test('adds new sections for course cards', async () => {
@@ -402,7 +402,7 @@ describe('Course Cards Redux', () => {
 
       // assert
       // testFetch with a MATH course has 1 section, which should be added
-      expect(store.getState().courseCards[0].sections).toHaveLength(1);
+      expect(store.getState().termData.courseCards[0].sections).toHaveLength(1);
     });
 
     test('keeps selected sections from courseCards', async () => {
@@ -433,7 +433,7 @@ describe('Course Cards Redux', () => {
 
       // assert
       // testFetch with a MATH course has 1 section
-      expect(store.getState().courseCards[0].sections[0].selected).toBeTruthy();
+      expect(store.getState().termData.courseCards[0].sections[0].selected).toBeTruthy();
     });
 
     test('maintains card order when fetches finish out of order', async () => {
@@ -441,7 +441,7 @@ describe('Course Cards Redux', () => {
       const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
       // wait for second course card to be created to add the first one
       fetchMock.mockImplementationOnce(async (course: string) => {
-        await waitFor(() => store.getState().courseCards[1]);
+        await waitFor(() => store.getState().termData.courseCards[1]);
         return testFetch(course);
       });
       fetchMock.mockImplementationOnce(testFetch);
@@ -465,9 +465,9 @@ describe('Course Cards Redux', () => {
       await new Promise(setImmediate);
 
       // assert
-      expect(store.getState().courseCards.numCardsCreated).toEqual(2);
-      expect(store.getState().courseCards[0].course).toEqual('CSCE 121');
-      expect(store.getState().courseCards[1].course).toEqual('MATH 151');
+      expect(store.getState().termData.courseCards.numCardsCreated).toEqual(2);
+      expect(store.getState().termData.courseCards[0].course).toEqual('CSCE 121');
+      expect(store.getState().termData.courseCards[1].course).toEqual('MATH 151');
     });
   });
 
@@ -480,8 +480,8 @@ describe('Course Cards Redux', () => {
       store.dispatch(addCourseCard('202031'));
 
       // assert
-      expect(store.getState().courseCards.numCardsCreated).toEqual(2);
-      expect(store.getState().courseCards[1]).not.toBeUndefined();
+      expect(store.getState().termData.courseCards.numCardsCreated).toEqual(2);
+      expect(store.getState().termData.courseCards[1]).not.toBeUndefined();
     });
 
     test('collapses other cards and expands the new one', () => {
@@ -490,12 +490,12 @@ describe('Course Cards Redux', () => {
 
       // act
       // precondition: initial course card is expanded
-      expect(store.getState().courseCards[0].collapsed).toBe(false);
+      expect(store.getState().termData.courseCards[0].collapsed).toBe(false);
       store.dispatch(addCourseCard('202031'));
 
       // assert
-      expect(store.getState().courseCards[0].collapsed).toBe(true);
-      expect(store.getState().courseCards[1].collapsed).toBe(false);
+      expect(store.getState().termData.courseCards[0].collapsed).toBe(true);
+      expect(store.getState().termData.courseCards[1].collapsed).toBe(false);
     });
   });
 
@@ -510,9 +510,9 @@ describe('Course Cards Redux', () => {
       store.dispatch(removeCourseCard(1));
 
       // assert
-      expect(store.getState().courseCards.numCardsCreated).toEqual(3);
-      expect(store.getState().courseCards[1]).toBeUndefined();
-      expect(store.getState().courseCards[2]).not.toBeUndefined();
+      expect(store.getState().termData.courseCards.numCardsCreated).toEqual(3);
+      expect(store.getState().termData.courseCards[1]).toBeUndefined();
+      expect(store.getState().termData.courseCards[2]).not.toBeUndefined();
     });
 
     describe('when deleting the expanded card', () => {
@@ -527,10 +527,10 @@ describe('Course Cards Redux', () => {
         store.dispatch(removeCourseCard(1));
 
         // assert
-        expect(store.getState().courseCards.numCardsCreated).toEqual(3);
-        expect(store.getState().courseCards[0].collapsed).toBe(false);
-        expect(store.getState().courseCards[1]).toBeUndefined();
-        expect(store.getState().courseCards[2].collapsed).toBe(true);
+        expect(store.getState().termData.courseCards.numCardsCreated).toEqual(3);
+        expect(store.getState().termData.courseCards[0].collapsed).toBe(false);
+        expect(store.getState().termData.courseCards[1]).toBeUndefined();
+        expect(store.getState().termData.courseCards[2].collapsed).toBe(true);
       });
 
       test("expands the one above if there isn't one below it", () => {
@@ -542,9 +542,9 @@ describe('Course Cards Redux', () => {
         store.dispatch(removeCourseCard(1));
 
         // assert
-        expect(store.getState().courseCards.numCardsCreated).toEqual(2);
-        expect(store.getState().courseCards[0].collapsed).toBe(false);
-        expect(store.getState().courseCards[1]).toBeUndefined();
+        expect(store.getState().termData.courseCards.numCardsCreated).toEqual(2);
+        expect(store.getState().termData.courseCards[0].collapsed).toBe(false);
+        expect(store.getState().termData.courseCards[1]).toBeUndefined();
       });
 
       test('leaves no cards if no other ones exist', () => {
@@ -555,8 +555,8 @@ describe('Course Cards Redux', () => {
         store.dispatch(removeCourseCard(0));
 
         // assert
-        expect(store.getState().courseCards.numCardsCreated).toEqual(1);
-        expect(store.getState().courseCards[0]).toBeUndefined();
+        expect(store.getState().termData.courseCards.numCardsCreated).toEqual(1);
+        expect(store.getState().termData.courseCards[0]).toBeUndefined();
       });
     });
   });
@@ -571,7 +571,7 @@ describe('Course Cards Redux', () => {
       store.dispatch<any>(updateCourseCard(0, { course: 'PSYC 107' }, '201931'));
 
       // assert
-      expect(store.getState().courseCards[0].course).toEqual('PSYC 107');
+      expect(store.getState().termData.courseCards[0].course).toEqual('PSYC 107');
     });
 
     test('Updates course card basic filter options', () => {
@@ -585,9 +585,9 @@ describe('Course Cards Redux', () => {
       store.dispatch<any>(updateCourseCard(0, { asynchronous: 'exclude' }));
 
       // assert
-      expect(store.getState().courseCards[0].remote).toBe('exclude');
-      expect(store.getState().courseCards[0].honors).toBe('only');
-      expect(store.getState().courseCards[0].asynchronous).toBe('exclude');
+      expect(store.getState().termData.courseCards[0].remote).toBe('exclude');
+      expect(store.getState().termData.courseCards[0].honors).toBe('only');
+      expect(store.getState().termData.courseCards[0].asynchronous).toBe('exclude');
     });
 
     test('collapses other cards and expands the provided one when given collapsed: false', () => {
@@ -597,13 +597,13 @@ describe('Course Cards Redux', () => {
 
       // act
       // precondition: second course card should be expanded
-      expect(store.getState().courseCards[1].collapsed).toBe(false);
+      expect(store.getState().termData.courseCards[1].collapsed).toBe(false);
 
       store.dispatch<any>(updateCourseCard(0, { collapsed: false }, '201931'));
 
       // assert
-      expect(store.getState().courseCards[0].collapsed).toBe(false);
-      expect(store.getState().courseCards[1].collapsed).toBe(true);
+      expect(store.getState().termData.courseCards[0].collapsed).toBe(false);
+      expect(store.getState().termData.courseCards[1].collapsed).toBe(true);
     });
 
     describe('rejects an update', () => {
@@ -618,7 +618,7 @@ describe('Course Cards Redux', () => {
 
         // assert
         // assert that the current course card is the original term's value
-        expect(store.getState().courseCards[0].remote).toEqual('exclude');
+        expect(store.getState().termData.courseCards[0].remote).toEqual('exclude');
       });
     });
   });

--- a/autoscheduler/frontend/src/tests/redux/Schedule.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/Schedule.test.ts
@@ -163,8 +163,8 @@ describe('Schedule Redux', () => {
       store.dispatch(addSchedule(schedule2));
 
       // assert
-      expect(store.getState().schedules[0].meetings).toEqual(schedule1);
-      expect(store.getState().schedules[1].meetings).toEqual(schedule2);
+      expect(store.getState().termData.schedules[0].meetings).toEqual(schedule1);
+      expect(store.getState().termData.schedules[1].meetings).toEqual(schedule2);
     });
   });
 
@@ -180,9 +180,9 @@ describe('Schedule Redux', () => {
       store.dispatch(removeSchedule(0));
 
       // assert
-      expect(store.getState().schedules).toHaveLength(2);
-      expect(store.getState().schedules[0].meetings).toEqual(schedule2);
-      expect(store.getState().schedules[1].meetings).toEqual(schedule3);
+      expect(store.getState().termData.schedules).toHaveLength(2);
+      expect(store.getState().termData.schedules[0].meetings).toEqual(schedule2);
+      expect(store.getState().termData.schedules[1].meetings).toEqual(schedule3);
     });
 
     test('when the middle schedule is deleted', () => {
@@ -196,9 +196,9 @@ describe('Schedule Redux', () => {
       store.dispatch(removeSchedule(1));
 
       // assert
-      expect(store.getState().schedules).toHaveLength(2);
-      expect(store.getState().schedules[0].meetings).toEqual(schedule1);
-      expect(store.getState().schedules[1].meetings).toEqual(schedule3);
+      expect(store.getState().termData.schedules).toHaveLength(2);
+      expect(store.getState().termData.schedules[0].meetings).toEqual(schedule1);
+      expect(store.getState().termData.schedules[1].meetings).toEqual(schedule3);
     });
 
     test('when the last schedule is deleted', () => {
@@ -212,9 +212,9 @@ describe('Schedule Redux', () => {
       store.dispatch(removeSchedule(2));
 
       // assert
-      expect(store.getState().schedules).toHaveLength(2);
-      expect(store.getState().schedules[0].meetings).toEqual(schedule1);
-      expect(store.getState().schedules[1].meetings).toEqual(schedule2);
+      expect(store.getState().termData.schedules).toHaveLength(2);
+      expect(store.getState().termData.schedules[0].meetings).toEqual(schedule1);
+      expect(store.getState().termData.schedules[1].meetings).toEqual(schedule2);
     });
   });
 
@@ -228,9 +228,9 @@ describe('Schedule Redux', () => {
       store.dispatch(replaceSchedules([schedule2, schedule3]));
 
       // assert
-      expect(store.getState().schedules).toHaveLength(2);
-      expect(store.getState().schedules[0].meetings).toEqual(schedule2);
-      expect(store.getState().schedules[1].meetings).toEqual(schedule3);
+      expect(store.getState().termData.schedules).toHaveLength(2);
+      expect(store.getState().termData.schedules[0].meetings).toEqual(schedule2);
+      expect(store.getState().termData.schedules[1].meetings).toEqual(schedule3);
     });
 
     test('when a schedule is saved and then unsaved', () => {
@@ -244,9 +244,9 @@ describe('Schedule Redux', () => {
       store.dispatch(replaceSchedules([schedule2, schedule3]));
 
       // assert
-      expect(store.getState().schedules).toHaveLength(2);
-      expect(store.getState().schedules[0].meetings).toEqual(schedule2);
-      expect(store.getState().schedules[1].meetings).toEqual(schedule3);
+      expect(store.getState().termData.schedules).toHaveLength(2);
+      expect(store.getState().termData.schedules[0].meetings).toEqual(schedule2);
+      expect(store.getState().termData.schedules[1].meetings).toEqual(schedule3);
     });
   });
 
@@ -261,13 +261,13 @@ describe('Schedule Redux', () => {
       store.dispatch(replaceSchedules([schedule2, schedule3]));
 
       // assert
-      expect(store.getState().schedules).toHaveLength(3);
-      expect(store.getState().schedules[0]).toMatchObject({
+      expect(store.getState().termData.schedules).toHaveLength(3);
+      expect(store.getState().termData.schedules[0]).toMatchObject({
         meetings: schedule1,
         saved: true,
       });
-      expect(store.getState().schedules[1].meetings).toEqual(schedule2);
-      expect(store.getState().schedules[2].meetings).toEqual(schedule3);
+      expect(store.getState().termData.schedules[1].meetings).toEqual(schedule2);
+      expect(store.getState().termData.schedules[2].meetings).toEqual(schedule3);
     });
 
     test('when the new schedules contain a schedule identical to a saved one', () => {
@@ -283,8 +283,8 @@ describe('Schedule Redux', () => {
 
       // assert
       // only one schedule should be saved since the schedules are equal
-      expect(store.getState().schedules).toHaveLength(1);
-      expect(store.getState().schedules[0].meetings).toEqual(schedule1);
+      expect(store.getState().termData.schedules).toHaveLength(1);
+      expect(store.getState().termData.schedules[0].meetings).toEqual(schedule1);
     });
   });
 
@@ -300,12 +300,12 @@ describe('Schedule Redux', () => {
       store.dispatch(replaceSchedules([schedule3]));
 
       // assert
-      expect(store.getState().schedules).toHaveLength(2);
-      expect(store.getState().schedules[0]).toMatchObject({
+      expect(store.getState().termData.schedules).toHaveLength(2);
+      expect(store.getState().termData.schedules[0]).toMatchObject({
         meetings: schedule2,
         saved: true,
       });
-      expect(store.getState().schedules[1].meetings).toEqual(schedule3);
+      expect(store.getState().termData.schedules[1].meetings).toEqual(schedule3);
     });
   });
 
@@ -322,8 +322,8 @@ describe('Schedule Redux', () => {
       store.dispatch(unsaveSchedule(0));
 
       // assert
-      expect(store.getState().schedules[0].saved).toBe(false);
-      expect(store.getState().schedules[1].saved).toBe(true);
+      expect(store.getState().termData.schedules[0].saved).toBe(false);
+      expect(store.getState().termData.schedules[1].saved).toBe(true);
     });
 
     test('when the schedule at a non-zero index is unsaved', () => {
@@ -338,8 +338,8 @@ describe('Schedule Redux', () => {
       store.dispatch(unsaveSchedule(1));
 
       // assert
-      expect(store.getState().schedules[0].saved).toBe(true);
-      expect(store.getState().schedules[1].saved).toBe(false);
+      expect(store.getState().termData.schedules[0].saved).toBe(true);
+      expect(store.getState().termData.schedules[1].saved).toBe(false);
     });
   });
 
@@ -347,13 +347,15 @@ describe('Schedule Redux', () => {
     test('when the first schedule is renamed', () => {
       // arrange
       const store = createStore(autoSchedulerReducer, {
-        schedules: [
-          {
-            meetings: schedule1,
-            name: 'Schedule 1',
-            saved: false,
-          },
-        ],
+        termData: {
+          schedules: [
+            {
+              meetings: schedule1,
+              name: 'Schedule 1',
+              saved: false,
+            },
+          ],
+        },
       });
       const scheduleName = 'Test schedule';
 
@@ -361,24 +363,26 @@ describe('Schedule Redux', () => {
       store.dispatch(renameSchedule(0, scheduleName));
 
       // assert
-      expect(store.getState().schedules[0].name).toBe(scheduleName);
+      expect(store.getState().termData.schedules[0].name).toBe(scheduleName);
     });
 
     test('when the second schedule is renamed', () => {
       // arrange
       const store = createStore(autoSchedulerReducer, {
-        schedules: [
-          {
-            meetings: schedule1,
-            name: 'Schedule 1',
-            saved: false,
-          },
-          {
-            meetings: schedule2,
-            name: 'Schedule 2',
-            saved: false,
-          },
-        ],
+        termData: {
+          schedules: [
+            {
+              meetings: schedule1,
+              name: 'Schedule 1',
+              saved: false,
+            },
+            {
+              meetings: schedule2,
+              name: 'Schedule 2',
+              saved: false,
+            },
+          ],
+        },
       });
       const scheduleName = 'Test schedule';
 
@@ -386,7 +390,7 @@ describe('Schedule Redux', () => {
       store.dispatch(renameSchedule(1, scheduleName));
 
       // assert
-      expect(store.getState().schedules[1].name).toBe(scheduleName);
+      expect(store.getState().termData.schedules[1].name).toBe(scheduleName);
     });
   });
 
@@ -396,25 +400,29 @@ describe('Schedule Redux', () => {
       // arrange
       const schedule1Name = 'Schedule 1';
       const store = createStore(autoSchedulerReducer, {
-        schedules: [
-          {
-            meetings: schedule1,
-            name: schedule1Name,
-            saved: false,
-          },
-          {
-            meetings: schedule2,
-            name: 'Schedule 2',
-            saved: false,
-          },
-        ],
+        termData: {
+          schedules: [
+            {
+              meetings: schedule1,
+              name: schedule1Name,
+              saved: false,
+            },
+            {
+              meetings: schedule2,
+              name: 'Schedule 2',
+              saved: false,
+            },
+          ],
+        },
       });
 
       // act
       store.dispatch(renameSchedule(1, schedule1Name));
 
       // assert
-      const uniqueNames = new Set(store.getState().schedules.map((schedule) => schedule.name));
+      const uniqueNames = new Set(
+        store.getState().termData.schedules.map((schedule) => schedule.name),
+      );
       expect(uniqueNames.size).toBe(2);
     });
 
@@ -426,13 +434,15 @@ describe('Schedule Redux', () => {
       // act
       store.dispatch(replaceSchedules([schedule1]));
       // condition for test to be valid: first generated schedule should have defaultScheduleName
-      expect(store.getState().schedules[0].name).toBe(defaultScheduleName);
+      expect(store.getState().termData.schedules[0].name).toBe(defaultScheduleName);
       store.dispatch(saveSchedule(0));
       store.dispatch(replaceSchedules([schedule2]));
 
       // assert
       // new schedule should have been generated with the name 'Schedule 1'
-      const uniqueNames = new Set(store.getState().schedules.map((schedule) => schedule.name));
+      const uniqueNames = new Set(
+        store.getState().termData.schedules.map((schedule) => schedule.name),
+      );
       expect(uniqueNames.size).toBe(2);
     });
   });

--- a/autoscheduler/frontend/src/tests/redux/Schedule.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/Schedule.test.ts
@@ -2,11 +2,12 @@ import { createStore } from 'redux';
 import autoSchedulerReducer from '../../redux/reducer';
 import {
   addSchedule, removeSchedule, replaceSchedules, saveSchedule,
-  unsaveSchedule, renameSchedule,
+  unsaveSchedule, renameSchedule, setSchedules,
 } from '../../redux/actions/schedules';
 import Meeting, { MeetingType } from '../../types/Meeting';
 import Section from '../../types/Section';
 import Instructor from '../../types/Instructor';
+import setTerm from '../../redux/actions/term';
 
 const testSectionA = new Section({
   id: 123456,
@@ -444,6 +445,47 @@ describe('Schedule Redux', () => {
         store.getState().termData.schedules.map((schedule) => schedule.name),
       );
       expect(uniqueNames.size).toBe(2);
+    });
+  });
+
+  describe('sets schedules', () => {
+    test('when the terms match up', () => {
+      // arrange
+      const store = createStore(autoSchedulerReducer);
+      store.dispatch(setTerm('202031'));
+
+      const fullSchedule1 = {
+        name: 'Name1',
+        meetings: schedule1,
+        saved: true,
+      };
+
+      // act
+      store.dispatch(setSchedules([fullSchedule1], '202031'));
+
+      // assert
+      expect(store.getState().termData.schedules.length).toEqual(1);
+      expect(store.getState().termData.schedules[0]).toEqual(fullSchedule1);
+    });
+  });
+
+  describe('skips set schedules', () => {
+    test("when there's a term mismatch", () => {
+      // arrange
+      const store = createStore(autoSchedulerReducer);
+      store.dispatch(setTerm('202031'));
+
+      const fullSchedule1 = {
+        name: 'Name1',
+        meetings: schedule1,
+        saved: true,
+      };
+
+      // act
+      store.dispatch(setSchedules([fullSchedule1], '201931'));
+
+      // assert
+      expect(store.getState().termData.schedules.length).toEqual(0);
     });
   });
 });

--- a/autoscheduler/frontend/src/tests/redux/SchedulingPage.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/SchedulingPage.test.ts
@@ -14,7 +14,7 @@ describe('Scheduling Page Redux', () => {
       store.dispatch(addSchedule(testSchedule2));
 
       // assert
-      const { schedules } = store.getState();
+      const { schedules } = store.getState().termData;
       expect(schedules).toHaveLength(2);
       expect(schedules[0].meetings).toEqual(testSchedule1);
       expect(schedules[1].meetings).toEqual(testSchedule2);
@@ -28,7 +28,7 @@ describe('Scheduling Page Redux', () => {
       store.dispatch(replaceSchedules([testSchedule1, testSchedule2]));
 
       // assert
-      const { schedules } = store.getState();
+      const { schedules } = store.getState().termData;
       expect(schedules).toHaveLength(2);
       expect(schedules[0].meetings).toEqual(testSchedule1);
       expect(schedules[1].meetings).toEqual(testSchedule2);
@@ -44,7 +44,7 @@ describe('Scheduling Page Redux', () => {
       store.dispatch(replaceSchedules([testSchedule2]));
 
       // assert
-      const { schedules } = store.getState();
+      const { schedules } = store.getState().termData;
       expect(schedules).toHaveLength(1);
       expect(schedules[0].meetings).toEqual(testSchedule2);
     });
@@ -58,7 +58,7 @@ describe('Scheduling Page Redux', () => {
       store.dispatch(addSchedule(testSchedule2));
 
       // assert
-      const { schedules } = store.getState();
+      const { schedules } = store.getState().termData;
       expect(schedules).toHaveLength(1);
       expect(schedules[0].meetings).toEqual(testSchedule2);
     });
@@ -74,7 +74,7 @@ describe('Scheduling Page Redux', () => {
       store.dispatch(removeSchedule(0));
 
       // assert
-      const { schedules } = store.getState();
+      const { schedules } = store.getState().termData;
       expect(schedules).toHaveLength(1);
       expect(schedules[0].meetings).toEqual(testSchedule2);
     });

--- a/autoscheduler/frontend/src/tests/redux/Term.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/Term.test.ts
@@ -12,6 +12,6 @@ describe('Terms redux', () => {
     store.dispatch(setTerm(term));
 
     // assert
-    expect(store.getState().term).toEqual(term);
+    expect(store.getState().termData.term).toEqual(term);
   });
 });

--- a/autoscheduler/frontend/src/tests/types/Availability.test.ts
+++ b/autoscheduler/frontend/src/tests/types/Availability.test.ts
@@ -39,7 +39,7 @@ describe('roundUpAvailability()', () => {
       store.dispatch(mergeAvailability());
 
       // assert
-      expect(store.getState().availability).toEqual(expectedResult);
+      expect(store.getState().termData.availability).toEqual(expectedResult);
     });
 
     test('if the user starts within 30 minutes of the last hour and drags down', () => {
@@ -63,7 +63,7 @@ describe('roundUpAvailability()', () => {
       store.dispatch(mergeAvailability());
 
       // assert
-      expect(store.getState().availability).toEqual(expectedResult);
+      expect(store.getState().termData.availability).toEqual(expectedResult);
     });
   });
   describe('expands in the direction of dragging', () => {
@@ -90,7 +90,7 @@ describe('roundUpAvailability()', () => {
       store.dispatch(mergeAvailability());
 
       // assert
-      expect(store.getState().availability).toEqual(expectedResult);
+      expect(store.getState().termData.availability).toEqual(expectedResult);
     });
 
     test('if the user starts after 20:30 and drags up', () => {
@@ -116,7 +116,7 @@ describe('roundUpAvailability()', () => {
       store.dispatch(mergeAvailability());
 
       // assert
-      expect(store.getState().availability).toEqual(expectedResult);
+      expect(store.getState().termData.availability).toEqual(expectedResult);
     });
 
     test('if the user drags upward in the middle of the day', () => {
@@ -142,7 +142,7 @@ describe('roundUpAvailability()', () => {
       store.dispatch(mergeAvailability());
 
       // assert
-      expect(store.getState().availability).toEqual(expectedResult);
+      expect(store.getState().termData.availability).toEqual(expectedResult);
     });
   });
 });

--- a/autoscheduler/frontend/src/tests/ui/BasicSelect.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/BasicSelect.test.tsx
@@ -23,7 +23,7 @@ describe('BasicSelect', () => {
               hasAsynchronous: true,
             },
           },
-        }
+        },
       }, applyMiddleware(thunk));
       const { queryByRole, getByLabelText, findByText } = render(
         <Provider store={store}>
@@ -52,7 +52,7 @@ describe('BasicSelect', () => {
               hasAsynchronous: true,
             },
           },
-        }
+        },
       }, applyMiddleware(thunk));
       const { queryByRole, getByLabelText, findByText } = render(
         <Provider store={store}>
@@ -81,7 +81,7 @@ describe('BasicSelect', () => {
               hasAsynchronous: true,
             },
           },
-        }
+        },
       }, applyMiddleware(thunk));
       const { queryByRole, getByLabelText, findByText } = render(
         <Provider store={store}>

--- a/autoscheduler/frontend/src/tests/ui/BasicSelect.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/BasicSelect.test.tsx
@@ -13,15 +13,17 @@ describe('BasicSelect', () => {
     test('when the user changes Honors to Only', async () => {
       // arrange
       const store = createStore(autoSchedulerReducer, {
-        courseCards: {
-          0: {
-            course: 'MATH 151',
-            customizationLevel: CustomizationLevel.BASIC,
-            hasHonors: true,
-            hasRemote: true,
-            hasAsynchronous: true,
+        termData: {
+          courseCards: {
+            0: {
+              course: 'MATH 151',
+              customizationLevel: CustomizationLevel.BASIC,
+              hasHonors: true,
+              hasRemote: true,
+              hasAsynchronous: true,
+            },
           },
-        },
+        }
       }, applyMiddleware(thunk));
       const { queryByRole, getByLabelText, findByText } = render(
         <Provider store={store}>
@@ -40,15 +42,17 @@ describe('BasicSelect', () => {
     test('when the user changes Remote to Only', async () => {
       // arrange
       const store = createStore(autoSchedulerReducer, {
-        courseCards: {
-          0: {
-            course: 'MATH 151',
-            customizationLevel: CustomizationLevel.BASIC,
-            hasHonors: true,
-            hasRemote: true,
-            hasAsynchronous: true,
+        termData: {
+          courseCards: {
+            0: {
+              course: 'MATH 151',
+              customizationLevel: CustomizationLevel.BASIC,
+              hasHonors: true,
+              hasRemote: true,
+              hasAsynchronous: true,
+            },
           },
-        },
+        }
       }, applyMiddleware(thunk));
       const { queryByRole, getByLabelText, findByText } = render(
         <Provider store={store}>
@@ -67,15 +71,17 @@ describe('BasicSelect', () => {
     test('when the user changes Asynchronous to Only', async () => {
       // arrange
       const store = createStore(autoSchedulerReducer, {
-        courseCards: {
-          0: {
-            course: 'MATH 151',
-            customizationLevel: CustomizationLevel.BASIC,
-            hasHonors: true,
-            hasRemote: true,
-            hasAsynchronous: true,
+        termData: {
+          courseCards: {
+            0: {
+              course: 'MATH 151',
+              customizationLevel: CustomizationLevel.BASIC,
+              hasHonors: true,
+              hasRemote: true,
+              hasAsynchronous: true,
+            },
           },
-        },
+        }
       }, applyMiddleware(thunk));
       const { queryByRole, getByLabelText, findByText } = render(
         <Provider store={store}>

--- a/autoscheduler/frontend/src/tests/ui/ConfigureCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/ConfigureCard.test.tsx
@@ -93,7 +93,7 @@ describe('ConfigureCard component', () => {
       // Doesn't need to return anything valid
       fetchMock.mockOnce('[]'); // mocks scheduler/generate call
 
-      const getCardSections = (): SectionSelected[] => store.getState().courseCards[0].sections;
+      const getCardSections = (): SectionSelected[] => store.getState().termData.courseCards[0].sections;
       // wait for Redux to fill in sections
       await waitFor(() => expect(getCardSections()).not.toHaveLength(0));
 
@@ -146,7 +146,7 @@ describe('ConfigureCard component', () => {
         course: 'CSCE 121',
       }, term));
 
-      const cardSections = store.getState().courseCards[0].sections;
+      const cardSections = store.getState().termData.courseCards[0].sections;
 
       // Make all of the sections selected
       store.dispatch<any>(updateCourseCard(0, {
@@ -195,7 +195,7 @@ describe('ConfigureCard component', () => {
         course: 'CSCE 121',
       }, '201931'));
 
-      const cardSections = store.getState().courseCards[0].sections;
+      const cardSections = store.getState().termData.courseCards[0].sections;
 
       // Make all of the sections selected
       store.dispatch<any>(updateCourseCard(0, {

--- a/autoscheduler/frontend/src/tests/ui/ConfigureCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/ConfigureCard.test.tsx
@@ -93,7 +93,9 @@ describe('ConfigureCard component', () => {
       // Doesn't need to return anything valid
       fetchMock.mockOnce('[]'); // mocks scheduler/generate call
 
-      const getCardSections = (): SectionSelected[] => store.getState().termData.courseCards[0].sections;
+      const getCardSections = (): SectionSelected[] => (
+        store.getState().termData.courseCards[0].sections
+      );
       // wait for Redux to fill in sections
       await waitFor(() => expect(getCardSections()).not.toHaveLength(0));
 

--- a/autoscheduler/frontend/src/tests/ui/NavBar.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/NavBar.test.tsx
@@ -11,7 +11,6 @@ import { Provider } from 'react-redux';
 import NavBar from '../../components/NavBar/NavBar';
 import reloadPage from '../../components/NavBar/reloadPage';
 import autoSchedulerReducer from '../../redux/reducer';
-import setTerm from '../../redux/actions/term';
 
 // Mocks window.open so it is possible to check if it is redirecting to the correct url
 window.open = jest.fn();

--- a/autoscheduler/frontend/src/tests/ui/Schedule.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/Schedule.test.tsx
@@ -64,13 +64,15 @@ describe('Schedule UI', () => {
     test('when given a schedule with 1 meeting', () => {
       // arrange and act
       const store = createStore(autoSchedulerReducer, {
-        schedules: [
-          {
-            meetings: [testMeeting1],
-            name: 'Schedule 1',
-            saved: false,
-          },
-        ],
+        termData: {
+          schedules: [
+            {
+              meetings: [testMeeting1],
+              name: 'Schedule 1',
+              saved: false,
+            },
+          ],
+        },
       });
       const { container } = render(
         <Provider store={store}>
@@ -87,13 +89,15 @@ describe('Schedule UI', () => {
     test('for up to 10 different sections', () => {
       // arrange
       const store = createStore(autoSchedulerReducer, {
-        schedules: [
-          {
-            meetings: testSchedule3,
-            name: 'Schedule 1',
-            saved: false,
-          },
-        ],
+        termData: {
+          schedules: [
+            {
+              meetings: testSchedule3,
+              name: 'Schedule 1',
+              saved: false,
+            },
+          ],
+        },
         selectedSchedule: 0,
       });
       const { getAllByTestId } = render(

--- a/autoscheduler/frontend/src/tests/ui/Schedule.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/Schedule.test.tsx
@@ -190,5 +190,35 @@ describe('Schedule UI', () => {
         );
       });
     });
+
+    describe('re-shows the availabilities loading indicator', () => {
+      test('when we set the term, it shows+disappears, then we change the term again', async () => {
+        // arrange
+        fetchMock.mockResponseOnce('[]'); // sessions_get_saved_availabilities
+        fetchMock.mockResponseOnce('[]'); // sessions_get_saved_availabilities
+
+        const store = createStore(autoSchedulerReducer);
+        store.dispatch(setTerm('202031'));
+
+        const { queryByLabelText } = render(
+          <Provider store={store}>
+            <Schedule />
+          </Provider>,
+        );
+
+        // wait for it to disappear once
+        await waitForElementToBeRemoved(
+          () => queryByLabelText('availabilities-loading-indicator'),
+        );
+
+        // act
+        store.dispatch(setTerm('202111'));
+
+        // assert
+        await waitFor(
+          () => expect(queryByLabelText('availabilities-loading-indicator')).toBeInTheDocument(),
+        );
+      });
+    });
   });
 });

--- a/autoscheduler/frontend/src/tests/ui/Schedule.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/Schedule.test.tsx
@@ -166,7 +166,7 @@ describe('Schedule UI', () => {
       );
 
       // assert
-      expect(store.getState().availability).toEqual(savedAvails);
+      expect(store.getState().termData.availability).toEqual(savedAvails);
     });
 
     describe('hides the loading indicator', () => {

--- a/autoscheduler/frontend/src/tests/ui/SchedulePreview.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SchedulePreview.test.tsx
@@ -59,7 +59,7 @@ describe('SchedulePreview component', () => {
 
       // assert
       await waitFor(() => (
-        expect(store.getState().schedules[0].saved).toBe(true)
+        expect(store.getState().termData.schedules[0].saved).toBe(true)
       ));
     });
 
@@ -79,7 +79,7 @@ describe('SchedulePreview component', () => {
 
       // assert
       await waitFor(() => (
-        expect(store.getState().schedules[1].saved).toBe(true)
+        expect(store.getState().termData.schedules[1].saved).toBe(true)
       ));
     });
   });
@@ -104,7 +104,9 @@ describe('SchedulePreview component', () => {
 
       // assert
       await waitFor(() => (
-        expect(store.getState().schedules.filter((schedule) => schedule.saved)).toHaveLength(0)
+        expect(
+          store.getState().termData.schedules.filter((schedule) => schedule.saved),
+        ).toHaveLength(0)
       ));
     });
 
@@ -127,7 +129,9 @@ describe('SchedulePreview component', () => {
 
       // assert
       await waitFor(() => (
-        expect(store.getState().schedules.filter((schedule) => schedule.saved)).toHaveLength(0)
+        expect(
+          store.getState().termData.schedules.filter((schedule) => schedule.saved),
+        ).toHaveLength(0)
       ));
     });
   });
@@ -148,7 +152,7 @@ describe('SchedulePreview component', () => {
       fireEvent.click(deleteScheduleButton);
 
       // assert
-      const { schedules } = store.getState();
+      const { schedules } = store.getState().termData;
       expect(schedules).toHaveLength(1);
       expect(schedules[0].meetings).toEqual(testSchedule1);
     });
@@ -174,7 +178,7 @@ describe('SchedulePreview component', () => {
       fireEvent.click(confirmDeleteButton);
 
       // assert
-      const { schedules } = store.getState();
+      const { schedules } = store.getState().termData;
       expect(schedules).toHaveLength(1);
       expect(schedules[0].saved).toBe(false);
       expect(schedules[0].meetings).toEqual(testSchedule1);
@@ -208,7 +212,7 @@ describe('SchedulePreview component', () => {
       fireEvent.click(renameScheduleButton);
 
       // assert
-      expect(store.getState().schedules[0].name).toBe(newScheduleName);
+      expect(store.getState().termData.schedules[0].name).toBe(newScheduleName);
     });
 
     test('when the second schedule is renamed', async () => {
@@ -237,7 +241,7 @@ describe('SchedulePreview component', () => {
       fireEvent.click(renameScheduleButton);
 
       // assert
-      expect(store.getState().schedules[1].name).toBe(newScheduleName);
+      expect(store.getState().termData.schedules[1].name).toBe(newScheduleName);
     });
   });
 
@@ -341,7 +345,7 @@ describe('SchedulePreview component', () => {
         await new Promise(setImmediate);
 
         // assert
-        expect(store.getState().schedules).toEqual(exampleSchedules);
+        expect(store.getState().termData.schedules).toEqual(exampleSchedules);
       });
     });
   });

--- a/autoscheduler/frontend/src/tests/ui/SchedulingPage.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SchedulingPage.test.tsx
@@ -181,7 +181,7 @@ describe('Scheduling Page UI', () => {
         </Provider>,
       );
 
-      const { term } = store.getState();
+      const { term } = store.getState().termData;
 
       // assert
       waitFor(() => expect(term).toBe('202031'));

--- a/autoscheduler/frontend/src/types/CourseCardOptions.ts
+++ b/autoscheduler/frontend/src/types/CourseCardOptions.ts
@@ -34,7 +34,6 @@ export interface CourseCardOptions {
   sections?: SectionSelected[];
   loading?: boolean;
   collapsed?: boolean;
-  term?: string;
 }
 
 // Represents a course card when saved and serialized, sections are saved as strings

--- a/autoscheduler/frontend/src/types/TermData.ts
+++ b/autoscheduler/frontend/src/types/TermData.ts
@@ -1,0 +1,10 @@
+import Availability from './Availability';
+import { CourseCardArray } from './CourseCardOptions';
+import Schedule from './Schedule';
+
+export default interface TermData {
+    term: string;
+    courseCards: CourseCardArray;
+    schedules: Schedule[];
+    availability: Availability[];
+}


### PR DESCRIPTION
## Description

This re arranges the Redux so that course cards, schedules, and availabilities have instant access to the current term.

I'll be following this up with a PR based off of this one that'll address the session desync that we were facing previously

## Rationale

To fix the dependency cycle I put all of the appropriate action type interfaces in `redux/actions/termData.ts`, which I really don't think is the right place/name for it.

Also there's a few linting warnings, but I'll fix them in the term-select PR at a later point just b/c I don't wanna update this with term-select.

## How to test

Tbh I think we just have to rely on our tests / linting for this one.
