### PR TITLE
User session fix

### DIFF
--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -1,8 +1,5 @@
 name: GCP Deploy
-on:
-  push:
-    branches:
-      - production
+on: push
 
 jobs:
   deploy-app-engine:

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -1,5 +1,8 @@
 name: GCP Deploy
-on: push
+on:
+  push:
+    branches:
+      - production
 
 jobs:
   deploy-app-engine:

--- a/autoscheduler/autoscheduler/settings/base.py
+++ b/autoscheduler/autoscheduler/settings/base.py
@@ -63,6 +63,9 @@ LOGIN_URL = '/auth/login/google-auth2/' #or try -oauth2?
 LOGIN_REDIRECT_URL = '/'
 LOGOUT_REDIRECT_URL = '/'
 
+# SESSION_COOKIE_AGE must be an integer - make sessions take 10 years to expire
+SESSION_COOKIE_AGE = 10 * 365 * 24 * 60 * 60
+
 SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = os.getenv('GOOGLE_OAUTH2_CLIENT_ID')
 SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = os.getenv('GOOGLE_OAUTH2_SECRET')
 

--- a/autoscheduler/user_sessions/utils/retrieve_data_session.py
+++ b/autoscheduler/user_sessions/utils/retrieve_data_session.py
@@ -23,12 +23,11 @@ def retrieve_data_session(request):
         # If user is logged in and model exists, uses the session in the model
             session_key = UserToDataSession.objects.get(user_id=user_id).session_key
             data_session = SessionStore(session_key=session_key)
-            if not data_session.keys():
-                # Session existed, but was deleted
-                raise UserToDataSession.DoesNotExist
+            # Ensure a Session object exists matching the UserToDataSession
+            Session.objects.get(pk=session_key)
             yield data_session
-    except UserToDataSession.DoesNotExist:
-        # The user is logged in but the model doesn't exist.
+    except (UserToDataSession.DoesNotExist, Session.DoesNotExist):
+        # The user is logged in but a data session doesn't exist.
         # Create the model before returning the corresponding data session
         # Create a session object
         data_session = SessionStore()


### PR DESCRIPTION
## Description

Fixes the issue where users would end up with invalid sessions, leaving them stuck on the homepage for all of eternity

More concretely:
- Sessions now take 10 years to expire instead of 2 weeks, meaning no more users should run into the issue (unless they don't use the site for 10 years in which case we should probably delete their data anyways). 
- If a user ends up with an invalid `Session` object associated with their `UserToDataSession`, a new one will be created (to fix the sessions of users who have already encountered the issue)

## Rationale
This performs an additional query every time `retrieve_data_session` is called in order to check the `Session` is valid, as there's no way to determine this with 100% accuracy using only a `SessionStore` object: empty sessions are treated the same as ones that don't exist.

## How to test
You can check if your affected accounts on deployment are fixed, as well as manually mess around with your `user_to_data_session` and `django_session` tables locally to test different situations and what happens

## Related tasks
Closes #495.