### PR TITLE
Fixed backend linting (on GitHub Actions)

### DIFF
--- a/.github/lint-requirements.txt
+++ b/.github/lint-requirements.txt
@@ -2,7 +2,7 @@ aiohttp==3.6.2
 beautifulsoup4==4.8.2
 Django~=2.2.6
 djangorestframework~=3.9.2
-pylint-django==2.0.11
+pylint-django==2.4.2
 PyPDF2==1.26.0
 requests==2.21.0
 python-dotenv==0.13.0

--- a/.github/workflows/backend-workflow.yml
+++ b/.github/workflows/backend-workflow.yml
@@ -20,4 +20,4 @@ jobs:
         uses: cclauss/GitHub-Action-for-pylint@master
         with:
         # Installs Django and pylint-django, then runs pylint on all of the files in autoscheduler/
-          args: pip install -r .github/lint-requirements.txt ; pylint autoscheduler/scraper autoscheduler/scheduler autoscheduler/autoscheduler autoscheduler/manage.py --load-plugins pylint_django
+          args: pip install -r .github/lint-requirements.txt ; pylint autoscheduler/scraper autoscheduler/scheduler autoscheduler/autoscheduler autoscheduler/manage.py --load-plugins pylint_django --django-settings-module=autoscheduler.settings.base

--- a/autoscheduler/requirements.txt
+++ b/autoscheduler/requirements.txt
@@ -5,8 +5,8 @@ djangorestframework~=3.9.2
 lxml==4.5.0
 psycopg2-binary==2.8.4
 pycodestyle==2.5.0
-pylint==2.4.3
-pylint-django==2.0.11
+pylint==2.7.0
+pylint-django==2.4.2
 pytest==3.6
 pytest-django==3.6.0
 PyPDF2==1.26.0

--- a/autoscheduler/scraper/banner_requests.py
+++ b/autoscheduler/scraper/banner_requests.py
@@ -33,17 +33,16 @@ import requests
 
 class Semester(Enum):
     """ The semester of a given term """
-    spring = 1
-    summer = 2
-    fall = 3
-    # winter = 3 # Winter minimister
+    SPRING = 1
+    SUMMER = 2
+    FALL = 3
 
 class Location(Enum):
     """ The location of the university that the term takes place at """
-    college_station = 1
-    galveston = 2
-    qatar = 3
-    half_year_term = 4 # Not sure where to put this, may not need to include
+    COLLEGE_STATION = 1
+    GALVESTON = 2
+    QATAR = 3
+    HALF_YEAR_TERM = 4 # Not sure where to put this, may not need to include
 
 def generate_session_id():
     """ Generates an 18 character session id """

--- a/autoscheduler/scraper/tests/banner_requests_tests.py
+++ b/autoscheduler/scraper/tests/banner_requests_tests.py
@@ -29,8 +29,8 @@ class GetTermCodeTests(unittest.TestCase):
     def test_fall_college_station_returns_31(self):
         """ Tests if when given fall semester & at college station if it returns 31 """
         # Arrange
-        semester = Semester.fall
-        loc = Location.college_station
+        semester = Semester.FALL
+        loc = Location.COLLEGE_STATION
 
         # Act
         term_code = get_term_code("2019", semester, loc)
@@ -42,8 +42,8 @@ class GetTermCodeTests(unittest.TestCase):
     def test_spring_galveston_returns_22(self):
         """ Tests if when given spring & at galveston, if the given term ends in 22 """
         # Arrange
-        semester = Semester.spring
-        loc = Location.galveston
+        semester = Semester.SPRING
+        loc = Location.GALVESTON
 
         # Act
         term_code = get_term_code("2019", semester, loc)
@@ -54,7 +54,7 @@ class GetTermCodeTests(unittest.TestCase):
     def test_invalid_year_does_raise_error(self):
         """ Provides an invalid year(where len != 4) and passes if it throws an error """
         try:
-            _ = get_term_code("9", Semester.fall, Location.college_station)
+            _ = get_term_code("9", Semester.FALL, Location.COLLEGE_STATION)
 
             assert False # If it doesn't raise an error, then didn't pass
         except ValueError:


### PR DESCRIPTION
## Description

I'm pretty sure the linting Action workflow we use, [GitHub Action for pylint](https://github.com/cclauss/GitHub-Action-for-pylint), upgraded it's pylint version, which is causing a few PR's to fail when you wouldn't expect them to (#511, #508, #494). This updates `pylint` (and `pylint_django`) to the most recent version, as well as fixes the linting errors that arose. As such, make sure to run `pip install -r requirements.txt` after this is merged so that you're up-to-date.

### NOTE

You'll need to fix your linting in VSCode by going to your `.vscode/settings.json` and adding the last line, `--django-settings-module=autoscheduler.settings.base` to your pylint arguments, which means it'll look like:

```json
	"python.linting.pylintArgs": [
		"--load-plugins",
		"pylint_django",
		"--django-settings-module=autoscheduler.settings.base"
	],
```

frankly I'm pretty sure it can be changed to

```json
	"python.linting.pylintArgs": [
		"--load-plugins=pylint_django",
		"--django-settings-module=autoscheduler.settings.base"
	],
```

but I don't think it matters.

I also updated the [Setup Pylint Wiki](https://github.com/aggie-coding-club/Rev-Registration/wiki/Setup-Pylint) with this info.

## How to test

If it passes the Actions linting step then we're good

