### PR TITLE
Fix test failing after merge

### DIFF
--- a/autoscheduler/frontend/src/tests/redux/CourseCards.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/CourseCards.test.ts
@@ -375,6 +375,7 @@ describe('Course Cards Redux', () => {
           honors: false,
           remote: false,
           asynchronous: false,
+          instructionalMethod: InstructionalMethod.NONE,
         });
         const genericMeetingOutput = {
           building: '',


### PR DESCRIPTION
## Description
Fixes the test from master that failed after merging the instructional method icon PR

## Rationale

A test was added to master that didn't have the correct parameters for a section leading to compilation failing

## How to test
Run tests

## Screenshots


## Related tasks

n/a