### PR TITLE
Extended FIRST_HOUR and LAST_HOUR by 1 hour

### DIFF
--- a/autoscheduler/frontend/src/tests/types/Availability.test.ts
+++ b/autoscheduler/frontend/src/tests/types/Availability.test.ts
@@ -3,7 +3,7 @@ import Availability, { roundUpAvailability, AvailabilityArgs, AvailabilityType }
 import autoSchedulerReducer from '../../redux/reducer';
 import { addAvailability, mergeAvailability } from '../../redux/actions/availability';
 import DayOfWeek from '../../types/DayOfWeek';
-import { LAST_HOUR } from '../../utils/timeUtil';
+import { FIRST_HOUR, LAST_HOUR } from '../../utils/timeUtil';
 
 /**
  * Converts a pair of hours and minutes into a number of minutes past midnight
@@ -16,21 +16,21 @@ const dummyArgs = {
 
 describe('roundUpAvailability()', () => {
   describe('keeps availabilities within bounds', () => {
-    test('if the user starts before 8:30 and drags up', () => {
+    test('if the user starts before 7:30 and drags up', () => {
       // arrange
       const store = createStore(autoSchedulerReducer);
       const avArgs: AvailabilityArgs = {
         dayOfWeek: 2,
         available: AvailabilityType.BUSY,
-        time1: makeTime(8, 20),
-        time2: makeTime(8, 10),
+        time1: makeTime(FIRST_HOUR, 20),
+        time2: makeTime(FIRST_HOUR, 10),
       };
       const expectedResult: Availability[] = [{
         dayOfWeek: 2,
         available: AvailabilityType.BUSY,
-        startTimeHours: 8,
+        startTimeHours: FIRST_HOUR,
         startTimeMinutes: 0,
-        endTimeHours: 8,
+        endTimeHours: FIRST_HOUR,
         endTimeMinutes: 30,
       }];
 

--- a/autoscheduler/frontend/src/tests/ui/Availability.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/Availability.test.tsx
@@ -12,7 +12,7 @@ import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import autoSchedulerReducer from '../../redux/reducer';
 import Schedule from '../../components/SchedulingPage/Schedule/Schedule';
-import { timeToEvent, LAST_HOUR } from '../../utils/timeUtil';
+import { timeToEvent, LAST_HOUR, FIRST_HOUR } from '../../utils/timeUtil';
 import setTerm from '../../redux/actions/term';
 
 describe('Availability UI', () => {
@@ -122,7 +122,7 @@ describe('Availability UI', () => {
         .toHaveAttribute('aria-valuetext', expectedEnd);
     });
 
-    test('with an end time of 10 PM and a size of 30 mins if dragged below the bottom', async () => {
+    test('with an end time of LAST_HOUR-1 PM and a size of 30 mins if dragged below the bottom', async () => {
       // arrange
       fetchMock.mockResponseOnce(JSON.stringify([])); // sesssion/get_saved_availablities
 
@@ -152,8 +152,8 @@ describe('Availability UI', () => {
         clientY: 1200,
         clientX: 100,
       };
-      const expectedStart = '21:30';
-      const expectedEnd = '22:00';
+      const expectedStart = `${LAST_HOUR - 1}:30`;
+      const expectedEnd = `${LAST_HOUR}:00`;
       const meetingsContainer = document.getElementById('meetings-container');
       jest.spyOn(meetingsContainer, 'clientHeight', 'get')
         .mockImplementation(() => 1000);
@@ -198,8 +198,8 @@ describe('Availability UI', () => {
       );
       const startEventProps = timeToEvent(LAST_HOUR - 1, 40, 100);
       const endEventProps = timeToEvent(LAST_HOUR - 1, 50, 100);
-      const expectedStart = '21:30';
-      const expectedEnd = '22:00';
+      const expectedStart = `${LAST_HOUR - 1}:30`;
+      const expectedEnd = `${LAST_HOUR}:00`;
 
       // Wait for the loading indicator to be removed to continue
       await waitForElementToBeRemoved(
@@ -234,7 +234,7 @@ describe('Availability UI', () => {
         .toHaveAttribute('aria-valuetext', expectedEnd);
     });
 
-    test('with a start time of 8 AM if dragged upward near the top', async () => {
+    test('with a start time of FIRST_HOUR AM if dragged upward near the top', async () => {
       // arrange
       fetchMock.mockResponseOnce(JSON.stringify([])); // sesssion/get_saved_availablities
 
@@ -248,10 +248,10 @@ describe('Availability UI', () => {
           <Schedule />
         </Provider>,
       );
-      const startEventProps = timeToEvent(8, 20, 100);
-      const endEventProps = timeToEvent(8, 10, 100);
-      const expectedStart = '8:00';
-      const expectedEnd = '8:30';
+      const startEventProps = timeToEvent(FIRST_HOUR, 20, 100);
+      const endEventProps = timeToEvent(FIRST_HOUR, 10, 100);
+      const expectedStart = `${FIRST_HOUR}:00`;
+      const expectedEnd = `${FIRST_HOUR}:30`;
 
       // Wait for the loading indicator to be removed to continue
       await waitForElementToBeRemoved(
@@ -286,7 +286,7 @@ describe('Availability UI', () => {
         .toHaveAttribute('aria-valuetext', expectedEnd);
     });
 
-    test('with a start time of 8 AM if the user drags out of the schedule and above the top', async () => {
+    test('with a start time of FIRST_HOUR AM if the user drags out of the schedule and above the top', async () => {
       // arrange
       fetchMock.mockResponseOnce(JSON.stringify([])); // sesssion/get_saved_availablities
 
@@ -302,8 +302,8 @@ describe('Availability UI', () => {
       );
       const startEventProps = timeToEvent(11, 0, 100);
       const leaveEventProps = timeToEvent(10, 0, 100);
-      const endEventProps = timeToEvent(7, 0, 100);
-      const expectedStart = '8:00';
+      const endEventProps = timeToEvent(FIRST_HOUR - 1, 0, 100);
+      const expectedStart = `${FIRST_HOUR}:00`;
       const expectedEnd = '11:00';
 
       // Wait for the loading indicator to be removed to continue

--- a/autoscheduler/frontend/src/tests/ui/Availability.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/Availability.test.tsx
@@ -122,7 +122,7 @@ describe('Availability UI', () => {
         .toHaveAttribute('aria-valuetext', expectedEnd);
     });
 
-    test('with an end time of LAST_HOUR-1 PM and a size of 30 mins if dragged below the bottom', async () => {
+    test('with an end time of LAST_HOUR PM and a size of 30 mins if dragged below the bottom', async () => {
       // arrange
       fetchMock.mockResponseOnce(JSON.stringify([])); // sesssion/get_saved_availablities
 

--- a/autoscheduler/frontend/src/utils/timeUtil.ts
+++ b/autoscheduler/frontend/src/utils/timeUtil.ts
@@ -1,5 +1,5 @@
-export const FIRST_HOUR = 8;
-export const LAST_HOUR = 22;
+export const FIRST_HOUR = 7;
+export const LAST_HOUR = 23;
 /**
  * Given the hours and minutes of a time, returns a formatted string representation of
  * that time. By default, this uses 12-hour format, but an extra argument can be specified


### PR DESCRIPTION
## Description

Extends FIRST_HOUR and LAST_HOUR for the schedule by 1 hour.

## Rationale

Classes such as KINE-199 have early times, so we have to account for them. Likewise, MATH classes frequently have exams that end at 10:30, so we need to account for it as well.

## How to test

KINE 199-598 and MATH 151-521 for 202111 have early and late times. Likewise, CSCE 482 has 15 minute times

## Screenshots

|Before|After|
|--|--|
|![chrome_Zk4h90oTTB](https://user-images.githubusercontent.com/7295783/107887080-6f94e980-6eb8-11eb-86b2-ac87563b5653.png)|![chrome_chRyg1wgfP](https://user-images.githubusercontent.com/7295783/107887085-74f23400-6eb8-11eb-8ce8-1a30cf6c74a4.png)|

## Related tasks

Closes #370
