### PR TITLE
Fix site.webmanifest CORS

### DIFF
--- a/autoscheduler/frontend/assets/webmanifest-cors-fix.json
+++ b/autoscheduler/frontend/assets/webmanifest-cors-fix.json
@@ -1,0 +1,8 @@
+[
+    {
+      "origin": ["https://revregistration.com", "https://www.revregistration.com", "http://revregistration.com"],
+      "method": ["GET","OPTIONS","POST","PUT"],
+      "responseHeader": ["Allow","Content-Length","Content-Type","Date","Server","Vary","X-Frame-Options"],
+      "maxAgeSeconds": 3600
+    }
+]


### PR DESCRIPTION
## Description

This fixes the site.webmanifest CORS issue we were getting previously. Note that the file I'm adding doesn't actually do anything when it's in the repository - it's simply there for our memory.

To fix it, I did the steps Carlos gave in #436 - simply added the JSON and ran `gsutil cors set webmanifest-cors-fix.json gs://bucketname` (thank you @ThatJuanGuy !). This basically just tells Google Cloud Storage that if it's okay to share resources across origins (websites) if the origin is any of the URLs in `origin` in the JSON file.

## How to test

Go on https://revregistration.com and check the console to make sure we're not getting a CORS error for `site.webmanifest` anymore.

## Related tasks

Closes #436 
