### PR TITLE
Filters for section select

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionFilters.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionFilters.tsx
@@ -62,7 +62,7 @@ const SectionFilters: React.FC<SectionFiltersProps> = ({ id }) => {
 
   const filterRows: JSX.Element[] = [];
   filterStates.forEach((val, key) => {
-    if (val !== SectionFilter.NO_PREFERENCE) {
+    if (val !== undefined && val !== SectionFilter.NO_PREFERENCE) {
       filterRows.push(
         <tr>
           <td>

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionFilters.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionFilters.tsx
@@ -4,9 +4,11 @@ import {
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import DeleteIcon from '@material-ui/icons/Delete';
+import CollapseIcon from '@material-ui/icons/ExpandLess';
 import { SectionFilter } from '../../../../../../types/CourseCardOptions';
 import * as styles from '../../../../../LandingPage/SelectTerm/SelectTerm.css';
 import * as menuStyles from '../BasicSelect/BasicSelect.css';
+import * as sectionStyles from './SectionSelect.css';
 import { updateCourseCard } from '../../../../../../redux/actions/courseCards';
 import { RootState } from '../../../../../../redux/reducer';
 
@@ -21,6 +23,7 @@ const courseCardFields = new Map<string, string>([
 ]);
 
 const SectionFilters: React.FC<SectionFiltersProps> = ({ id }) => {
+  const [expanded, setExpanded] = React.useState(false);
   const [anchorEl, setAnchorEl] = React.useState(null);
   const open = Boolean(anchorEl);
   const dispatch = useDispatch();
@@ -39,6 +42,20 @@ const SectionFilters: React.FC<SectionFiltersProps> = ({ id }) => {
     setAnchorEl(null);
   };
   const options = [...filterStates.keys()];
+
+  const openFilterHandle = (
+    <div
+      className={sectionStyles.filterHandle}
+      onClick={(): void => setExpanded(!expanded)}
+      onKeyPress={(): void => setExpanded(!expanded)}
+      role="button"
+      tabIndex={0}
+    >
+      <CollapseIcon />
+      <Typography>Show Filters</Typography>
+      <div className={sectionStyles.filterHandleBar} />
+    </div>
+  );
 
   const filterRows: JSX.Element[] = [];
   filterStates.forEach((val, key) => {
@@ -83,35 +100,38 @@ const SectionFilters: React.FC<SectionFiltersProps> = ({ id }) => {
 
   return (
     <>
-      <Button
-        variant="text"
-        size="small"
-        aria-controls={open ? 'menu-list-grow' : undefined}
-        aria-haspopup
-        onClick={handleClick}
-        style={{ width: 'fit-content' }}
-      >
+      {openFilterHandle}
+      {expanded || (
+        <>
+          <Button
+            variant="text"
+            size="small"
+            aria-controls={open ? 'menu-list-grow' : undefined}
+            aria-haspopup
+            onClick={handleClick}
+            style={{ width: 'fit-content' }}
+          >
         + Add Filter
-      </Button>
-      <Menu
-        id="long-menu"
-        anchorEl={anchorEl}
-        anchorOrigin={{
-          vertical: 'top',
-          horizontal: 'left',
-        }}
-        transformOrigin={{
-          vertical: 'top',
-          horizontal: 'left',
-        }}
-        keepMounted
-        open={open}
-        onClose={handleClose}
-        PaperProps={{
-          className: styles.menuPaper,
-        }}
-      >
-        {
+          </Button>
+          <Menu
+            id="long-menu"
+            anchorEl={anchorEl}
+            anchorOrigin={{
+              vertical: 'top',
+              horizontal: 'left',
+            }}
+            transformOrigin={{
+              vertical: 'top',
+              horizontal: 'left',
+            }}
+            keepMounted
+            open={open}
+            onClose={handleClose}
+            PaperProps={{
+              className: styles.menuPaper,
+            }}
+          >
+            {
           /* renders a menu item for each term */
           options.map((option) => (
             <MenuItem
@@ -123,8 +143,11 @@ const SectionFilters: React.FC<SectionFiltersProps> = ({ id }) => {
             </MenuItem>
           ))
         }
-      </Menu>
-      <table>{filterRows}</table>
+          </Menu>
+          <table>{filterRows}</table>
+          <div className={sectionStyles.filterHandleBottomBar} />
+        </>
+      )}
     </>
   );
 };

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionFilters.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionFilters.tsx
@@ -1,0 +1,132 @@
+import {
+  Button, Menu, MenuItem, Typography, Select,
+} from '@material-ui/core';
+import * as React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import DeleteIcon from '@material-ui/icons/Delete';
+import { SectionFilter } from '../../../../../../types/CourseCardOptions';
+import * as styles from '../../../../../LandingPage/SelectTerm/SelectTerm.css';
+import * as menuStyles from '../BasicSelect/BasicSelect.css';
+import { updateCourseCard } from '../../../../../../redux/actions/courseCards';
+import { RootState } from '../../../../../../redux/reducer';
+
+interface SectionFiltersProps {
+  id: number;
+}
+
+const courseCardFields = new Map<string, string>([
+  ['Honors', 'filterHonors'],
+  ['Remote', 'filterRemote'],
+  ['No Meeting Times', 'filterAsynchronous'],
+]);
+
+const SectionFilters: React.FC<SectionFiltersProps> = ({ id }) => {
+  const [anchorEl, setAnchorEl] = React.useState(null);
+  const open = Boolean(anchorEl);
+  const dispatch = useDispatch();
+  const filterStates = useSelector<RootState, Map<string, SectionFilter>>((state) => new Map([
+    ['Honors', state.termData.courseCards[id].filterHonors],
+    ['Remote', state.termData.courseCards[id].filterRemote],
+    ['No Meeting Times', state.termData.courseCards[id].filterAsynchronous],
+  ]));
+  const handleClick = (event: React.MouseEvent<HTMLElement>): void => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = (option: string): void => {
+    dispatch(updateCourseCard(id, {
+      [courseCardFields.get(option)]: SectionFilter.ONLY,
+    }));
+    setAnchorEl(null);
+  };
+  const options = [...filterStates.keys()];
+
+  const filterRows: JSX.Element[] = [];
+  filterStates.forEach((val, key) => {
+    if (val !== SectionFilter.NO_PREFERENCE) {
+      filterRows.push(
+        <tr>
+          <td>
+            <Typography variant="body1" style={{ paddingRight: 8 }} id={`${key}-${id}`}>
+              {`${key}:`}
+            </Typography>
+          </td>
+          <td>
+            <Select
+              variant="outlined"
+              value={val}
+              classes={{ root: menuStyles.selectRoot, selectMenu: menuStyles.selectMenu }}
+              labelId={key}
+              onChange={(evt): void => {
+                dispatch(updateCourseCard(id, {
+                  [courseCardFields.get(key)]: evt.target.value as string,
+                }));
+              }}
+            >
+              <MenuItem value={SectionFilter.EXCLUDE}>Exclude</MenuItem>
+              <MenuItem value={SectionFilter.ONLY}>Only</MenuItem>
+            </Select>
+          </td>
+          <td>
+            <DeleteIcon
+              style={{ cursor: 'pointer' }}
+              onClick={(): void => {
+                dispatch(updateCourseCard(id, {
+                  [courseCardFields.get(key)]: SectionFilter.NO_PREFERENCE,
+                }));
+              }}
+            />
+          </td>
+        </tr>,
+      );
+    }
+  });
+
+  return (
+    <>
+      <Button
+        variant="text"
+        size="small"
+        aria-controls={open ? 'menu-list-grow' : undefined}
+        aria-haspopup
+        onClick={handleClick}
+        style={{ width: 'fit-content' }}
+      >
+        + Add Filter
+      </Button>
+      <Menu
+        id="long-menu"
+        anchorEl={anchorEl}
+        anchorOrigin={{
+          vertical: 'top',
+          horizontal: 'left',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'left',
+        }}
+        keepMounted
+        open={open}
+        onClose={handleClose}
+        PaperProps={{
+          className: styles.menuPaper,
+        }}
+      >
+        {
+          /* renders a menu item for each term */
+          options.map((option) => (
+            <MenuItem
+              key={option}
+              selected={option === '' /* TODO */}
+              onClick={(): void => handleClose(option)}
+            >
+              {option}
+            </MenuItem>
+          ))
+        }
+      </Menu>
+      <table>{filterRows}</table>
+    </>
+  );
+};
+
+export default SectionFilters;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionFilters.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionFilters.tsx
@@ -52,7 +52,10 @@ const SectionFilters: React.FC<SectionFiltersProps> = ({ id }) => {
       tabIndex={0}
     >
       <CollapseIcon />
-      <Typography>Show Filters</Typography>
+      <Typography>
+        {expanded ? 'Show ' : 'Hide '}
+        Filters
+      </Typography>
       <div className={sectionStyles.filterHandleBar} />
     </div>
   );
@@ -111,7 +114,7 @@ const SectionFilters: React.FC<SectionFiltersProps> = ({ id }) => {
             onClick={handleClick}
             style={{ width: 'fit-content' }}
           >
-        + Add Filter
+            + Add Filter
           </Button>
           <Menu
             id="long-menu"
@@ -132,17 +135,17 @@ const SectionFilters: React.FC<SectionFiltersProps> = ({ id }) => {
             }}
           >
             {
-          /* renders a menu item for each term */
-          options.map((option) => (
-            <MenuItem
-              key={option}
-              selected={option === '' /* TODO */}
-              onClick={(): void => handleClose(option)}
-            >
-              {option}
-            </MenuItem>
-          ))
-        }
+              /* renders a menu item for only and exclude */
+              options.map((option) => (
+                <MenuItem
+                  key={option}
+                  selected={option === '' /* TODO */}
+                  onClick={(): void => handleClose(option)}
+                >
+                  {option}
+                </MenuItem>
+              ))
+            }
           </Menu>
           <table>{filterRows}</table>
           <div className={sectionStyles.filterHandleBottomBar} />

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
@@ -118,3 +118,28 @@
     justify-content: center;
     min-height: 300px;
 }
+
+.filter-handle {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.filter-handle:focus {
+    outline: none;
+}
+
+.filter-handle-bar {
+    flex-grow: 1;
+    height: 2px;
+    background-color: black;
+    margin-left: 6px;
+    margin-right: 6px;
+}
+
+.filter-handle-bottom-bar {
+    width: calc(100% - 12px);
+    height: 2px;
+    background-color: black;
+    margin: 6px 6px 0 6px;
+}

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
@@ -123,6 +123,7 @@
     display: flex;
     flex-direction: row;
     align-items: center;
+    cursor: pointer;
 }
 
 .filter-handle:focus {

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css.d.ts
@@ -8,6 +8,12 @@ declare namespace SectionSelectCssNamespace {
     denseListItem: string;
     "divider-container": string;
     dividerContainer: string;
+    "filter-handle": string;
+    "filter-handle-bar": string;
+    "filter-handle-bottom-bar": string;
+    filterHandle: string;
+    filterHandleBar: string;
+    filterHandleBottomBar: string;
     "list-subheader-content": string;
     "list-subheader-dense": string;
     listSubheaderContent: string;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
@@ -15,6 +15,7 @@ import { RootState } from '../../../../../../redux/reducer';
 import * as styles from './SectionSelect.css';
 import SectionInfo from './SectionInfo';
 import SmallFastProgress from '../../../../../SmallFastProgress';
+import SectionFilters from './SectionFilters';
 
 interface SectionSelectProps {
   id: number;
@@ -233,6 +234,7 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id, onMounted }): JSX.Ele
   // and causes ugly flashing
   return (
     <>
+      <SectionFilters id={id} />
       {sectionSelectOptions}
       {((sortState.frontendSortType === reduxSortType
         && sortState.frontendSortIsDescending === reduxSortIsDescending)

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
@@ -9,13 +9,14 @@ import SortIcon from '@material-ui/icons/Sort';
 import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
 import { toggleSelectedAll, updateSortType } from '../../../../../../redux/actions/courseCards';
 import {
-  SectionSelected, SortType, SortTypeLabels, DefaultSortTypeDirections,
+  SectionSelected, SortType, SortTypeLabels, DefaultSortTypeDirections, SectionFilter,
 } from '../../../../../../types/CourseCardOptions';
 import { RootState } from '../../../../../../redux/reducer';
 import * as styles from './SectionSelect.css';
 import SectionInfo from './SectionInfo';
 import SmallFastProgress from '../../../../../SmallFastProgress';
 import SectionFilters from './SectionFilters';
+import { InstructionalMethod } from '../../../../../../types/Section';
 
 interface SectionSelectProps {
   id: number;
@@ -23,15 +24,43 @@ interface SectionSelectProps {
 }
 
 const SectionSelect: React.FC<SectionSelectProps> = ({ id, onMounted }): JSX.Element => {
-  const sections = useSelector<RootState, SectionSelected[]>(
-    (state) => state.termData.courseCards[id].sections,
-  );
   // to show loading symbol when needed
   const reduxSortType = useSelector<RootState, SortType>(
     (state) => state.termData.courseCards[id].sortType,
   );
   const reduxSortIsDescending = useSelector<RootState, boolean>(
     (state) => state.termData.courseCards[id].sortIsDescending,
+  );
+  const filterHonors = useSelector<RootState, SectionFilter>(
+    (state) => state.termData.courseCards[id].filterHonors,
+  );
+  const filterRemote = useSelector<RootState, SectionFilter>(
+    (state) => state.termData.courseCards[id].filterRemote,
+  );
+  const filterAsync = useSelector<RootState, SectionFilter>(
+    (state) => state.termData.courseCards[id].filterAsynchronous,
+  );
+  const sections = useSelector<RootState, SectionSelected[]>(
+    (state) => state.termData.courseCards[id].sections.filter(
+      // applies section filters
+      (sec) => {
+        let filtersMet = true;
+        if (filterHonors === SectionFilter.ONLY) filtersMet = filtersMet && sec.section.honors;
+        if (filterHonors === SectionFilter.EXCLUDE) filtersMet = filtersMet && !sec.section.honors;
+        if (filterRemote === SectionFilter.ONLY) {
+          filtersMet = filtersMet && sec.section.instructionalMethod === InstructionalMethod.REMOTE;
+        }
+        if (filterRemote === SectionFilter.EXCLUDE) {
+          filtersMet = filtersMet && sec.section.instructionalMethod !== InstructionalMethod.REMOTE;
+        }
+        if (filterAsync === SectionFilter.ONLY) filtersMet = filtersMet && sec.section.asynchronous;
+        if (filterAsync === SectionFilter.EXCLUDE) {
+          filtersMet = filtersMet && !sec.section.asynchronous;
+        }
+
+        return filtersMet;
+      },
+    ),
   );
   // for sorting, in a map so you can set multiple without too many rerenders
   const [sortState, setSortState] = React.useState<{

--- a/autoscheduler/frontend/src/redux/reducers/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/reducers/courseCards.ts
@@ -32,6 +32,9 @@ const initialCourseCardArray: CourseCardArray = {
     sections: [],
     loading: true,
     collapsed: false,
+    filterRemote: SectionFilter.NO_PREFERENCE,
+    filterHonors: SectionFilter.NO_PREFERENCE,
+    filterAsynchronous: SectionFilter.NO_PREFERENCE,
   },
 };
 

--- a/autoscheduler/frontend/src/types/CourseCardOptions.ts
+++ b/autoscheduler/frontend/src/types/CourseCardOptions.ts
@@ -64,6 +64,9 @@ export interface CourseCardOptions {
   collapsed?: boolean;
   sortType?: SortType;
   sortIsDescending?: boolean;
+  filterRemote?: SectionFilter;
+  filterHonors?: SectionFilter;
+  filterAsynchronous?: SectionFilter;
 }
 
 // Represents a course card when saved and serialized, sections are saved as strings
@@ -78,6 +81,9 @@ export interface SerializedCourseCardOptions {
   collapsed?: boolean;
   sortType?: SortType;
   sortIsDescending?: boolean;
+  filterRemote?: SectionFilter;
+  filterHonors?: SectionFilter;
+  filterAsynchronous?: SectionFilter;
 }
 
 /**


### PR DESCRIPTION
## Description

If a user wants to select indidivual sections but narrow them down, they currently have no option besides scrolling through every section and manually checking which ones meet their criteria. This PR adds filters to SectionSelect, so that users can limit to/exclude honors, remote, or asynchronous sections.

Since we're close to launch and we want this feature by then, I've made a draft PR to start collecting feedback, even though the feature is not yet complete. TODO:

- ~Add UI~
- Add filtering functionality
- Save to sessions
- Fix transition heights
- Fix tests

## Rationale

I added a bottom divider to help distinguish the filters part from the rest of the SectionSelect

## How to test

Actual functionality is still TODO, so far only the UI is finished

## Screenshots

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/10082177/111871467-38eb3c80-8958-11eb-9e15-25417f648743.png)|![image](https://user-images.githubusercontent.com/10082177/111871066-53241b00-8956-11eb-8bc1-143c124bfd27.png)|

## Related tasks

Closes #364 
