### PR TITLE
Use -moz- vendor prefix for fit-content

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/BasicSelect/BasicSelect.css
@@ -1,4 +1,5 @@
 .fit-content, .table-container, .select-root {
+    width: -moz-fit-content;
     width: fit-content;
 }
 

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/InstructionsDialog/InstructionsDialog.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/InstructionsDialog/InstructionsDialog.css
@@ -14,6 +14,7 @@
 
 .availability-dialog {
     width: 50%;
+    height: -moz-fit-content;
     height: fit-content;
     max-width: 400px;
 }


### PR DESCRIPTION
## Description
Firefox doesn't support `fit-content` which makes it so parts of the websites that use it look odd, for example:
![fit-content](https://user-images.githubusercontent.com/28655462/111889913-bc397c00-89b2-11eb-9420-3420937b2b61.gif)
This adds `-moz-fit-content` wherever `fit-content` is used to achieve the intended effect:
![image](https://user-images.githubusercontent.com/28655462/111889922-c9ef0180-89b2-11eb-93be-bdc13d82845b.png)

## Rationale
The basic options row is really wonky on firefox without this, and while the instructions dialog looks fine I figured I might as well change it so that it works the same across browsers.

## How to test
Use firefox lol

## Screenshots
See above

## Related tasks
None, but I pointed out this issue during the last meeting
