### PR TITLE
Fix term select after redux-rearrange

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
@@ -7,7 +7,7 @@ import * as styles from './CourseSelectColumn.css';
 import { RootState } from '../../../redux/reducer';
 import { CourseCardArray, CustomizationLevel, SerializedCourseCardOptions } from '../../../types/CourseCardOptions';
 import CourseSelectCard from './CourseSelectCard/CourseSelectCard';
-import { addCourseCard, replaceCourseCards, clearCourseCards } from '../../../redux/actions/courseCards';
+import { addCourseCard, replaceCourseCards } from '../../../redux/actions/courseCards';
 import createThrottleFunction from '../../../utils/createThrottleFunction';
 
 // Creates a throttle function that shares state between calls
@@ -49,9 +49,6 @@ const CourseSelectColumn: React.FC = () => {
         dispatch(replaceCourseCards(courses, term));
       });
     }
-
-    // on unmount, clear course cards
-    return (): void => { dispatch(clearCourseCards()); };
   }, [term, dispatch]);
 
   /* When courseCards are changed, create a callback to save courses in their current state.

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/Schedule.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/Schedule.tsx
@@ -7,6 +7,7 @@ import MeetingCard from './MeetingCard/MeetingCard';
 import { RootState } from '../../../redux/reducer';
 import {
   addAvailability, updateAvailability, mergeAvailability, deleteAvailability, setAvailabilities,
+  clearAvailabilities,
 } from '../../../redux/actions/availability';
 import {
   clearSelectedAvailabilities, removeSelectedAvailability, addSelectedAvailability,
@@ -429,14 +430,16 @@ const Schedule: React.FC = () => {
         (res) => res.json(),
       ).then((avails: Availability[]) => {
         // We're done loading - hide the loading indicator and set the new availabilities
-        dispatch(setAvailabilities(avails));
+        dispatch(setAvailabilities(avails, term));
         setIsLoadingAvailabilities(false);
       });
     }
 
     // on unmount, clear availabilities
     return (): void => {
-      dispatch(setAvailabilities([]));
+      // Should re-show the loading indicator when we change terms
+      setIsLoadingAvailabilities(true);
+      dispatch(clearAvailabilities());
     };
   }, [term, dispatch]);
 
@@ -460,7 +463,7 @@ const Schedule: React.FC = () => {
       });
     };
 
-    throttle(`${term}`, saveAvailabilities, 15000, true);
+    throttle(`${term}`, saveAvailabilities, 3000, true);
   }, [availabilityList, term, isMouseDown, isLoadingAvailabilities]);
 
   // On unmount, force-call the previously called throttle functions

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/Schedule.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/Schedule.tsx
@@ -7,7 +7,6 @@ import MeetingCard from './MeetingCard/MeetingCard';
 import { RootState } from '../../../redux/reducer';
 import {
   addAvailability, updateAvailability, mergeAvailability, deleteAvailability, setAvailabilities,
-  clearAvailabilities,
 } from '../../../redux/actions/availability';
 import {
   clearSelectedAvailabilities, removeSelectedAvailability, addSelectedAvailability,
@@ -439,7 +438,6 @@ const Schedule: React.FC = () => {
     return (): void => {
       // Should re-show the loading indicator when we change terms
       setIsLoadingAvailabilities(true);
-      dispatch(clearAvailabilities());
     };
   }, [term, dispatch]);
 

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
@@ -7,7 +7,7 @@ import { RootState } from '../../../redux/reducer';
 import * as styles from './SchedulePreview.css';
 import ScheduleListItem from './ScheduleListItem/ScheduleListItem';
 import Schedule from '../../../types/Schedule';
-import { clearSchedules, setSchedules } from '../../../redux/actions/schedules';
+import { setSchedules } from '../../../redux/actions/schedules';
 import createThrottleFunction from '../../../utils/createThrottleFunction';
 import { parseAllMeetings } from '../../../redux/actions/courseCards';
 import SmallFastProgress from '../../SmallFastProgress';
@@ -55,10 +55,6 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({
     return (): void => {
       // Re-show the loading indicator when we change terms
       setIsLoadingSchedules(true);
-      // We can't just do setSchedules([], term) b/c it will be ignored due to the term mismatch
-      // Although the loading indicator will hide the schedules regardless, it's still a good
-      // practice to clear the schedules
-      dispatch(clearSchedules());
     };
   }, [term, dispatch]);
 

--- a/autoscheduler/frontend/src/redux/actions/availability.ts
+++ b/autoscheduler/frontend/src/redux/actions/availability.ts
@@ -1,9 +1,10 @@
 import Availability, { AvailabilityArgs } from '../../types/Availability'; import {
   ADD_AVAILABILITY, DELETE_AVAILABILITY, UPDATE_AVAILABILITY, MERGE_AVAILABILITY,
   SET_AVAILABILITIES,
+  CLEAR_AVAILABILITIES,
 } from '../reducers/availability';
 import {
-  AddAvailabilityAction, DeleteAvailabilityAction, MergeAvailabilityAction, SetAvailabilitiesAction,
+  AddAvailabilityAction, ClearAvailabilitiesAction, DeleteAvailabilityAction, MergeAvailabilityAction, SetAvailabilitiesAction,
   UpdateAvailabilityAction,
 } from './termData';
 
@@ -49,9 +50,18 @@ export function mergeAvailability(numNewAvs = 1): MergeAvailabilityAction {
   };
 }
 
-export function setAvailabilities(availabilities: Availability[]): SetAvailabilitiesAction {
+export function setAvailabilities(
+  availabilities: Availability[], term: string,
+): SetAvailabilitiesAction {
   return {
     type: SET_AVAILABILITIES,
     availabilities,
+    term,
+  };
+}
+
+export function clearAvailabilities(): ClearAvailabilitiesAction {
+  return {
+    type: CLEAR_AVAILABILITIES,
   };
 }

--- a/autoscheduler/frontend/src/redux/actions/availability.ts
+++ b/autoscheduler/frontend/src/redux/actions/availability.ts
@@ -59,9 +59,3 @@ export function setAvailabilities(
     term,
   };
 }
-
-export function clearAvailabilities(): ClearAvailabilitiesAction {
-  return {
-    type: CLEAR_AVAILABILITIES,
-  };
-}

--- a/autoscheduler/frontend/src/redux/actions/availability.ts
+++ b/autoscheduler/frontend/src/redux/actions/availability.ts
@@ -4,8 +4,8 @@ import Availability, { AvailabilityArgs } from '../../types/Availability'; impor
   CLEAR_AVAILABILITIES,
 } from '../reducers/availability';
 import {
-  AddAvailabilityAction, ClearAvailabilitiesAction, DeleteAvailabilityAction, MergeAvailabilityAction, SetAvailabilitiesAction,
-  UpdateAvailabilityAction,
+  AddAvailabilityAction, ClearAvailabilitiesAction, DeleteAvailabilityAction,
+  MergeAvailabilityAction, SetAvailabilitiesAction, UpdateAvailabilityAction,
 } from './termData';
 
 export function addAvailability(availability: AvailabilityArgs): AddAvailabilityAction {

--- a/autoscheduler/frontend/src/redux/actions/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/actions/courseCards.ts
@@ -32,13 +32,11 @@ export function addCourseCard(
   courseCard = createEmptyCourseCard(),
   idx: number = undefined,
 ): AddCourseAction {
-  const card = courseCard;
-  card.term = term;
-
   return {
     type: ADD_COURSE_CARD,
-    courseCard: card,
+    courseCard,
     idx,
+    term,
   };
 }
 
@@ -53,12 +51,16 @@ export function removeCourseCard(index: number): RemoveCourseAction {
    * Helper action creator that generates plain old UpdateCourseActions
    * @param index the index of the course card to update in the CourseCardArray
    * @param courseCard the options to update
+   * @param term the current term, which defaults to undefined
    */
-function updateCourseCardSync(index: number, courseCard: CourseCardOptions): UpdateCourseAction {
+function updateCourseCardSync(
+  index: number, courseCard: CourseCardOptions, term: string = undefined,
+): UpdateCourseAction {
   return {
     type: UPDATE_COURSE_CARD,
     index,
     courseCard,
+    term,
   };
 }
 
@@ -210,7 +212,6 @@ async function fetchCourseCardFrom(
         hasHonors,
         hasRemote,
         hasAsynchronous,
-        term,
         honors,
         remote,
         asynchronous,
@@ -231,7 +232,7 @@ function updateCourseCardAsync(
   return (dispatch): Promise<void> => new Promise((resolve) => {
     fetchCourseCardFrom(courseCard, term).then((updatedCourseCard) => {
       if (updatedCourseCard) {
-        dispatch(updateCourseCardSync(index, updatedCourseCard));
+        dispatch(updateCourseCardSync(index, updatedCourseCard, term));
         resolve();
       }
     });
@@ -309,7 +310,6 @@ function getSelectedSections(
 
   // courseCard can be undefined occasionally when you change terms when it's loading
   if (!courseCard) {
-    console.log('term is undefined!');
     return [];
   }
 
@@ -354,9 +354,8 @@ export function replaceCourseCards(
         const cardWithSectionsSelected = {
           sections: getSelectedSections(courseCards[idx], updatedCard),
           loading: false,
-          term,
         };
-        dispatch(updateCourseCardSync(idx, cardWithSectionsSelected));
+        dispatch(updateCourseCardSync(idx, cardWithSectionsSelected, term));
       });
     });
   };

--- a/autoscheduler/frontend/src/redux/actions/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/actions/courseCards.ts
@@ -4,7 +4,7 @@ import {
   SectionFilter,
 } from '../../types/CourseCardOptions';
 import {
-  ADD_COURSE_CARD, REMOVE_COURSE_CARD, UPDATE_COURSE_CARD, CLEAR_COURSE_CARDS,
+  ADD_COURSE_CARD, REMOVE_COURSE_CARD, UPDATE_COURSE_CARD,
 } from '../reducers/courseCards';
 import { RootState } from '../reducer';
 import Meeting, { MeetingType } from '../../types/Meeting';
@@ -276,11 +276,6 @@ ThunkAction<void, RootState, undefined, UpdateCourseAction> {
       ),
     }));
   };
-}
-
-
-export function clearCourseCards(): ClearCourseCardsAction {
-  return { type: CLEAR_COURSE_CARDS };
 }
 
 /**

--- a/autoscheduler/frontend/src/redux/actions/schedules.ts
+++ b/autoscheduler/frontend/src/redux/actions/schedules.ts
@@ -3,7 +3,6 @@ import * as Cookies from 'js-cookie';
 import {
   ADD_SCHEDULE, REMOVE_SCHEDULE, REPLACE_SCHEDULES, SAVE_SCHEDULE, UNSAVE_SCHEDULE, RENAME_SCHEDULE,
   SET_SCHEDULES,
-  CLEAR_SCHEDULES,
 } from '../reducers/schedules';
 import Meeting from '../../types/Meeting';
 import { RootState } from '../reducer';
@@ -15,7 +14,7 @@ import selectSchedule from './selectedSchedule';
 import { GenerateSchedulesResponse } from '../../types/APIResponses';
 import Schedule from '../../types/Schedule';
 import {
-  AddScheduleAction, ClearSchedulesAction, RemoveScheduleAction, RenameScheduleAction,
+  AddScheduleAction, RemoveScheduleAction, RenameScheduleAction,
   ReplaceSchedulesAction, SaveScheduleAction, SetSchedulesAction, UnsaveScheduleAction,
 } from './termData';
 
@@ -157,11 +156,5 @@ export function setSchedules(schedules: Schedule[], term: string): SetSchedulesA
     type: SET_SCHEDULES,
     schedules,
     term,
-  };
-}
-
-export function clearSchedules(): ClearSchedulesAction {
-  return {
-    type: CLEAR_SCHEDULES,
   };
 }

--- a/autoscheduler/frontend/src/redux/actions/schedules.ts
+++ b/autoscheduler/frontend/src/redux/actions/schedules.ts
@@ -151,9 +151,16 @@ ThunkAction<Promise<void>, RootState, undefined, ReplaceSchedulesAction | Select
   };
 }
 
-export function setSchedules(schedules: Schedule[]): SetSchedulesAction {
+export function setSchedules(schedules: Schedule[], term: string): SetSchedulesAction {
   return {
     type: SET_SCHEDULES,
     schedules,
+    term,
+  };
+}
+
+export function clearSchedules(): ClearSchedulesAction {
+  return {
+    type: CLEAR_SCHEDULES,
   };
 }

--- a/autoscheduler/frontend/src/redux/actions/schedules.ts
+++ b/autoscheduler/frontend/src/redux/actions/schedules.ts
@@ -15,8 +15,8 @@ import selectSchedule from './selectedSchedule';
 import { GenerateSchedulesResponse } from '../../types/APIResponses';
 import Schedule from '../../types/Schedule';
 import {
-  AddScheduleAction, ClearSchedulesAction, RemoveScheduleAction, RenameScheduleAction, ReplaceSchedulesAction,
-  SaveScheduleAction, SetSchedulesAction, UnsaveScheduleAction,
+  AddScheduleAction, ClearSchedulesAction, RemoveScheduleAction, RenameScheduleAction,
+  ReplaceSchedulesAction, SaveScheduleAction, SetSchedulesAction, UnsaveScheduleAction,
 } from './termData';
 
 export function addSchedule(meetings: Meeting[]): AddScheduleAction {

--- a/autoscheduler/frontend/src/redux/actions/schedules.ts
+++ b/autoscheduler/frontend/src/redux/actions/schedules.ts
@@ -3,6 +3,7 @@ import * as Cookies from 'js-cookie';
 import {
   ADD_SCHEDULE, REMOVE_SCHEDULE, REPLACE_SCHEDULES, SAVE_SCHEDULE, UNSAVE_SCHEDULE, RENAME_SCHEDULE,
   SET_SCHEDULES,
+  CLEAR_SCHEDULES,
 } from '../reducers/schedules';
 import Meeting from '../../types/Meeting';
 import { RootState } from '../reducer';
@@ -14,7 +15,7 @@ import selectSchedule from './selectedSchedule';
 import { GenerateSchedulesResponse } from '../../types/APIResponses';
 import Schedule from '../../types/Schedule';
 import {
-  AddScheduleAction, RemoveScheduleAction, RenameScheduleAction, ReplaceSchedulesAction,
+  AddScheduleAction, ClearSchedulesAction, RemoveScheduleAction, RenameScheduleAction, ReplaceSchedulesAction,
   SaveScheduleAction, SetSchedulesAction, UnsaveScheduleAction,
 } from './termData';
 

--- a/autoscheduler/frontend/src/redux/actions/termData.ts
+++ b/autoscheduler/frontend/src/redux/actions/termData.ts
@@ -99,6 +99,7 @@ export interface AddCourseAction {
     type: 'ADD_COURSE_CARD';
     courseCard: CourseCardOptions;
     idx?: number;
+    term: string;
 }
 export interface RemoveCourseAction {
     type: 'REMOVE_COURSE_CARD';
@@ -108,6 +109,7 @@ export interface UpdateCourseAction {
     type: 'UPDATE_COURSE_CARD';
     index: number;
     courseCard: CourseCardOptions;
+    term: string;
 }
 export interface ClearCourseCardsAction {
   type: 'CLEAR_COURSE_CARDS';

--- a/autoscheduler/frontend/src/redux/actions/termData.ts
+++ b/autoscheduler/frontend/src/redux/actions/termData.ts
@@ -76,9 +76,14 @@ export interface RenameScheduleAction {
 export interface SetSchedulesAction {
   type: 'SET_SCHEDULES';
   schedules: Schedule[];
+  term: string;
+}
+export interface ClearSchedulesAction {
+  type: 'CLEAR_SCHEDULES';
 }
 export type ScheduleAction = AddScheduleAction | RemoveScheduleAction | ReplaceSchedulesAction
-| SaveScheduleAction | UnsaveScheduleAction | RenameScheduleAction | SetSchedulesAction;
+| SaveScheduleAction | UnsaveScheduleAction | RenameScheduleAction | SetSchedulesAction
+| ClearSchedulesAction;
 
 /*
   COURSE CARDS

--- a/autoscheduler/frontend/src/redux/actions/termData.ts
+++ b/autoscheduler/frontend/src/redux/actions/termData.ts
@@ -39,10 +39,15 @@ export interface MergeAvailabilityAction {
 export interface SetAvailabilitiesAction {
   type: 'SET_AVAILABILITIES';
   availabilities: Availability[];
+  term: string;
+}
+export interface ClearAvailabilitiesAction {
+  type: 'CLEAR_AVAILABILITIES';
 }
 export type AvailabilityAction =
     AddAvailabilityAction | DeleteAvailabilityAction | UpdateAvailabilityAction |
-    MergeAvailabilityAction | SetAvailabilitiesAction | RemoveSelectedAvailabilityAction;
+    MergeAvailabilityAction | SetAvailabilitiesAction | RemoveSelectedAvailabilityAction |
+    ClearAvailabilitiesAction;
 
 /*
     SCHEDULES

--- a/autoscheduler/frontend/src/redux/reducers/availability.ts
+++ b/autoscheduler/frontend/src/redux/reducers/availability.ts
@@ -14,13 +14,14 @@ export const DELETE_AVAILABILITY = 'DELETE_AVAILABILITY';
 export const UPDATE_AVAILABILITY = 'UPDATE_AVAILABILITY';
 export const MERGE_AVAILABILITY = 'MERGE_AVAILABILITY';
 export const SET_AVAILABILITIES = 'SET_AVAILABILITIES';
+export const CLEAR_AVAILABILITIES = 'CLEAR_AVAILABILITIES';
 
 
 // helper functions for reducer
 
 // reducer
 export default function availability(
-  state: Availability[] = [], action: TermDataAction,
+  state: Availability[] = [], action: TermDataAction, term: string,
 ): Availability[] {
   switch (action.type) {
     case ADD_AVAILABILITY:
@@ -97,7 +98,12 @@ export default function availability(
       return newState;
     }
     case SET_AVAILABILITIES:
+      // If there's a term mismatch, return the original state
+      if (action.term !== term) return state;
+
       return action.availabilities;
+    case CLEAR_AVAILABILITIES:
+      return [];
     default:
       return state;
   }

--- a/autoscheduler/frontend/src/redux/reducers/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/reducers/courseCards.ts
@@ -66,9 +66,7 @@ export default function courseCards(
   switch (action.type) {
     case ADD_COURSE_CARD: {
       // If there's a term mismatch, return the original state
-      if (term !== action.courseCard.term) {
-        return state;
-      }
+      if (term !== action.term) return state;
 
       const newCardIdx = action.idx ?? state.numCardsCreated;
       // If new card is explicitly expanded, perform necessary state changes
@@ -117,11 +115,9 @@ export default function courseCards(
       // if card doesn't exist, don't update
       if (!state[action.index]) return state;
 
-      // If there's a term-mismatch, ignore the action's new state and return the original
-      // Note the term is only sent in the action when there's a possibility of a mismatch
-      if (action.courseCard.term && state[action.index].term !== action.courseCard.term) {
-        return state;
-      }
+      // If there's a term-mismatch, return the original state
+      // Note the term is only sent in the action when there's a possiblity of a mismatch
+      if (action.term && term !== action.term) return state;
 
       // if card was expanded, collapse other cards
       if (action.courseCard.collapsed === false && state[action.index]?.collapsed !== false) {
@@ -136,12 +132,8 @@ export default function courseCards(
       };
     case CLEAR_COURSE_CARDS:
       return initialCourseCardArray;
-    case SET_TERM: {
-      // Really only do this to pass the tests
-      const ret = initialCourseCardArray;
-      ret[0].term = action.term;
-      return ret;
-    }
+    case SET_TERM:
+      return initialCourseCardArray;
     default:
       return state;
   }

--- a/autoscheduler/frontend/src/redux/reducers/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/reducers/courseCards.ts
@@ -61,15 +61,21 @@ function getStateAfterExpanding(
 
 // reducer
 export default function courseCards(
-  state: CourseCardArray = initialCourseCardArray, action: TermDataAction,
+  state: CourseCardArray = initialCourseCardArray, action: TermDataAction, term: string,
 ): CourseCardArray {
   switch (action.type) {
     case ADD_COURSE_CARD: {
+      // If there's a term mismatch, return the original state
+      if (term !== action.courseCard.term) {
+        return state;
+      }
+
       const newCardIdx = action.idx ?? state.numCardsCreated;
       // If new card is explicitly expanded, perform necessary state changes
       if (action.courseCard.collapsed === false) {
         return getStateAfterExpanding(state, newCardIdx, action.courseCard);
       }
+
       // New card isn't supposed to be expanded, simply add it
       return {
         ...state,

--- a/autoscheduler/frontend/src/redux/reducers/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/reducers/courseCards.ts
@@ -12,7 +12,6 @@ import { SET_TERM } from './term';
 export const ADD_COURSE_CARD = 'ADD_COURSE_CARD';
 export const REMOVE_COURSE_CARD = 'REMOVE_COURSE_CARD';
 export const UPDATE_COURSE_CARD = 'UPDATE_COURSE_CARD';
-export const CLEAR_COURSE_CARDS = 'CLEAR_COURSE_CARDS';
 
 // initial state for courseCards
 // if no courses are saved for the term, an intial course card will be added
@@ -130,8 +129,6 @@ export default function courseCards(
         [action.index]: { ...state[action.index], ...action.courseCard },
         numCardsCreated: Math.max(state.numCardsCreated, action.index + 1),
       };
-    case CLEAR_COURSE_CARDS:
-      return initialCourseCardArray;
     case SET_TERM:
       return initialCourseCardArray;
     default:

--- a/autoscheduler/frontend/src/redux/reducers/schedules.ts
+++ b/autoscheduler/frontend/src/redux/reducers/schedules.ts
@@ -14,7 +14,7 @@ export const SAVE_SCHEDULE = 'SAVE_SCHEDULE';
 export const UNSAVE_SCHEDULE = 'UNSAVE_SCHEDULE';
 export const RENAME_SCHEDULE = 'RENAME_SCHEDULE';
 export const SET_SCHEDULES = 'SET_SCHEDULES';
-
+export const CLEAR_SCHEDULES = 'CLEAR_SCHEDULES';
 
 const initialSchedules: Schedule[] = [];
 
@@ -70,7 +70,9 @@ function getUniqueSchedules(allSchedules: Schedule[]): Schedule[] {
 }
 
 // reducer
-function schedules(state: Schedule[] = initialSchedules, action: TermDataAction): Schedule[] {
+function schedules(
+  state: Schedule[] = initialSchedules, action: TermDataAction, term: string,
+): Schedule[] {
   switch (action.type) {
     case ADD_SCHEDULE: {
       return [...state, createSchedule(action.meetings, state)];
@@ -110,7 +112,12 @@ function schedules(state: Schedule[] = initialSchedules, action: TermDataAction)
       return newState;
     }
     case SET_SCHEDULES:
+      // Check for a term mismatch and return the original state if there is one
+      if (action.term !== term) return state;
+
       return action.schedules;
+    case CLEAR_SCHEDULES:
+      return [];
     default:
       return state;
   }

--- a/autoscheduler/frontend/src/redux/reducers/schedules.ts
+++ b/autoscheduler/frontend/src/redux/reducers/schedules.ts
@@ -5,6 +5,7 @@
 import Meeting from '../../types/Meeting';
 import Schedule from '../../types/Schedule';
 import { TermDataAction } from '../actions/termData';
+import { SET_TERM } from './term';
 
 // action type strings
 export const ADD_SCHEDULE = 'ADD_SCHEDULE';
@@ -116,7 +117,7 @@ function schedules(
       if (action.term !== term) return state;
 
       return action.schedules;
-    case CLEAR_SCHEDULES:
+    case SET_TERM:
       return [];
     default:
       return state;

--- a/autoscheduler/frontend/src/redux/reducers/termData.ts
+++ b/autoscheduler/frontend/src/redux/reducers/termData.ts
@@ -16,7 +16,7 @@ export default function termData(state: TermData = initialState, action: TermDat
   return {
     term: term(state.term, action),
     schedules: schedules(state.schedules, action, state.term),
-    availability: availability(state.availability, action),
+    availability: availability(state.availability, action, state.term),
     courseCards: courseCards(state.courseCards, action, state.term),
   };
 }

--- a/autoscheduler/frontend/src/redux/reducers/termData.ts
+++ b/autoscheduler/frontend/src/redux/reducers/termData.ts
@@ -17,6 +17,6 @@ export default function termData(state: TermData = initialState, action: TermDat
     term: term(state.term, action),
     schedules: schedules(state.schedules, action),
     availability: availability(state.availability, action),
-    courseCards: courseCards(state.courseCards, action),
+    courseCards: courseCards(state.courseCards, action, state.term),
   };
 }

--- a/autoscheduler/frontend/src/redux/reducers/termData.ts
+++ b/autoscheduler/frontend/src/redux/reducers/termData.ts
@@ -15,7 +15,7 @@ const initialState: TermData = {
 export default function termData(state: TermData = initialState, action: TermDataAction): TermData {
   return {
     term: term(state.term, action),
-    schedules: schedules(state.schedules, action),
+    schedules: schedules(state.schedules, action, state.term),
     availability: availability(state.availability, action),
     courseCards: courseCards(state.courseCards, action, state.term),
   };

--- a/autoscheduler/frontend/src/tests/redux/Availability.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/Availability.test.ts
@@ -483,7 +483,7 @@ describe('Availabilities', () => {
   });
 
   describe('skips set availabilities', () => {
-    test('when theres a term mismatch', () => {
+    test("when there's a term mismatch", () => {
       // arrange
       const store = createStore(autoSchedulerReducer);
       store.dispatch(setTerm('202031'));

--- a/autoscheduler/frontend/src/tests/redux/Availability.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/Availability.test.ts
@@ -10,6 +10,7 @@ import {
 import 'isomorphic-fetch';
 import Availability, { AvailabilityType, argsToAvailability, AvailabilityArgs } from '../../types/Availability';
 import DayOfWeek from '../../types/DayOfWeek';
+import setTerm from '../../redux/actions/term';
 
 /**
  * Converts a pair of hours and minutes into a number of minutes past midnight
@@ -464,6 +465,7 @@ describe('Availabilities', () => {
     test('when setAvailabilities is called', () => {
       // arrange
       const store = createStore(autoSchedulerReducer);
+      store.dispatch(setTerm('202031'));
       const expected: Availability[] = [{
         ...dummyArgs,
         startTimeHours: 10,
@@ -473,10 +475,32 @@ describe('Availabilities', () => {
       }];
 
       // act
-      store.dispatch(setAvailabilities(expected));
+      store.dispatch(setAvailabilities(expected, '202031'));
 
       // assert
       expect(store.getState().termData.availability).toEqual(expected);
+    });
+  });
+
+  describe('skips set availabilities', () => {
+    test('when theres a term mismatch', () => {
+      // arrange
+      const store = createStore(autoSchedulerReducer);
+      store.dispatch(setTerm('202031'));
+
+      const mismatchedAvails: Availability[] = [{
+        ...dummyArgs,
+        startTimeHours: 10,
+        startTimeMinutes: 0,
+        endTimeHours: 11,
+        endTimeMinutes: 0,
+      }];
+
+      // act
+      store.dispatch(setAvailabilities(mismatchedAvails, '201931')); // mismatched term
+
+      // assert
+      expect(store.getState().termData.availability.length).toEqual(0);
     });
   });
 });

--- a/autoscheduler/frontend/src/tests/redux/CourseCards.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/CourseCards.test.ts
@@ -8,7 +8,7 @@ import { waitFor } from '@testing-library/react';
 import thunk from 'redux-thunk';
 import autoSchedulerReducer from '../../redux/reducer';
 import {
-  parseSectionSelected, clearCourseCards, replaceCourseCards, addCourseCard,
+  parseSectionSelected, replaceCourseCards, addCourseCard,
   updateCourseCard, removeCourseCard,
 } from '../../redux/actions/courseCards';
 import testFetch from '../testData';
@@ -315,32 +315,6 @@ describe('Course Cards Redux', () => {
         // assert
         expect(output).toEqual(expected);
       });
-    });
-  });
-
-  describe('clearCourseCards', () => {
-    test('resets course cards to initial state', () => {
-      // arrange
-      const expected: CourseCardArray = {
-        numCardsCreated: 1,
-        0: {
-          course: '',
-          customizationLevel: CustomizationLevel.BASIC,
-          remote: SectionFilter.NO_PREFERENCE,
-          honors: SectionFilter.EXCLUDE,
-          asynchronous: SectionFilter.NO_PREFERENCE,
-          sections: [],
-        },
-      };
-      const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
-      // add another course card, should be removed by clearCourseCards()
-      store.dispatch(addCourseCard('202031', {}));
-
-      // act
-      store.dispatch(clearCourseCards());
-
-      // assert
-      expect(store.getState().termData.courseCards).toMatchObject(expected);
     });
   });
 

--- a/autoscheduler/frontend/src/tests/redux/CourseCards.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/CourseCards.test.ts
@@ -24,8 +24,6 @@ import setTerm from '../../redux/actions/term';
 // The input from the backend use snake_case, so disable camelcase errors for this file
 /* eslint-disable @typescript-eslint/camelcase */
 describe('Course Cards Redux', () => {
-
-
   test('Initial state has one empty course card', () => {
     // arrange
     const store = createStore(autoSchedulerReducer);
@@ -718,22 +716,6 @@ describe('Course Cards Redux', () => {
       // assert
       expect(store.getState().termData.courseCards[0].collapsed).toBe(false);
       expect(store.getState().termData.courseCards[1].collapsed).toBe(true);
-    });
-
-    describe('rejects an update', () => {
-      test('when theres a term mismatch', () => {
-        // arrange
-        const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
-        store.dispatch(setTerm('202031'));
-        store.dispatch<any>(updateCourseCard(0, { term: '202031', remote: 'exclude' }, '202031'));
-
-        // act
-        store.dispatch<any>(updateCourseCard(0, { term: '201931', remote: 'only' }, '201931'));
-
-        // assert
-        // assert that the current course card is the original term's value
-        expect(store.getState().termData.courseCards[0].remote).toEqual('exclude');
-      });
     });
   });
 });

--- a/autoscheduler/frontend/src/tests/redux/CourseCards.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/CourseCards.test.ts
@@ -473,7 +473,7 @@ describe('Course Cards Redux', () => {
       expect(store.getState().termData.courseCards[1].course).toEqual('MATH 151');
     });
 
-    describe('rejects an update when theres a term mismatch', () => {
+    describe("rejects an update when there's a term mismatch", () => {
       test('when there are no cards and we call replaceCourseCards with a mismatched term', () => {
         // arrange
         const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));

--- a/autoscheduler/frontend/src/tests/redux/Schedule.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/Schedule.test.ts
@@ -2,11 +2,12 @@ import { createStore } from 'redux';
 import autoSchedulerReducer from '../../redux/reducer';
 import {
   addSchedule, removeSchedule, replaceSchedules, saveSchedule,
-  unsaveSchedule, renameSchedule,
+  unsaveSchedule, renameSchedule, setSchedules,
 } from '../../redux/actions/schedules';
 import Meeting, { MeetingType } from '../../types/Meeting';
 import Section from '../../types/Section';
 import Instructor from '../../types/Instructor';
+import setTerm from '../../redux/actions/term';
 
 const testSectionA = new Section({
   id: 123456,
@@ -444,6 +445,47 @@ describe('Schedule Redux', () => {
         store.getState().termData.schedules.map((schedule) => schedule.name),
       );
       expect(uniqueNames.size).toBe(2);
+    });
+  });
+
+  describe('sets schedules', () => {
+    test('when the terms match up', () => {
+      // arrange
+      const store = createStore(autoSchedulerReducer);
+      store.dispatch(setTerm('202031'));
+
+      const fullSchedule1 = {
+        name: 'Name1',
+        meetings: schedule1,
+        saved: true,
+      };
+
+      // act
+      store.dispatch(setSchedules([fullSchedule1], '202031'));
+
+      // assert
+      expect(store.getState().termData.schedules.length).toEqual(1);
+      expect(store.getState().termData.schedules[0]).toEqual(fullSchedule1);
+    });
+  });
+
+  describe('skips set schedules', () => {
+    test('when theres a term mismatch', () => {
+      // arrange
+      const store = createStore(autoSchedulerReducer);
+      store.dispatch(setTerm('202031'));
+
+      const fullSchedule1 = {
+        name: 'Name1',
+        meetings: schedule1,
+        saved: true,
+      };
+
+      // act
+      store.dispatch(setSchedules([fullSchedule1], '201931'));
+
+      // assert
+      expect(store.getState().termData.schedules.length).toEqual(0);
     });
   });
 });

--- a/autoscheduler/frontend/src/tests/redux/Schedule.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/Schedule.test.ts
@@ -470,7 +470,7 @@ describe('Schedule Redux', () => {
   });
 
   describe('skips set schedules', () => {
-    test('when theres a term mismatch', () => {
+    test("when there's a term mismatch", () => {
       // arrange
       const store = createStore(autoSchedulerReducer);
       store.dispatch(setTerm('202031'));

--- a/autoscheduler/frontend/src/tests/ui/Schedule.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/Schedule.test.tsx
@@ -190,5 +190,35 @@ describe('Schedule UI', () => {
         );
       });
     });
+
+    describe('re-shows the availabilities loading indicator', () => {
+      test('when we set the term, it shows+disappears, then we change the term again', async () => {
+        // arrange
+        fetchMock.mockResponseOnce('[]'); // sessions_get_saved_availabilities
+        fetchMock.mockResponseOnce('[]'); // sessions_get_saved_availabilities
+
+        const store = createStore(autoSchedulerReducer);
+        store.dispatch(setTerm('202031'));
+
+        const { queryByLabelText } = render(
+          <Provider store={store}>
+            <Schedule />
+          </Provider>,
+        );
+
+        // wait for it to disappear once
+        await waitForElementToBeRemoved(
+          () => queryByLabelText('availabilities-loading-indicator'),
+        );
+
+        // act
+        store.dispatch(setTerm('202111'));
+
+        // assert
+        await waitFor(
+          () => expect(queryByLabelText('availabilities-loading-indicator')).toBeInTheDocument(),
+        );
+      });
+    });
   });
 });

--- a/autoscheduler/frontend/src/types/CourseCardOptions.ts
+++ b/autoscheduler/frontend/src/types/CourseCardOptions.ts
@@ -34,7 +34,6 @@ export interface CourseCardOptions {
   sections?: SectionSelected[];
   loading?: boolean;
   collapsed?: boolean;
-  term?: string;
 }
 
 // Represents a course card when saved and serialized, sections are saved as strings


### PR DESCRIPTION
## Description

> This PR is based off of #472, which is based on #349

In essence, this fixes all of the issues with term mismatches when switching terms that we discovered in #349, including:

- Course cards' `get_saved_courses` (filling in the course title + card info)
- Course cards' `api/sections` (filling in the sections for sessions)
- Saved schedules
- Availabilities

I would highly suggest going commit-by-commit with this, as I tried to make the commits self-contained in their changes.

Note that the commit `Made ADD_COURSE_CARD reject mismatched terms` (15c0d65) is what fixes the `get_saved_courses` issues from [Ryan's most recent comment](https://github.com/aggie-coding-club/Rev-Registration/pull/349#issuecomment-727628534) on #349.

I must have spent like 15 hours on term select at this point

## Rationale

So there are actually two "bugs" in this, but they're basically the same thing. If you do the steps mentioned in `How to test` for schedules or availabilities, it will correctly ignore the mismatched term's data but will hide the loading indicator b/c the loading indicator is just a boolean state. I think you could fix this by somewhere alongside the `showLoadingIndicator` state (like convert it to a dict or another state variable) store the term, but I mentioned it before and I think we said it was fine. Regardless, here's a gif of it:

![schedules-bug](https://user-images.githubusercontent.com/7295783/101108371-36233200-3589-11eb-8e25-4f5ad05c7dc4.gif)

## How to test

The easiest way to test it is to add `time.sleep(3)` in the respective API view in either `user_sessions/views.py` or `scraper/views.py` for what you're trying to test for.

For instance, if you were testing schedules, you would fill in save 2 different schedules in each term. Next, you'd add a `time.sleep(3)` in `get_saved_schedules` in `users_sessions/views.py`. Then, you would reload the page, have it restore the term and start the loading of the schedules, then change the term and make sure it doesn't restore the initial term's schedules.

