### PR TITLE
useMeetingColor returns the same map if possible

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/meetingColors.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/meetingColors.ts
@@ -13,7 +13,13 @@ export const colors = [
   '#612b0d', // dark brown
 ];
 
+let lastSectionIds = new Set<string>();
+let lastMap: Map<string, string> = null;
+const isSetEqual = (a: Set<string>, b: Set<string>): boolean => a.size === b.size
+  && [...a].every((val) => b.has(val));
+
 export default function useMeetingColor(): Map<string, string> {
+  // go through every section in every schedule and make a set of unique ID's
   const allSectionIds = new Set(useSelector<RootState, string[]>(
     (state) => state.schedules.reduce<string[]>(
       (arr, schedule) => arr.concat(
@@ -25,9 +31,16 @@ export default function useMeetingColor(): Map<string, string> {
     ),
   ));
 
+  if (lastSectionIds && isSetEqual(allSectionIds, lastSectionIds)) return lastMap;
+
   const sectionToColor = new Map<string, string>();
   [...allSectionIds.keys()].forEach((courseName, idx) => {
     sectionToColor.set(courseName, colors[idx % colors.length]);
   });
+
+  // memo-izde values for next time
+  lastSectionIds = allSectionIds;
+  lastMap = sectionToColor;
+
   return sectionToColor;
 }


### PR DESCRIPTION
## Description

Moving my mouse around the schedule has been very laggy recently, and I popped open the Profiler to figure out why. The `Schedule` component was apparently re-rendering every `MeetingCard`, but not the `AvailabilityCard`s, every time I moved my mouse. However, the meeting cards should have been memo-ized, so I looked at the dependency list to see why it was re-rendering them. The answer was that the `useMeetingColor` hook returns a new map every time the `Schedule` re-renders, which forces a re-render of the meeting cards.

I chose to fix this by adding static variables to keep track of the set of section ID's and the map of ID's to colors that were generated during the previous run of the hook. If the section ID's have not changes, then the hook will return the same Map object as last time rather than creating a new one. I tested in browser and mouse movement was much more smooth.

## Rationale

See above

## How to test

Move your mouse around the schedule after generating a schedule with a few classes. You can also profile it if you want.

## Screenshots

Too lazy to record a GIF. My excuse is that the lag might not be visible with GIF frame rate anyway.

## Related tasks

No issue created
