### PR TITLE
Cache terms api

### DIFF
--- a/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
+++ b/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
@@ -8,6 +8,23 @@ import { useDispatch } from 'react-redux';
 import setTerm from '../../../redux/actions/term';
 import * as styles from './SelectTerm.css';
 
+/**
+ * Stateful function that caches the json for an api/terms call, so that the API route
+ * only has to be fetched once.
+ */
+const getTermsJson = ((): () => Promise<any> => {
+  let fetched = false;
+  let fetchedData: Promise<any>;
+
+  return async (): Promise<any> => {
+    if (fetched) return fetchedData;
+
+    fetchedData = fetch('api/terms').then((res) => res.json());
+    fetched = true;
+    return fetchedData;
+  };
+})();
+
 const SelectTerm: React.FC = () => {
   // anchorEl tells the popover menu where to center itself. Null means the menu is hidden
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
@@ -17,9 +34,9 @@ const SelectTerm: React.FC = () => {
 
   // Fetch all terms to use as ListItem options
   function getTerms(): void {
-    fetch('api/terms').then((res) => res.json()).then(
+    getTermsJson().then(
       (res) => {
-        const termsMap = new Map(Object.entries(res));
+        const termsMap = new Map<string, string>(Object.entries(res));
         setTermMap(termsMap);
         setOptions(Array.from(termsMap.keys()));
       },

--- a/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
+++ b/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
@@ -13,14 +13,12 @@ import * as styles from './SelectTerm.css';
  * only has to be fetched once.
  */
 const getTermsJson = ((): () => Promise<any> => {
-  let fetched = false;
   let fetchedData: Promise<any>;
 
   return async (): Promise<any> => {
-    if (fetched) return fetchedData;
+    if (fetchedData) return fetchedData;
 
     fetchedData = fetch('api/terms').then((res) => res.json());
-    fetched = true;
     return fetchedData;
   };
 })();

--- a/autoscheduler/frontend/src/tests/ui/SelectTerm.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SelectTerm.test.tsx
@@ -127,4 +127,22 @@ describe('SelectTerm', () => {
       );
     });
   });
+
+  describe('Only calls api/terms once', () => {
+    test('when multiple SelectTerm components are rendered', async () => {
+      // arrange
+      const store = createStore(autoSchedulerReducer);
+
+      render(
+        <Provider store={store}>
+          <SelectTerm />
+          <SelectTerm />
+        </Provider>,
+      );
+
+      // act - terms API will automatically fetch
+
+      // assert - if api/terms is called a second time then it won't be mocked, throwing an error
+    });
+  });
 });


### PR DESCRIPTION
## Description

Caches the result of `api/terms`, meaning it will only ever be called once

## Rationale

I used a self-executing function to store state instead of doing it in global scope to make the caching self-contained

Also the test doesn't technically assert that `api/terms` is only called once for a couple reasons:
- `fetchMock` isn't actually adding the api call to the results of `fetchMock.mock.calls` for some reason
- The test will fail if it's called twice anyways, since the component won't know how to handle the response

## How to test

What I was doing instead of checking out the navbar term select branch is just add multiple `<TermSelect />` components to the main page, you'll notice the call only executes once

## Screenshots

If it's a frontend change, provide screenshots of it. If possible, show the change on different
resolutions/sizes.

If you're changing a existing frontend look, provide a before and after screenshot in the table below.

|Before|After|
|--|--|
| ![image](https://user-images.githubusercontent.com/28655462/100021657-758e9900-2da7-11eb-9c46-604211c6c92a.png) | | [terms fetching](https://user-images.githubusercontent.com/28655462/100021415-0e70e480-2da7-11eb-84ea-881851b56283.gif) |

## Related tasks
Closes #386