### PR TITLE
Disable course cards

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/CourseSelectCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/CourseSelectCard.tsx
@@ -93,6 +93,7 @@ const CourseSelectCard: React.FC<CourseSelectCardProps> = ({
             style={{
               transform: collapsed ? '' : 'rotate(180deg)',
             }}
+            aria-label={collapsed ? 'Expand' : 'Collapse'}
           />
         </div>
       </div>

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/CourseSelectCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/CourseSelectCard.tsx
@@ -14,7 +14,7 @@ import SmallFastProgress from '../../../SmallFastProgress';
 import * as styles from './ExpandedCourseCard/ExpandedCourseCard.css';
 import SectionSelect from './ExpandedCourseCard/SectionSelect/SectionSelect';
 import BasicSelect from './ExpandedCourseCard/BasicSelect/BasicSelect';
-import { getCourseHeaderCardColor } from '../../../../theme';
+import { getCourseCardHeaderColor } from '../../../../theme';
 
 interface CourseSelectCardProps {
   // id of the course card in Redux whose information will be displayed
@@ -56,7 +56,7 @@ const CourseSelectCard: React.FC<CourseSelectCardProps> = ({
       tabIndex={0}
       onKeyPress={toggleCollapsed}
       style={{
-        backgroundColor: getCourseHeaderCardColor(disabled),
+        backgroundColor: getCourseCardHeaderColor(disabled),
       }}
       data-testid="card-header"
     >

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/CourseSelectCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/CourseSelectCard.tsx
@@ -78,7 +78,7 @@ const CourseSelectCard: React.FC<CourseSelectCardProps> = ({
       </div>
       <div className={styles.rightHeaderGroup}>
         <span className={styles.course}>{collapsed && (course || 'No Course Selected')}</span>
-        <span className={styles.includeInSchedules}> {!collapsed && 'Include in schedules'}</span>
+        <span className={styles.includeInSchedules}>{!collapsed && 'Include in schedules'}</span>
         <Switch
           aria-label="Disable"
           checked={!disabled}

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/CourseSelectCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/CourseSelectCard.tsx
@@ -14,7 +14,7 @@ import SmallFastProgress from '../../../SmallFastProgress';
 import * as styles from './ExpandedCourseCard/ExpandedCourseCard.css';
 import SectionSelect from './ExpandedCourseCard/SectionSelect/SectionSelect';
 import BasicSelect from './ExpandedCourseCard/BasicSelect/BasicSelect';
-import { getDisabledCourseCardColor } from '../../../../theme';
+import { getCourseHeaderCardColor } from '../../../../theme';
 
 interface CourseSelectCardProps {
   // id of the course card in Redux whose information will be displayed
@@ -56,7 +56,7 @@ const CourseSelectCard: React.FC<CourseSelectCardProps> = ({
       tabIndex={0}
       onKeyPress={toggleCollapsed}
       style={{
-        backgroundColor: getDisabledCourseCardColor(disabled),
+        backgroundColor: getCourseHeaderCardColor(disabled),
       }}
       data-testid="card-header"
     >

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/CourseSelectCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/CourseSelectCard.tsx
@@ -76,9 +76,9 @@ const CourseSelectCard: React.FC<CourseSelectCardProps> = ({
       >
         <RemoveIcon />
       </div>
-      <span className={styles.course}>{collapsed && (course || 'No Course Selected')}</span>
       <div className={styles.rightHeaderGroup}>
-        {!collapsed && 'Include in schedule'}
+        <span className={styles.course}>{collapsed && (course || 'No Course Selected')}</span>
+        <span className={styles.includeInSchedules}> {!collapsed && 'Include in schedules'}</span>
         <Switch
           aria-label="Disable"
           checked={!disabled}

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/CourseSelectCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/CourseSelectCard.tsx
@@ -4,7 +4,7 @@ import RemoveIcon from '@material-ui/icons/Delete';
 import CollapseIcon from '@material-ui/icons/ExpandLess';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import {
-  TextField, ButtonGroup, Button, FormLabel, Card, Typography, Collapse,
+  TextField, ButtonGroup, Button, FormLabel, Card, Typography, Collapse, Switch,
 } from '@material-ui/core';
 import { RootState } from '../../../../redux/reducer';
 import { updateCourseCard } from '../../../../redux/actions/courseCards';
@@ -14,6 +14,7 @@ import SmallFastProgress from '../../../SmallFastProgress';
 import * as styles from './ExpandedCourseCard/ExpandedCourseCard.css';
 import SectionSelect from './ExpandedCourseCard/SectionSelect/SectionSelect';
 import BasicSelect from './ExpandedCourseCard/BasicSelect/BasicSelect';
+import { getDisabledCourseCardColor } from '../../../../theme';
 
 interface CourseSelectCardProps {
   // id of the course card in Redux whose information will be displayed
@@ -34,7 +35,9 @@ const CourseSelectCard: React.FC<CourseSelectCardProps> = ({
 }) => {
   const dispatch = useDispatch();
   const term = useSelector<RootState, string>((state) => state.termData.term);
-  const { course, customizationLevel, loading } = useSelector<RootState, CourseCardOptions>(
+  const {
+    course, customizationLevel, loading, disabled,
+  } = useSelector<RootState, CourseCardOptions>(
     (state) => state.termData.courseCards[id],
   );
 
@@ -52,6 +55,10 @@ const CourseSelectCard: React.FC<CourseSelectCardProps> = ({
       role="button"
       tabIndex={0}
       onKeyPress={toggleCollapsed}
+      style={{
+        backgroundColor: getDisabledCourseCardColor(disabled),
+      }}
+      data-testid="card-header"
     >
       <div
         className={styles.headerGroup}
@@ -68,17 +75,26 @@ const CourseSelectCard: React.FC<CourseSelectCardProps> = ({
         aria-label="Remove"
       >
         <RemoveIcon />
-        {!collapsed && 'Remove'}
       </div>
       <span className={styles.course}>{collapsed && (course || 'No Course Selected')}</span>
-      <div className={styles.headerGroup}>
-        <CollapseIcon
-          classes={{ root: styles.rotatableIcon }}
-          style={{
-            transform: collapsed ? '' : 'rotate(180deg)',
+      <div className={styles.rightHeaderGroup}>
+        {!collapsed && 'Include in schedule'}
+        <Switch
+          aria-label="Disable"
+          checked={!disabled}
+          onClick={(evt): void => {
+            dispatch(updateCourseCard(id, { disabled: !disabled }));
+            evt.stopPropagation();
           }}
-          aria-label={collapsed ? 'Expand' : 'Collapse'}
         />
+        <div className={styles.headerGroup}>
+          <CollapseIcon
+            classes={{ root: styles.rotatableIcon }}
+            style={{
+              transform: collapsed ? '' : 'rotate(180deg)',
+            }}
+          />
+        </div>
       </div>
     </div>
   );

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.css
@@ -30,6 +30,12 @@
     cursor: pointer;
 }
 
+.right-header-group {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
 .header-group {
     display: flex;
     flex-direction: row;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.css
@@ -34,6 +34,8 @@
     display: flex;
     flex-direction: row;
     align-items: center;
+    overflow: auto;
+    width: 100%;    
 }
 
 .header-group {
@@ -98,4 +100,11 @@
 .rotatable-icon {
     transition: transform 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,
     fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms !important;
+}
+
+.include-in-schedules {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-align: right;
 }

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.css
@@ -35,7 +35,7 @@
     flex-direction: row;
     align-items: center;
     overflow: auto;
-    width: 100%;    
+    width: 100%;
 }
 
 .header-group {

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.css.d.ts
@@ -18,6 +18,8 @@ declare namespace ExpandedCourseCardCssNamespace {
     headerGroup: string;
     "no-elevation": string;
     noElevation: string;
+    "right-header-group": string;
+    rightHeaderGroup: string;
     "rotatable-icon": string;
     rotatableIcon: string;
   }

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/ExpandedCourseCard.css.d.ts
@@ -16,6 +16,8 @@ declare namespace ExpandedCourseCardCssNamespace {
     header: string;
     "header-group": string;
     headerGroup: string;
+    "include-in-schedules": string;
+    includeInSchedules: string;
     "no-elevation": string;
     noElevation: string;
     "right-header-group": string;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
@@ -151,6 +151,7 @@ const CourseSelectColumn: React.FC = () => {
             collapsed: course.collapsed,
             sortType: course.sortType,
             sortIsDescending: course.sortIsDescending,
+            disabled: course.disabled,
           });
         }
       }

--- a/autoscheduler/frontend/src/redux/actions/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/actions/courseCards.ts
@@ -28,6 +28,7 @@ function createEmptyCourseCard(): CourseCardOptions {
     collapsed: false,
     sortType: SortType.DEFAULT,
     sortIsDescending: true,
+    disabled: false,
   };
 }
 

--- a/autoscheduler/frontend/src/redux/actions/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/actions/courseCards.ts
@@ -333,6 +333,7 @@ function deserializeCourseCard(courseCard: SerializedCourseCardOptions): CourseC
     loading: true,
     sortType: courseCard.sortType,
     sortIsDescending: courseCard.sortIsDescending,
+    disabled: courseCard.disabled,
   };
 }
 

--- a/autoscheduler/frontend/src/redux/actions/schedules.ts
+++ b/autoscheduler/frontend/src/redux/actions/schedules.ts
@@ -83,6 +83,10 @@ ThunkAction<Promise<void>, RootState, undefined, ReplaceSchedulesAction | Select
       if (courseCards[i] && courseCards[i].course) {
         const courseCard = courseCards[i];
 
+        // If the course card is disabled, skip it
+        // eslint-disable-next-line no-continue
+        if (courseCard.disabled) continue;
+
         // Iterate through the sections and only choose the ones that are selected
         const selectedSections = courseCard.sections
           .filter((sectionSel) => sectionSel.selected)

--- a/autoscheduler/frontend/src/tests/redux/Schedule.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/Schedule.test.ts
@@ -518,7 +518,7 @@ describe('Schedule Redux', () => {
       }, '202031'));
 
       // Add a course card that will be sent with /scheduler/generate
-      store.dispatch<any>(addCourseCard());
+      store.dispatch<any>(addCourseCard('202031'));
       store.dispatch<any>(updateCourseCard(1, {
         course: 'MATH 151',
       }, '202031'));

--- a/autoscheduler/frontend/src/tests/redux/Schedule.test.ts
+++ b/autoscheduler/frontend/src/tests/redux/Schedule.test.ts
@@ -524,7 +524,7 @@ describe('Schedule Redux', () => {
       }, '202031'));
 
       // act
-      store.dispatch<any>(generateSchedules(true));
+      store.dispatch<any>(generateSchedules());
 
       // Third call is the /scheduler/generate call. Second index of that call is the body
       const { body } = fetchMock.mock.calls[2][1];

--- a/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
@@ -20,7 +20,7 @@ import setTerm from '../../redux/actions/term';
 import { updateCourseCard } from '../../redux/actions/courseCards';
 import { InstructionalMethod } from '../../types/Section';
 import CourseSelectColumn from '../../components/SchedulingPage/CourseSelectColumn/CourseSelectColumn';
-import { getCourseHeaderCardColor } from '../../theme';
+import { getCourseCardHeaderColor } from '../../theme';
 
 function ignoreInvisible(content: string, element: HTMLElement, query: string | RegExp): boolean {
   if (element.style.visibility === 'hidden') return false;
@@ -660,7 +660,7 @@ describe('Course Select Card UI', () => {
         );
 
         const header = getByTestId('card-header');
-        const headerColor = getCourseHeaderCardColor(false); // Should be "#500"
+        const headerColor = getCourseCardHeaderColor(false); // Should be "#500"
         // pre-assertion to make sure it's not disabled yet
         expect(header).toHaveStyle(`background-color: ${headerColor}`);
 

--- a/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
@@ -57,6 +57,8 @@ describe('Course Select Card UI', () => {
 
       const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
       store.dispatch(setTerm('201931'));
+      // Disable the course cards so it doesn't count for 'Mui-checked'
+      store.dispatch<any>(updateCourseCard(0, { disabled: true }, '201931'));
       const {
         getByText, getByLabelText, findByText,
       } = render(

--- a/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
@@ -20,6 +20,7 @@ import setTerm from '../../redux/actions/term';
 import { updateCourseCard } from '../../redux/actions/courseCards';
 import { InstructionalMethod } from '../../types/Section';
 import CourseSelectColumn from '../../components/SchedulingPage/CourseSelectColumn/CourseSelectColumn';
+import { getCourseHeaderCardColor } from '../../theme';
 
 function ignoreInvisible(content: string, element: HTMLElement, query: string | RegExp): boolean {
   if (element.style.visibility === 'hidden') return false;
@@ -659,8 +660,9 @@ describe('Course Select Card UI', () => {
         );
 
         const header = getByTestId('card-header');
+        const headerColor = getCourseHeaderCardColor(false); // Should be "#500"
         // pre-assertion to make sure it's not disabled yet
-        expect(header).toHaveStyle('background-color: #500');
+        expect(header).toHaveStyle(`background-color: ${headerColor}`);
 
         // act
         const disable = getByLabelText('Disable');
@@ -668,7 +670,7 @@ describe('Course Select Card UI', () => {
 
         // assert
         // Don't care what color it changed to - just that it changed from the default
-        expect(header).not.toHaveStyle('background-color: #500');
+        expect(header).not.toHaveStyle(`background-color: ${headerColor}`);
       });
     });
   });

--- a/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
@@ -655,7 +655,7 @@ describe('Course Select Card UI', () => {
         const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
         const { getByLabelText, getByTestId } = render(
           <Provider store={store}>
-            <CourseSelectCard id={0} />
+            <CourseSelectCard collapsed={false} id={0} />
           </Provider>,
         );
 

--- a/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/CourseSelectCard.test.tsx
@@ -644,4 +644,30 @@ describe('Course Select Card UI', () => {
       expect(tooltip).toBeInTheDocument();
     });
   });
+
+  describe('disabled course cards', () => {
+    describe('changes the card header color', () => {
+      test('when the card is disabled', async () => {
+        // arrange
+        const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
+        const { getByLabelText, getByTestId } = render(
+          <Provider store={store}>
+            <CourseSelectCard id={0} />
+          </Provider>,
+        );
+
+        const header = getByTestId('card-header');
+        // pre-assertion to make sure it's not disabled yet
+        expect(header).toHaveStyle('background-color: #500');
+
+        // act
+        const disable = getByLabelText('Disable');
+        fireEvent.click(disable);
+
+        // assert
+        // Don't care what color it changed to - just that it changed from the default
+        expect(header).not.toHaveStyle('background-color: #500');
+      });
+    });
+  });
 });

--- a/autoscheduler/frontend/src/tests/ui/CourseSelectColumn.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/CourseSelectColumn.test.tsx
@@ -88,7 +88,7 @@ describe('CourseSelectColumn', () => {
       // sessions/get_saved_courses
       fetchMock.mockResponseOnce(JSON.stringify({}));
 
-      const { getByText, queryAllByText } = render(
+      const { getByLabelText, queryAllByLabelText } = render(
         <Provider store={store}>
           <CourseSelectColumn />
         </Provider>,
@@ -96,9 +96,9 @@ describe('CourseSelectColumn', () => {
 
       // act
       // Press the button
-      act(() => { fireEvent.click(getByText('Remove')); });
+      act(() => { fireEvent.click(getByLabelText('Remove')); });
 
-      const cardsCount = queryAllByText('Remove').length;
+      const cardsCount = queryAllByLabelText('Remove').length;
 
       // assert
       // Starts with 1 by default, so removing one should make it 0
@@ -129,7 +129,7 @@ describe('CourseSelectColumn', () => {
       fetchMock.mockResponseOnce(JSON.stringify({}));
 
       const {
-        getByText, getAllByLabelText, findByText, getAllByDisplayValue,
+        getAllByLabelText, findByText, getAllByText, getAllByDisplayValue,
       } = render(
         <Provider store={store}>
           <CourseSelectColumn />
@@ -150,8 +150,12 @@ describe('CourseSelectColumn', () => {
       fireEvent.change(courseEntry, { target: { value: 'C' } });
       fireEvent.click(await findByText('CSCE 121'));
 
+      // Disable the course card so it doesn't count for 'Mui-checked'
+      store.dispatch<any>(updateCourseCard(0, { disabled: true }, '201931'));
+      store.dispatch<any>(updateCourseCard(1, { disabled: true }, '201931'));
+
       // switch to section select and select section 501
-      fireEvent.click(getByText(ignoreInvisible('Section')));
+      fireEvent.click(getAllByText(ignoreInvisible('Section'))[0]);
       fireEvent.click(
         await findByText('501'),
       );

--- a/autoscheduler/frontend/src/theme.ts
+++ b/autoscheduler/frontend/src/theme.ts
@@ -81,6 +81,6 @@ export const whiteButtonTheme = createMuiTheme({
  * Gets the color of the course card header depending on its disabled status
  * @param disabled Whether the course card is disable or not
  */
-export function getCourseHeaderCardColor(disabled: boolean): string {
+export function getCourseCardHeaderColor(disabled: boolean): string {
   return disabled ? '#666' : '#500';
 }

--- a/autoscheduler/frontend/src/theme.ts
+++ b/autoscheduler/frontend/src/theme.ts
@@ -37,6 +37,33 @@ const overrides: Overrides = {
       flexWrap: 'nowrap',
     },
   },
+  MuiSwitch: {
+    root: {
+      width: 50,
+      height: 30,
+      padding: 7,
+    },
+    switchBase: {
+      padding: 5,
+      color: '#aaa', // unselected/disabled color
+      '&$checked': {
+        color: 'white !important',
+      },
+      '&$checked + $track': {
+        opacity: 0.75, // Default is 0.5
+      },
+    },
+    thumb: {
+      width: 20,
+      height: 20,
+    },
+    track: {
+      borderRadius: 58 / 2,
+      opacity: 1,
+      backgroundColor: 'white', // disabled background color
+    },
+    checked: {},
+  },
 };
 
 export default createMuiTheme({ palette, overrides });
@@ -49,3 +76,7 @@ const whiteButtonPalette = {
 export const whiteButtonTheme = createMuiTheme({
   palette: whiteButtonPalette,
 });
+
+export function getDisabledCourseCardColor(disabled: boolean): string {
+  return disabled ? '#666' : '#500';
+}

--- a/autoscheduler/frontend/src/theme.ts
+++ b/autoscheduler/frontend/src/theme.ts
@@ -77,6 +77,10 @@ export const whiteButtonTheme = createMuiTheme({
   palette: whiteButtonPalette,
 });
 
-export function getDisabledCourseCardColor(disabled: boolean): string {
+/**
+ * Gets the color of the course card header depending on its disabled status
+ * @param disabled Whether the course card is disable or not
+ */
+export function getCourseHeaderCardColor(disabled: boolean): string {
   return disabled ? '#666' : '#500';
 }

--- a/autoscheduler/frontend/src/types/CourseCardOptions.ts
+++ b/autoscheduler/frontend/src/types/CourseCardOptions.ts
@@ -65,6 +65,7 @@ export interface CourseCardOptions {
   collapsed?: boolean;
   sortType?: SortType;
   sortIsDescending?: boolean;
+  disabled?: boolean;
 }
 
 // Represents a course card when saved and serialized, sections are saved as strings
@@ -80,6 +81,7 @@ export interface SerializedCourseCardOptions {
   collapsed?: boolean;
   sortType?: SortType;
   sortIsDescending?: boolean;
+  disabled?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Description

This adds a switch to the course card header which allows you to "disable" a course card, which includes or excludes it from the generated schedule. 

It also removes the `Collapse` and `Remove` text from the course card header in place of the "Include in schedule" text for the switch.

It also adds as custom switch since the default one was too tall and we didn't like the colors of it.

## How to test

Add any 2 course cards, disable one of them, generate schedules, and ensure that the disabled course card isn't included in the generated schedule. 

## Screenshots

![disabled-course-cards-demo](https://user-images.githubusercontent.com/7295783/106393464-143d0480-63ac-11eb-95fa-6f0eaadf455e.gif)

## Related tasks

Closes #379 
