### PR TITLE
Schedule preview improvements

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ColorBox.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ColorBox.tsx
@@ -1,12 +1,15 @@
+import { CSSProperties } from '@material-ui/styles';
 import * as React from 'react';
 import * as styles from '../SchedulePreview.css';
 
 interface ColorBoxProps {
-  color: string;
+  color?: string;
 }
 
-const ColorBox: React.FC<ColorBoxProps> = ({ color }) => (
-  <span className={styles.colorBox} style={{ backgroundColor: color }} />
-);
+const ColorBox: React.FC<ColorBoxProps> = ({ color }) => {
+  const colorBoxStyle: CSSProperties = color ? { backgroundColor: color } : { visibility: 'hidden' };
+
+  return <span className={styles.colorBox} style={colorBoxStyle} />;
+};
 
 export default ColorBox;

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ColorBox.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ColorBox.tsx
@@ -1,4 +1,3 @@
-import { CSSProperties } from '@material-ui/styles';
 import * as React from 'react';
 import * as styles from '../SchedulePreview.css';
 
@@ -7,9 +6,17 @@ interface ColorBoxProps {
 }
 
 const ColorBox: React.FC<ColorBoxProps> = ({ color }) => {
-  const colorBoxStyle: CSSProperties = color ? { backgroundColor: color } : { visibility: 'hidden' };
+  return color ? (
+    <span className={styles.colorBox} style={{ backgroundColor: color }} />
+  ) : (
+    <span className={styles.colorBoxPlaceholder} style={{ backgroundColor: '#fff' }}>
+      <span className={styles.xIconOuter}>
+        <span className={styles.xIconInner} />
+      </span>
+    </span>
+  );
+  // const colorBoxStyle: CSSProperties = color ? { backgroundColor: color } : { visibility: 'hidden' };
 
-  return <span className={styles.colorBox} style={colorBoxStyle} />;
 };
 
 export default ColorBox;

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ColorBox.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ColorBox.tsx
@@ -5,8 +5,8 @@ interface ColorBoxProps {
   color?: string;
 }
 
-const ColorBox: React.FC<ColorBoxProps> = ({ color }) => {
-  return color ? (
+const ColorBox: React.FC<ColorBoxProps> = ({ color }) => (
+  color ? (
     <span className={styles.colorBox} style={{ backgroundColor: color }} />
   ) : (
     <span className={styles.colorBoxPlaceholder} style={{ backgroundColor: '#fff' }}>
@@ -14,9 +14,7 @@ const ColorBox: React.FC<ColorBoxProps> = ({ color }) => {
         <span className={styles.xIconInner} />
       </span>
     </span>
-  );
-  // const colorBoxStyle: CSSProperties = color ? { backgroundColor: color } : { visibility: 'hidden' };
-
-};
+  )
+);
 
 export default ColorBox;

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ColorBox.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ColorBox.tsx
@@ -9,7 +9,7 @@ const ColorBox: React.FC<ColorBoxProps> = ({ color }) => (
   color ? (
     <span className={styles.colorBox} style={{ backgroundColor: color }} />
   ) : (
-    <span className={styles.colorBoxPlaceholder} style={{ backgroundColor: '#fff' }}>
+    <span className={styles.colorBox} style={{ backgroundColor: '#fff' }}>
       <span className={styles.xIconOuter}>
         <span className={styles.xIconInner} />
       </span>

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ScheduleListItem.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ScheduleListItem.tsx
@@ -59,13 +59,17 @@ const ScheduleListItem: React.FC<ScheduleListItemProps> = ({ index, onDetailsCli
     </ListItemSecondaryAction>
   );
 
-  const scheduleSections = sectionsForSchedule(schedule).map((sec: Section) => (
-    <span key={sec.id} className={styles.sectionLabelRow}>
-      <ColorBox color={meetingColors.get(sec.subject + sec.courseNum)} />
-      {`${sec.subject} ${sec.courseNum}-${sec.sectionNum}`}
-      <br />
-    </span>
-  ));
+  const scheduleSections = sectionsForSchedule(schedule).map((sec: Section) => {
+    const color = sec.asynchronous ? undefined : meetingColors.get(sec.subject + sec.courseNum);
+
+    return (
+      <span key={sec.id} className={styles.sectionLabelRow}>
+        <ColorBox color={color} />
+        {`${sec.subject} ${sec.courseNum}-${sec.sectionNum}`}
+        <br />
+      </span>
+    );
+  });
 
   const scheduleItemContent = (
     <span className={styles.scheduleContentContainer}>

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ScheduleListItem.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ScheduleListItem.tsx
@@ -60,7 +60,7 @@ const ScheduleListItem: React.FC<ScheduleListItemProps> = ({ index, onDetailsCli
   );
 
   const scheduleSections = sectionsForSchedule(schedule).map((sec: Section) => {
-    const color = sec.asynchronous ? '#fff' : meetingColors.get(sec.subject + sec.courseNum);
+    const color = !sec.asynchronous && meetingColors.get(sec.subject + sec.courseNum);
 
     return (
       <span key={sec.id} className={styles.sectionLabelRow}>
@@ -69,6 +69,7 @@ const ScheduleListItem: React.FC<ScheduleListItemProps> = ({ index, onDetailsCli
           {`${sec.subject} ${sec.courseNum}-${sec.sectionNum}`}
         </span>
         <span className={styles.instructorName}>
+          &nbsp;
           {`- ${sec.instructor.name}`}
         </span>
         <br />

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ScheduleListItem.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ScheduleListItem.tsx
@@ -60,7 +60,7 @@ const ScheduleListItem: React.FC<ScheduleListItemProps> = ({ index, onDetailsCli
   );
 
   const scheduleSections = sectionsForSchedule(schedule).map((sec: Section) => {
-    const color = sec.asynchronous ? undefined : meetingColors.get(sec.subject + sec.courseNum);
+    const color = sec.asynchronous ? '#fff' : meetingColors.get(sec.subject + sec.courseNum);
 
     return (
       <span key={sec.id} className={styles.sectionLabelRow}>
@@ -69,7 +69,7 @@ const ScheduleListItem: React.FC<ScheduleListItemProps> = ({ index, onDetailsCli
           {`${sec.subject} ${sec.courseNum}-${sec.sectionNum}`}
         </span>
         <span className={styles.instructorName}>
-          {sec.instructor.name}
+          {`- ${sec.instructor.name}`}
         </span>
         <br />
       </span>

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ScheduleListItem.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ScheduleListItem.tsx
@@ -65,7 +65,12 @@ const ScheduleListItem: React.FC<ScheduleListItemProps> = ({ index, onDetailsCli
     return (
       <span key={sec.id} className={styles.sectionLabelRow}>
         <ColorBox color={color} />
-        {`${sec.subject} ${sec.courseNum}-${sec.sectionNum}`}
+        <span className={styles.sectionNum}>
+          {`${sec.subject} ${sec.courseNum}-${sec.sectionNum}`}
+        </span>
+        <span className={styles.instructorName}>
+          {sec.instructor.name}
+        </span>
         <br />
       </span>
     );

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ScheduleListItem.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ScheduleListItem.tsx
@@ -63,17 +63,15 @@ const ScheduleListItem: React.FC<ScheduleListItemProps> = ({ index, onDetailsCli
     const color = !sec.asynchronous && meetingColors.get(sec.subject + sec.courseNum);
 
     return (
-      <span key={sec.id} className={styles.sectionLabelRow}>
+      <>
         <ColorBox color={color} />
         <span className={styles.sectionNum}>
           {`${sec.subject} ${sec.courseNum}-${sec.sectionNum}`}
         </span>
         <span className={styles.instructorName}>
-          &nbsp;
-          {`- ${sec.instructor.name}`}
+          {sec.instructor.name}
         </span>
-        <br />
-      </span>
+      </>
     );
   });
 

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ScheduleListItem.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ScheduleListItem.tsx
@@ -63,7 +63,7 @@ const ScheduleListItem: React.FC<ScheduleListItemProps> = ({ index, onDetailsCli
     const color = !sec.asynchronous ? meetingColors.get(sec.subject + sec.courseNum) : undefined;
 
     return (
-      <>
+      <React.Fragment key={sec.id}>
         <ColorBox color={color} />
         <span className={styles.sectionNum}>
           {`${sec.subject} ${sec.courseNum}-${sec.sectionNum}`}
@@ -71,7 +71,7 @@ const ScheduleListItem: React.FC<ScheduleListItemProps> = ({ index, onDetailsCli
         <span className={styles.instructorName}>
           {sec.instructor.name}
         </span>
-      </>
+      </React.Fragment>
     );
   });
 

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ScheduleListItem.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleListItem/ScheduleListItem.tsx
@@ -60,7 +60,7 @@ const ScheduleListItem: React.FC<ScheduleListItemProps> = ({ index, onDetailsCli
   );
 
   const scheduleSections = sectionsForSchedule(schedule).map((sec: Section) => {
-    const color = !sec.asynchronous && meetingColors.get(sec.subject + sec.courseNum);
+    const color = !sec.asynchronous ? meetingColors.get(sec.subject + sec.courseNum) : undefined;
 
     return (
       <>

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css
@@ -56,12 +56,39 @@
     flex-shrink: 0;
 }
 
+.color-box-placeholder {
+    position: relative;
+    display: inline-block;
+    border: 1px solid black;
+    margin-right: 4px;
+    width: 12px;
+    height: 12px;
+    flex-shrink: 0;
+}
+
+.x-icon-outer {
+    position: absolute;
+    height: 18px;
+    width: 1px;
+    background-color: red;
+    transform: rotate(45deg);
+    left: 5px;
+    top: -3px;
+}
+
+.x-icon-inner {
+    display: inline-block;
+    height: 18px;
+    width: 1px;
+    background-color: red;
+    transform: rotate(90deg);
+}
+
 .section-num {
     flex-shrink: 0;
 }
 
 .instructor-name {
-    margin-left: 8px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css
@@ -53,6 +53,18 @@
     margin-right: 4px;
     width: 12px;
     height: 12px;
+    flex-shrink: 0;
+}
+
+.section-num {
+    flex-shrink: 0;
+}
+
+.instructor-name {
+    margin-left: 8px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .hidden {

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css
@@ -47,38 +47,28 @@
 }
 
 .color-box {
-    display: inline-block;
+    display: block;
     outline: 1px solid black;
     border: 1px solid white;
     margin-right: 4px;
-    width: 12px;
-    height: 12px;
-    flex-shrink: 0;
-}
-
-.color-box-placeholder {
-    position: relative;
-    display: inline-block;
-    border: 1px solid black;
-    margin-right: 4px;
-    width: 12px;
-    height: 12px;
+    width: 13px;
+    height: 13px;
     flex-shrink: 0;
 }
 
 .x-icon-outer {
-    position: absolute;
-    height: 18px;
+    display: block;
+    height: 15px;
     width: 1px;
     background-color: red;
+    margin-left: 6px;
+    margin-top: -1px;
     transform: rotate(45deg);
-    left: 5px;
-    top: -3px;
 }
 
 .x-icon-inner {
-    display: inline-block;
-    height: 18px;
+    display: block;
+    height: 15px;
     width: 1px;
     background-color: red;
     transform: rotate(90deg);

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css
@@ -41,10 +41,6 @@
     flex-direction: row;
 }
 
-.section-label-row {
-    display: flex;
-    align-items: center;
-}
 
 .color-box {
     display: block;
@@ -75,7 +71,8 @@
 }
 
 .section-num {
-    flex-shrink: 0;
+    white-space: nowrap;
+    padding-right: 8px;
 }
 
 .instructor-name {
@@ -120,10 +117,8 @@
 }
 
 .schedule-content-container {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    height: 100%;
+    display: grid;
+    grid-template-columns: min-content min-content 1fr;
 }
 
 .section-container {

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css.d.ts
@@ -3,7 +3,9 @@ declare namespace SchedulePreviewCssNamespace {
     "card-header": string;
     cardHeader: string;
     "color-box": string;
+    "color-box-placeholder": string;
     colorBox: string;
+    colorBoxPlaceholder: string;
     "configure-card": string;
     configureCard: string;
     "details-button": string;
@@ -40,6 +42,10 @@ declare namespace SchedulePreviewCssNamespace {
     sectionContainer: string;
     sectionLabelRow: string;
     sectionNum: string;
+    "x-icon-inner": string;
+    "x-icon-outer": string;
+    xIconInner: string;
+    xIconOuter: string;
   }
 }
 

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css.d.ts
@@ -11,6 +11,8 @@ declare namespace SchedulePreviewCssNamespace {
     "enable-pointer-events": string;
     enablePointerEvents: string;
     hidden: string;
+    "instructor-name": string;
+    instructorName: string;
     list: string;
     "list-item-contents": string;
     "list-item-text-container": string;
@@ -34,8 +36,10 @@ declare namespace SchedulePreviewCssNamespace {
     schedulesLoadingIndicator: string;
     "section-container": string;
     "section-label-row": string;
+    "section-num": string;
     sectionContainer: string;
     sectionLabelRow: string;
+    sectionNum: string;
   }
 }
 

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css.d.ts
@@ -3,9 +3,7 @@ declare namespace SchedulePreviewCssNamespace {
     "card-header": string;
     cardHeader: string;
     "color-box": string;
-    "color-box-placeholder": string;
     colorBox: string;
-    colorBoxPlaceholder: string;
     "configure-card": string;
     configureCard: string;
     "details-button": string;

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.css.d.ts
@@ -35,10 +35,8 @@ declare namespace SchedulePreviewCssNamespace {
     "schedules-loading-indicator": string;
     schedulesLoadingIndicator: string;
     "section-container": string;
-    "section-label-row": string;
     "section-num": string;
     sectionContainer: string;
-    sectionLabelRow: string;
     sectionNum: string;
     "x-icon-inner": string;
     "x-icon-outer": string;


### PR DESCRIPTION
## Description

Replaces color boxes for sections with no meeting times with an X, and shows instructor names in the preview

## Rationale
I based this branch off of `schedule-details` because I reorganized the schedule preview significantly in that branch. No tests because I don't think they'd be very helpful but I could try to add some if we want.

I also resized `<ColorBox>` to be 1px bigger because the old size made it impossible to center the X, it would always be 1px off because of rounding

## How to test
Mess around with adding async classes, also try resizing the window to see how the instructor names interact when cut off (they should truncate the text and add an ellipsis)

## Screenshots

Before|After
--|--
![image](https://user-images.githubusercontent.com/28655462/106398645-b1626200-63d9-11eb-8638-7ef5af5608ab.png)|![image](https://user-images.githubusercontent.com/28655462/107126159-dd676280-6873-11eb-80fb-19093d3935d2.png)


## Related tasks

Closes #491, #297.
