### PR TITLE
Times are no longer covered by adjacent meetings

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/ScheduleCard/ScheduleCard.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/ScheduleCard/ScheduleCard.css
@@ -14,7 +14,8 @@
 }
 
 .schedule-card:hover {
-    z-index: 4;
+    /* needs important to override element styles */
+    z-index: 4 !important;
 }
 
 .start-time, .end-time {


### PR DESCRIPTION
## Description

We currently have a CSS bug where the start/end times for a meeting can be covered by an adjacent meeting if there's not enough time between classes. It looks like we've tried to fix this before, because we already have a style rule that increases the `z-index` on hover, but it's not being applied due to the element style rule taking priority. I fixed this by adding `!important` to the `.schedule-card:hover` style rule.

## Rationale

I could have also considered changing the `zIndex` that is applied in JavaScript at line 82 of `ScheduleCard.tsx`, but `!important` felt less invasive and less likely to break other things.

## How to test

Add PHYS 202-513 to your schedule. The recitation and lab times are back to back, so this should generate an overlap on GCP but you should be able to see the time on this branch.

## Screenshots

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/10082177/105770697-2ee32980-5f25-11eb-9456-b197c8a34cdd.png)|![image](https://user-images.githubusercontent.com/10082177/105771424-27705000-5f26-11eb-9b7d-ce02745235a0.png)|

## Related tasks

#219 