### PR TITLE
Instructional method icons

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.css
@@ -14,8 +14,7 @@
     padding-right: 30px;
 }
 
-.gray-text {
-    color: rgba(0, 0, 0, 0.56);
+.placeholder-text {
     padding-bottom: 8px;
     padding-right: 8px;
 }

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.css.d.ts
@@ -2,8 +2,8 @@ declare namespace BasicSelectCssNamespace {
   export interface IBasicSelectCss {
     "fit-content": string;
     fitContent: string;
-    "gray-text": string;
-    grayText: string;
+    "placeholder-text": string;
+    placeholderText: string;
     "select-menu": string;
     "select-root": string;
     selectMenu: string;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.tsx
@@ -24,7 +24,7 @@ const BasicSelect: React.FC<BasicSelectProps> = ({ id }) => {
   // shows placeholder text if no course is selected
   if (!course) {
     return (
-      <Typography className={styles.grayText} variant="body1">
+      <Typography className={styles.placeholderText} color="textSecondary" variant="body1">
         Select a course to show available options
       </Typography>
     );
@@ -33,7 +33,7 @@ const BasicSelect: React.FC<BasicSelectProps> = ({ id }) => {
   // show placeholder message if there are no special sections to filter
   if (!hasHonors && !hasRemote && !hasAsynchronous) {
     return (
-      <Typography className={styles.grayText}>
+      <Typography className={styles.placeholderText} color="textSecondary">
         There are no honors or remote sections for this class
       </Typography>
     );

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.css
@@ -67,11 +67,6 @@
     margin-top: 8px;
 }
 
-.gray-text {
-    color: rgba(0,0,0,0.56);
-    padding-bottom: 8px;
-}
-
 #center-progress {
     width: 100%;
     display: flex;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.css.d.ts
@@ -11,8 +11,6 @@ declare namespace ExpandedCourseCardCssNamespace {
     courseInputFocused: string;
     "customization-buttons": string;
     customizationButtons: string;
-    "gray-text": string;
-    grayText: string;
     header: string;
     "header-group": string;
     headerGroup: string;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.tsx
@@ -62,7 +62,7 @@ const ExpandedCourseCard: React.FC<ExpandedCourseCardProps> = ({
         return course
           ? <SectionSelect id={id} />
           : (
-            <Typography className={styles.grayText}>
+            <Typography color="textSecondary">
               Select a course to show available sections
             </Typography>
           );

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/InstructionalMethodIcon/InstructionalMethodIcon.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/InstructionalMethodIcon/InstructionalMethodIcon.css
@@ -1,0 +1,4 @@
+.instructional-method-container {
+    display: flex;
+    align-items: center;
+}

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/InstructionalMethodIcon/InstructionalMethodIcon.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/InstructionalMethodIcon/InstructionalMethodIcon.css.d.ts
@@ -1,0 +1,13 @@
+declare namespace InstructionalMethodIconCssNamespace {
+  export interface IInstructionalMethodIconCss {
+    "instructional-method-container": string;
+    instructionalMethodContainer: string;
+  }
+}
+
+declare const InstructionalMethodIconCssModule: InstructionalMethodIconCssNamespace.IInstructionalMethodIconCss & {
+  /** WARNING: Only available when `css-loader` is used without `style-loader` or `mini-css-extract-plugin` */
+  locals: InstructionalMethodIconCssNamespace.IInstructionalMethodIconCss;
+};
+
+export = InstructionalMethodIconCssModule;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/InstructionalMethodIcon/InstructionalMethodIcon.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/InstructionalMethodIcon/InstructionalMethodIcon.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { Tooltip, Typography } from '@material-ui/core';
+import {
+  Flight, Language, People, RecordVoiceOver, Search, Work,
+} from '@material-ui/icons';
+import { InstructionalMethod } from '../../../../../../../types/Section';
+import * as styles from './InstructionalMethodIcon.css';
+
+interface InstructionalMethodIconProps {
+  instructionalMethod: InstructionalMethod;
+}
+
+/* eslint-disable react/jsx-key */
+const instructionalMethodIcons = new Map<InstructionalMethod, JSX.Element>([
+  [InstructionalMethod.F2F, <People color="action" fontSize="inherit" />],
+  [InstructionalMethod.INTERNSHIP, <Work color="action" fontSize="inherit" />],
+  [InstructionalMethod.NONTRADITIONAL, <Search color="action" fontSize="inherit" />],
+  [InstructionalMethod.WEB_BASED, <Language color="action" fontSize="inherit" />],
+  [InstructionalMethod.STUDY_ABROAD, <Flight color="action" fontSize="inherit" />],
+  [InstructionalMethod.NONE, null],
+  [InstructionalMethod.REMOTE, <RecordVoiceOver color="action" fontSize="inherit" />],
+  [InstructionalMethod.F2F_REMOTE_OPTION, (
+    <>
+      <People color="action" fontSize="small" />
+      <Typography color="textSecondary">&nbsp;/&nbsp;</Typography>
+      <RecordVoiceOver color="action" fontSize="inherit" />
+    </>
+  )],
+  [InstructionalMethod.MIXED_F2F_REMOTE, (
+    <>
+      <People color="action" fontSize="small" />
+      <Typography color="textSecondary">&nbsp;+&nbsp;</Typography>
+      <RecordVoiceOver color="action" fontSize="inherit" />
+    </>
+  )],
+]);
+/* eslint-enable */
+
+const InstructionalMethodIcon: React.FC<InstructionalMethodIconProps> = ({
+  instructionalMethod,
+}) => {
+  const icon = instructionalMethodIcons.get(instructionalMethod);
+
+  return (
+    <Tooltip title={instructionalMethod} placement="top" arrow>
+      <span className={styles.instructionalMethodContainer}>
+        {icon}
+      </span>
+    </Tooltip>
+  );
+};
+
+export default InstructionalMethodIcon;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/InstructionalMethodIcon/InstructionalMethodIcon.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/InstructionalMethodIcon/InstructionalMethodIcon.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Tooltip, Typography } from '@material-ui/core';
 import {
-  Flight, Language, People, RecordVoiceOver, Search, Work,
+  Flight, Language, Laptop, People, Search, Work,
 } from '@material-ui/icons';
 import { InstructionalMethod } from '../../../../../../../types/Section';
 import * as styles from './InstructionalMethodIcon.css';
@@ -18,19 +18,19 @@ const instructionalMethodIcons = new Map<InstructionalMethod, JSX.Element>([
   [InstructionalMethod.WEB_BASED, <Language color="action" fontSize="inherit" />],
   [InstructionalMethod.STUDY_ABROAD, <Flight color="action" fontSize="inherit" />],
   [InstructionalMethod.NONE, null],
-  [InstructionalMethod.REMOTE, <RecordVoiceOver color="action" fontSize="inherit" />],
+  [InstructionalMethod.REMOTE, <Laptop color="action" fontSize="inherit" />],
   [InstructionalMethod.F2F_REMOTE_OPTION, (
     <>
       <People color="action" fontSize="small" />
       <Typography color="textSecondary">&nbsp;/&nbsp;</Typography>
-      <RecordVoiceOver color="action" fontSize="inherit" />
+      <Laptop color="action" fontSize="inherit" />
     </>
   )],
   [InstructionalMethod.MIXED_F2F_REMOTE, (
     <>
       <People color="action" fontSize="small" />
       <Typography color="textSecondary">&nbsp;+&nbsp;</Typography>
-      <RecordVoiceOver color="action" fontSize="inherit" />
+      <Laptop color="action" fontSize="inherit" />
     </>
   )],
 ]);

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
@@ -9,6 +9,7 @@ import { SectionSelected } from '../../../../../../types/CourseCardOptions';
 import Meeting, { MeetingType, MeetingTypeDescription } from '../../../../../../types/Meeting';
 import { formatTime } from '../../../../../../utils/timeUtil';
 import GradeDist from './GradeDist/GradeDist';
+import InstructionalMethodIcon from './InstructionalMethodIcon/InstructionalMethodIcon';
 import * as styles from './SectionSelect.css';
 
 interface SectionInfoProps {
@@ -112,7 +113,13 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
   const sectionHeader = (
     <Typography className={styles.denseListItem} component="tr">
       <td>
-        {section.sectionNum}
+        <span className={styles.sectionNameContainer}>
+          <span>
+            {section.sectionNum}
+            &nbsp;
+          </span>
+          <InstructionalMethodIcon instructionalMethod={section.instructionalMethod} />
+        </span>
       </td>
       <td
         style={{ color: remainingSeatsColor, textAlign: 'right' }}
@@ -158,7 +165,7 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
   const sectionDetails = (
     <ListItem
       onClick={(): void => { dispatch(toggleSelected(courseCardId, secIdx)); }}
-      className={styles.noBottomSpace}
+      className={styles.noExtraSpace}
       dense
       disableGutters
       button
@@ -173,7 +180,7 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
           className={styles.myIconButton}
         />
       </ListItemIcon>
-      <ListItemText disableTypography className={styles.noBottomSpace}>
+      <ListItemText disableTypography className={styles.noExtraSpace}>
         <table className={styles.sectionDetailsTable}>
           <colgroup>
             <col width="15%" />

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
@@ -114,10 +114,8 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
     <Typography className={styles.denseListItem} component="tr">
       <td>
         <span className={styles.sectionNameContainer}>
-          <span>
-            {section.sectionNum}
-            &nbsp;
-          </span>
+          {section.sectionNum}
+          &nbsp;
           <InstructionalMethodIcon instructionalMethod={section.instructionalMethod} />
         </span>
       </td>

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
@@ -48,8 +48,7 @@
     margin-right: 5px;
 }
 
-.gray-text {
-    color: rgba(0, 0, 0, 0.56);
+.placeholder-text {
     padding-bottom: 8px;
 }
 
@@ -61,8 +60,9 @@
     text-align: center;
 }
 
-/* The next 2 rules move the section divider to the bottom of the ListItem */
-.no-bottom-space {
+/* The next 2 rules remove extra padding on ListItem components */
+.no-extra-space {
+    margin-top: 0px !important;
     padding-bottom: 0px !important;
     margin-bottom: 0px !important;
 }
@@ -73,4 +73,9 @@
 
 .no-start-padding {
     padding-inline-start: 0;
+}
+
+.section-name-container {
+    display: flex;
+    align-items: center;
 }

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css.d.ts
@@ -6,8 +6,6 @@ declare namespace SectionSelectCssNamespace {
     denseListItem: string;
     "divider-container": string;
     dividerContainer: string;
-    "gray-text": string;
-    grayText: string;
     "list-subheader-content": string;
     "list-subheader-dense": string;
     listSubheaderContent: string;
@@ -20,15 +18,19 @@ declare namespace SectionSelectCssNamespace {
     myListItemIcon: string;
     "name-honors-icon": string;
     nameHonorsIcon: string;
-    "no-bottom-space": string;
+    "no-extra-space": string;
     "no-grades-available": string;
     "no-start-padding": string;
-    noBottomSpace: string;
+    noExtraSpace: string;
     noGradesAvailable: string;
     noStartPadding: string;
+    "placeholder-text": string;
+    placeholderText: string;
     "section-details-table": string;
+    "section-name-container": string;
     "section-rows": string;
     sectionDetailsTable: string;
+    sectionNameContainer: string;
     sectionRows: string;
   }
 }

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
@@ -18,7 +18,7 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
   // show placeholder text if there are no sections
   if (sections.length === 0) {
     return (
-      <Typography className={styles.grayText} variant="body1">
+      <Typography className={styles.placeholderText} color="textSecondary" variant="body1">
         There are no available sections for this term
       </Typography>
     );

--- a/autoscheduler/frontend/src/redux/actions/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/actions/courseCards.ts
@@ -9,7 +9,7 @@ import {
 } from '../reducers/courseCards';
 import { RootState } from '../reducer';
 import Meeting, { MeetingType } from '../../types/Meeting';
-import Section from '../../types/Section';
+import Section, { InstructionalMethod } from '../../types/Section';
 import Instructor from '../../types/Instructor';
 import Grades from '../../types/Grades';
 
@@ -77,6 +77,7 @@ function parseSection(sectionData: any): Section {
     asynchronous: sectionData.asynchronous,
     instructor: new Instructor({ name: sectionData.instructor_name }),
     grades: sectionData.grades == null ? null : new Grades(sectionData.grades),
+    instructionalMethod: sectionData.instructional_method ?? InstructionalMethod.NONE,
   });
 }
 

--- a/autoscheduler/frontend/src/redux/testData.ts
+++ b/autoscheduler/frontend/src/redux/testData.ts
@@ -1,5 +1,5 @@
 import Meeting, { MeetingType } from '../types/Meeting';
-import Section from '../types/Section';
+import Section, { InstructionalMethod } from '../types/Section';
 import Instructor from '../types/Instructor';
 
 export default async function fetch(route: string): Promise<Response> {
@@ -21,6 +21,7 @@ export default async function fetch(route: string): Promise<Response> {
       name: 'Aakash Tyagi',
     }),
     grades: null,
+    instructionalMethod: InstructionalMethod.NONE,
   });
   const testSection2 = new Section({
     id: 123458,
@@ -39,6 +40,7 @@ export default async function fetch(route: string): Promise<Response> {
       name: 'Aakash Tyagi',
     }),
     grades: null,
+    instructionalMethod: InstructionalMethod.NONE,
   });
   const testSection3 = new Section({
     id: 123457,
@@ -57,6 +59,7 @@ export default async function fetch(route: string): Promise<Response> {
       name: 'Somebody Else',
     }),
     grades: null,
+    instructionalMethod: InstructionalMethod.NONE,
   });
   const testSection4 = new Section({
     id: 830262,
@@ -75,6 +78,7 @@ export default async function fetch(route: string): Promise<Response> {
       name: 'Dr. Pepper',
     }),
     grades: null,
+    instructionalMethod: InstructionalMethod.NONE,
   });
 
   // test that different sections do different things

--- a/autoscheduler/frontend/src/tests/redux/CourseCards.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/CourseCards.test.ts
@@ -13,7 +13,7 @@ import {
 } from '../../redux/actions/courseCards';
 import testFetch from '../testData';
 import Meeting, { MeetingType } from '../../types/Meeting';
-import Section from '../../types/Section';
+import Section, { InstructionalMethod } from '../../types/Section';
 import Instructor from '../../types/Instructor';
 import Grades from '../../types/Grades';
 import {
@@ -90,6 +90,7 @@ describe('Course Cards Redux', () => {
           asynchronous: false,
           instructor: new Instructor({ name: 'Instructor Name' }),
           grades: new Grades(grades),
+          instructionalMethod: InstructionalMethod.NONE,
         });
 
         const meetings = [new Meeting({
@@ -153,6 +154,7 @@ describe('Course Cards Redux', () => {
           asynchronous: false,
           instructor: new Instructor({ name: 'Instructor Name' }),
           grades: null,
+          instructionalMethod: InstructionalMethod.NONE,
         });
 
         const meetings = [
@@ -220,6 +222,7 @@ describe('Course Cards Redux', () => {
           asynchronous: false,
           instructor: new Instructor({ name: 'Instructor Name' }),
           grades: null,
+          instructionalMethod: InstructionalMethod.NONE,
         });
 
         const meetings = [
@@ -290,6 +293,7 @@ describe('Course Cards Redux', () => {
           honors: false,
           remote: false,
           asynchronous: false,
+          instructionalMethod: InstructionalMethod.NONE,
         });
 
         const meetings = [

--- a/autoscheduler/frontend/src/tests/redux/Redux.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/Redux.test.ts
@@ -2,7 +2,7 @@ import { createStore } from 'redux';
 import fetchMock from 'jest-fetch-mock';
 import autoSchedulerReducer from '../../redux/reducer';
 import { addMeeting, removeMeeting, replaceMeetings } from '../../redux/actions/meetings';
-import Section from '../../types/Section';
+import Section, { InstructionalMethod } from '../../types/Section';
 import Instructor from '../../types/Instructor';
 import Meeting, { MeetingType } from '../../types/Meeting';
 
@@ -23,6 +23,7 @@ const testSection = new Section({
     name: 'Aakash Tyagi',
   }),
   grades: null,
+  instructionalMethod: InstructionalMethod.NONE,
 });
 
 const testMeeting1 = new Meeting({

--- a/autoscheduler/frontend/src/tests/redux/Schedule.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/Schedule.test.ts
@@ -5,7 +5,7 @@ import {
   unsaveSchedule, renameSchedule,
 } from '../../redux/actions/schedules';
 import Meeting, { MeetingType } from '../../types/Meeting';
-import Section from '../../types/Section';
+import Section, { InstructionalMethod } from '../../types/Section';
 import Instructor from '../../types/Instructor';
 
 const testSectionA = new Section({
@@ -25,6 +25,7 @@ const testSectionA = new Section({
     name: 'Aakash Tyagi',
   }),
   grades: null,
+  instructionalMethod: InstructionalMethod.NONE,
 });
 
 const testSectionB = new Section({
@@ -44,6 +45,7 @@ const testSectionB = new Section({
     name: 'Bad Bunny',
   }),
   grades: null,
+  instructionalMethod: InstructionalMethod.NONE,
 });
 
 const testSectionC = new Section({
@@ -63,6 +65,7 @@ const testSectionC = new Section({
     name: 'Creed Cratton',
   }),
   grades: null,
+  instructionalMethod: InstructionalMethod.NONE,
 });
 
 const testMeeting1 = new Meeting({

--- a/autoscheduler/frontend/src/tests/testData.ts
+++ b/autoscheduler/frontend/src/tests/testData.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/camelcase */
 
 import { GenerateSchedulesResponse } from '../types/APIResponses';
+import { InstructionalMethod } from '../types/Section';
 
 /**
  * Mocks the fetch call made to the API to retrieve all sections of a given course. Should return
@@ -24,6 +25,7 @@ export default async function testFetch(route: string): Promise<Response> {
     remote: false,
     asynchronous: false,
     instructor_name: 'Aakash Tyagi',
+    instructional_method: InstructionalMethod.F2F,
   };
   const testSection2 = {
     id: 123458,
@@ -39,6 +41,7 @@ export default async function testFetch(route: string): Promise<Response> {
     remote: false,
     asynchronous: false,
     instructor_name: 'Aakash Tyagi',
+    instructional_method: InstructionalMethod.NONE,
   };
   const testSection3 = {
     id: 123457,
@@ -54,6 +57,7 @@ export default async function testFetch(route: string): Promise<Response> {
     remote: false,
     asynchronous: false,
     instructor_name: 'Somebody Else',
+    instructional_method: InstructionalMethod.NONE,
   };
   const testSection4 = {
     id: 830262,
@@ -69,6 +73,7 @@ export default async function testFetch(route: string): Promise<Response> {
     remote: false,
     asynchronous: false,
     instructor_name: 'Dr. Pepper',
+    instructional_method: InstructionalMethod.NONE,
   };
   // for asynchronous testing
   const testSection5 = {
@@ -85,6 +90,7 @@ export default async function testFetch(route: string): Promise<Response> {
     remote: false,
     asynchronous: true,
     instructor_name: 'Coca Cola',
+    instructional_method: InstructionalMethod.NONE,
   };
 
   // test that different sections do different things

--- a/autoscheduler/frontend/src/tests/testSchedules.ts
+++ b/autoscheduler/frontend/src/tests/testSchedules.ts
@@ -1,4 +1,4 @@
-import Section from '../types/Section';
+import Section, { InstructionalMethod } from '../types/Section';
 import Instructor from '../types/Instructor';
 import Meeting, { MeetingType } from '../types/Meeting';
 
@@ -22,6 +22,7 @@ const testSection1 = new Section({
     name: 'Aakash Tyagi',
   }),
   grades: null,
+  instructionalMethod: InstructionalMethod.NONE,
 });
 
 const testSection2 = new Section({
@@ -41,6 +42,7 @@ const testSection2 = new Section({
     name: 'James Pennington',
   }),
   grades: null,
+  instructionalMethod: InstructionalMethod.NONE,
 });
 
 const testSection3 = new Section({
@@ -60,6 +62,7 @@ const testSection3 = new Section({
     name: 'William Cohn',
   }),
   grades: null,
+  instructionalMethod: InstructionalMethod.NONE,
 });
 
 const testMeeting = new Meeting({
@@ -125,6 +128,7 @@ const testSectionA = new Section({
   asynchronous: false,
   instructor: new Instructor({ name: 'Deborah Seagle' }),
   grades: null,
+  instructionalMethod: InstructionalMethod.NONE,
 });
 
 const testMeeting5 = new Meeting({
@@ -165,6 +169,7 @@ const testSectionB = new Section({
   asynchronous: false,
   instructor: new Instructor({ name: 'Donald Trump' }),
   grades: null,
+  instructionalMethod: InstructionalMethod.NONE,
 });
 
 const testMeeting7 = new Meeting({
@@ -194,6 +199,7 @@ const testSectionC = new Section({
   asynchronous: false,
   instructor: new Instructor({ name: 'Harley Quinn' }),
   grades: null,
+  instructionalMethod: InstructionalMethod.NONE,
 });
 
 const testMeeting8 = new Meeting({
@@ -223,6 +229,7 @@ const testSectionD = new Section({
   asynchronous: false,
   instructor: new Instructor({ name: 'Naruto Uchiha' }),
   grades: null,
+  instructionalMethod: InstructionalMethod.NONE,
 });
 
 const testMeeting9 = new Meeting({
@@ -252,6 +259,7 @@ const testSectionE = new Section({
   asynchronous: false,
   instructor: new Instructor({ name: 'Shawn Lupoli' }),
   grades: null,
+  instructionalMethod: InstructionalMethod.NONE,
 });
 
 const testMeeting10 = new Meeting({
@@ -281,6 +289,7 @@ const testSectionF = new Section({
   asynchronous: false,
   instructor: new Instructor({ name: 'Albert Einstein' }),
   grades: null,
+  instructionalMethod: InstructionalMethod.NONE,
 });
 
 const testMeeting11 = new Meeting({
@@ -310,6 +319,7 @@ const testSectionG = new Section({
   asynchronous: false,
   instructor: new Instructor({ name: 'Leonardo DiCaprio' }),
   grades: null,
+  instructionalMethod: InstructionalMethod.NONE,
 });
 
 const testMeeting12 = new Meeting({
@@ -339,6 +349,7 @@ const testSectionH = new Section({
   asynchronous: false,
   instructor: new Instructor({ name: 'Morgan Freeman' }),
   grades: null,
+  instructionalMethod: InstructionalMethod.NONE,
 });
 
 const testMeeting13 = new Meeting({

--- a/autoscheduler/frontend/src/tests/types/Meeting.test.ts
+++ b/autoscheduler/frontend/src/tests/types/Meeting.test.ts
@@ -1,6 +1,6 @@
 import Meeting, { MeetingType } from '../../types/Meeting';
 import { Indexable, fetchMock } from '../util';
-import Section from '../../types/Section';
+import Section, { InstructionalMethod } from '../../types/Section';
 import Instructor from '../../types/Instructor';
 
 // arrange
@@ -30,6 +30,7 @@ const correctArgs: Indexable = {
       name: 'Aakash Tyagi',
     }),
     grades: null,
+    instructionalMethod: InstructionalMethod.NONE,
   }),
 };
 const createMeeting = jest.fn((args) => new Meeting(fetchMock(args)));

--- a/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
@@ -7,7 +7,7 @@ enableFetchMocks();
 /* eslint-disable @typescript-eslint/camelcase */ // needed to mock server responses
 import * as React from 'react';
 import {
-  render, fireEvent, waitFor, queryByTitle as queryByTitleIn,
+  render, fireEvent, waitFor, queryByTitle as queryByTitleIn, within,
 } from '@testing-library/react';
 import 'isomorphic-fetch';
 import { createStore, applyMiddleware } from 'redux';
@@ -18,6 +18,7 @@ import autoSchedulerReducer from '../../redux/reducer';
 import testFetch from '../testData';
 import setTerm from '../../redux/actions/term';
 import { updateCourseCard } from '../../redux/actions/courseCards';
+import { InstructionalMethod } from '../../types/Section';
 
 const dummySectionArgs = {
   id: 123456,
@@ -729,6 +730,43 @@ describe('Course Select Card UI', () => {
       // assert
       const placeholder = 'There are no available sections for this term';
       expect(queryByText(placeholder)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('shows the appropriate instructional method for sections', () => {
+    test('when the instructional method is face to face', async () => {
+      // arrange
+      fetchMock.mockResponseOnce(JSON.stringify({ // api/course/search
+        results: ['CSCE 121', 'CSCE 221', 'CSCE 312'],
+      }));
+      fetchMock.mockImplementationOnce(testFetch); // api/sections
+
+      const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
+      store.dispatch(setTerm('201931'));
+      const { getByText, getByLabelText, findByText } = render(
+        <Provider store={store}><CourseSelectCard id={0} /></Provider>,
+      );
+
+      // act
+      // fill in course
+      const courseEntry = getByLabelText('Course') as HTMLInputElement;
+      fireEvent.change(courseEntry, { target: { value: 'CSCE ' } });
+      const csce121Btn = await findByText('CSCE 121');
+      fireEvent.click(csce121Btn);
+
+      // switch to section view
+      fireEvent.click(getByText('Section'));
+
+      // wait until the card is showing section options
+      const sectionLabel = await waitFor(() => getByText(
+        (content, element) => ignoreInvisible(content, element, '501'),
+      ));
+
+      // query for instructional method tooltip
+      const tooltip = within(sectionLabel).getByTitle(InstructionalMethod.F2F);
+
+      // assert
+      expect(tooltip).toBeInTheDocument();
     });
   });
 });

--- a/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
@@ -164,7 +164,7 @@ describe('Course Select Card UI', () => {
       const honorsLabels = getAllByTestId('honors');
       const sectionLabels = getAllByText(
         (content, element) => ignoreInvisible(content, element, sectionNumsRegex),
-      ).map((el) => el.textContent);
+      ).map((el) => el.textContent.trim());
 
       // assert
       expect(sectionLabels).toEqual(sortedSectionNums);

--- a/autoscheduler/frontend/src/tests/ui/MeetingCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/MeetingCard.test.tsx
@@ -6,7 +6,7 @@ import { Provider } from 'react-redux';
 import { createStore, Store } from 'redux';
 import MeetingCard from '../../components/SchedulingPage/Schedule/MeetingCard/MeetingCard';
 import Meeting, { MeetingType } from '../../types/Meeting';
-import Section from '../../types/Section';
+import Section, { InstructionalMethod } from '../../types/Section';
 import Instructor from '../../types/Instructor';
 import autoSchedulerReducer from '../../redux/reducer';
 
@@ -27,6 +27,7 @@ const testSection = new Section({
     name: 'Aakash Tyagi',
   }),
   grades: null,
+  instructionalMethod: InstructionalMethod.NONE,
 });
 
 const testMeeting = new Meeting({

--- a/autoscheduler/frontend/src/tests/ui/Schedule.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/Schedule.test.tsx
@@ -10,7 +10,7 @@ import * as React from 'react';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
 import Meeting, { MeetingType } from '../../types/Meeting';
-import Section from '../../types/Section';
+import Section, { InstructionalMethod } from '../../types/Section';
 import Instructor from '../../types/Instructor';
 import Schedule from '../../components/SchedulingPage/Schedule/Schedule';
 import autoSchedulerReducer from '../../redux/reducer';
@@ -36,6 +36,7 @@ const testSection = new Section({
     name: 'Aakash Tyagi',
   }),
   grades: null,
+  instructionalMethod: InstructionalMethod.NONE,
 });
 
 const testMeeting1 = new Meeting({

--- a/autoscheduler/frontend/src/tests/ui/SchedulePreview.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SchedulePreview.test.tsx
@@ -13,7 +13,7 @@ import SchedulePreview from '../../components/SchedulingPage/SchedulePreview/Sch
 import autoSchedulerReducer from '../../redux/reducer';
 import { replaceSchedules, setSchedules } from '../../redux/actions/schedules';
 import { testSchedule1, testSchedule2 } from '../testSchedules';
-import Section from '../../types/Section';
+import Section, { InstructionalMethod } from '../../types/Section';
 import Instructor from '../../types/Instructor';
 import Meeting, { MeetingType } from '../../types/Meeting';
 import setTerm from '../../redux/actions/term';
@@ -269,6 +269,7 @@ describe('SchedulePreview component', () => {
           asynchronous: false,
           instructor: new Instructor({ name: 'Dr. Pepper' }),
           grades: null,
+          instructionalMethod: InstructionalMethod.NONE,
         }),
       })],
       saved: true,

--- a/autoscheduler/frontend/src/tests/ui/SectionSelect.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SectionSelect.test.tsx
@@ -4,7 +4,7 @@ import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 import { render, queryByTitle as queryByTitleIn, fireEvent } from '@testing-library/react';
 import { CourseCardOptions } from '../../types/CourseCardOptions';
-import Section from '../../types/Section';
+import Section, { InstructionalMethod } from '../../types/Section';
 import Instructor from '../../types/Instructor';
 import Meeting, { MeetingType } from '../../types/Meeting';
 import autoSchedulerReducer from '../../redux/reducer';
@@ -27,6 +27,7 @@ const dummySection: Section = {
   asynchronous: false,
   instructor: new Instructor({ name: 'Dr. Doofenschmirtz' }),
   grades: null,
+  instructionalMethod: InstructionalMethod.NONE,
 };
 
 const dummyMeeting: Meeting = {
@@ -154,6 +155,7 @@ describe('SectionSelect', () => {
         remote: true,
         asynchronous: false,
         grades: null,
+        instructionalMethod: InstructionalMethod.NONE,
       });
       const testMeeting = new Meeting({
         id: 1,
@@ -207,6 +209,7 @@ describe('SectionSelect', () => {
         remote: true,
         asynchronous: false,
         grades: null,
+        instructionalMethod: InstructionalMethod.NONE,
       });
       const testMeeting = new Meeting({
         id: 1,
@@ -265,6 +268,7 @@ describe('SectionSelect', () => {
         remote: true,
         asynchronous: false,
         grades: null,
+        instructionalMethod: InstructionalMethod.NONE,
       });
       const testMeeting = new Meeting({
         id: 1,
@@ -326,6 +330,7 @@ describe('SectionSelect', () => {
         remote: true,
         asynchronous: false,
         grades: null,
+        instructionalMethod: InstructionalMethod.NONE,
       });
       const testMeeting1 = new Meeting({
         id: 1,
@@ -447,6 +452,7 @@ describe('SectionSelect', () => {
         remote: true,
         asynchronous: false,
         grades: null,
+        instructionalMethod: InstructionalMethod.NONE,
       });
       const testMeeting = new Meeting({
         id: 1,
@@ -502,6 +508,7 @@ describe('SectionSelect', () => {
         remote: false,
         asynchronous: false,
         grades: null,
+        instructionalMethod: InstructionalMethod.NONE,
       });
       const testMeeting = new Meeting({
         id: 1,
@@ -557,6 +564,7 @@ describe('SectionSelect', () => {
         remote: true,
         grades: null,
         asynchronous: false,
+        instructionalMethod: InstructionalMethod.NONE,
       });
       const testMeeting = new Meeting({
         id: 1,
@@ -614,6 +622,7 @@ describe('SectionSelect', () => {
         remote: true,
         asynchronous: false,
         grades: null,
+        instructionalMethod: InstructionalMethod.NONE,
       });
       const testMeeting = new Meeting({
         id: 1,
@@ -669,6 +678,7 @@ describe('SectionSelect', () => {
         remote: false,
         asynchronous: false,
         grades: null,
+        instructionalMethod: InstructionalMethod.NONE,
       });
       const testMeeting = new Meeting({
         id: 1,
@@ -726,6 +736,7 @@ describe('SectionSelect', () => {
         remote: true,
         asynchronous: false,
         grades: null,
+        instructionalMethod: InstructionalMethod.NONE,
       });
       const testMeeting = new Meeting({
         id: 1,

--- a/autoscheduler/frontend/src/theme.ts
+++ b/autoscheduler/frontend/src/theme.ts
@@ -3,11 +3,13 @@ import grey from '@material-ui/core/colors/grey';
 import { Overrides } from '@material-ui/core/styles/overrides';
 
 // Creates a global material UI theme
+export const textSecondary = grey[700];
 
 const palette = {
   primary: { main: '#500000', contrastText: '#ffffff' },
   secondary: { main: '#edc840', contrastText: '#000000' },
-  text: { secondary: grey[700] },
+  text: { secondary: textSecondary },
+  action: { active: textSecondary },
 };
 
 const overrides: Overrides = {

--- a/autoscheduler/frontend/src/types/Section.ts
+++ b/autoscheduler/frontend/src/types/Section.ts
@@ -1,6 +1,19 @@
 import Instructor from './Instructor';
 import Grades from './Grades';
 
+// Instructional methods from the backend, make sure these are synced with Django's Section model
+export enum InstructionalMethod {
+  F2F = 'Face to Face',
+  INTERNSHIP = 'Internship',
+  NONTRADITIONAL = 'Non-traditional',
+  WEB_BASED = 'Web Based',
+  STUDY_ABROAD = 'Study abroad',
+  NONE = '',
+  REMOTE = 'Remote Only',
+  F2F_REMOTE_OPTION = 'F2F or Remote',
+  MIXED_F2F_REMOTE = 'Mixed, F2F and Remote',
+}
+
 export default class Section {
   id: number;
   crn: number;
@@ -16,6 +29,7 @@ export default class Section {
   asynchronous: boolean;
   instructor: Instructor;
   grades: Grades;
+  instructionalMethod: InstructionalMethod;
 
   constructor(src: {
       id: number;
@@ -32,6 +46,7 @@ export default class Section {
       asynchronous: boolean;
       instructor: Instructor;
       grades: Grades;
+      instructionalMethod: InstructionalMethod;
     }) {
     if (!Number.isInteger(src.id)) { throw Error(`Section.id is invalid: ${src.id}`); }
     if (!Number.isInteger(src.crn)) { throw Error(`Meeting.crn is invalid: ${src.crn}`); }


### PR DESCRIPTION
## Description

Adds icons for instructional methods.

## Rationale

We've discussed whether we like all the icons here so there shouldn't be anything too controversial in this PR

## How to test

You can see most of the icons by looking at courses for MATH 151, ENGL 210, and JAPN 491, see `InstructionalMethodIcon.tsx` to look at all of them

## Screenshots

If it's a frontend change, provide screenshots of it. If possible, show the change on different
resolutions/sizes.

If you're changing a existing frontend look, provide a before and after screenshot in the table below.

|Before|After|
|--|--|
| ![image](https://user-images.githubusercontent.com/28655462/101934352-1603fc00-3ba3-11eb-983e-d766577863e5.png) | ![image](https://user-images.githubusercontent.com/28655462/101934482-43e94080-3ba3-11eb-9cff-d11311ff7a0f.png) |

## Related tasks
Closes #432.