### PR TITLE
Added V dropdown icons to SelectTerm

### DIFF
--- a/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
+++ b/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
@@ -9,6 +9,7 @@ import setTerm from '../../../redux/actions/term';
 import * as defaultStyles from './SelectTerm.css';
 import * as navBarStyles from './NavBarSelectTerm.css';
 import { RootState } from '../../../redux/reducer';
+import { ArrowDropDown } from '@material-ui/icons';
 
 interface SelectTermProps {
   navBar?: boolean;
@@ -109,6 +110,7 @@ const SelectTerm: React.FC<SelectTermProps> = ({ navBar = false }) => {
         aria-controls={open ? 'menu-list-grow' : undefined}
         aria-haspopup="true"
         onClick={handleClick}
+        endIcon={<ArrowDropDown />}
       >
         {navBar
           // If we're on the navbar, show the user-friendly term. If it's null, show 'Select Term'

--- a/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
+++ b/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
@@ -5,11 +5,11 @@ import {
 import { navigate } from '@reach/router';
 import * as Cookies from 'js-cookie';
 import { useDispatch, useSelector } from 'react-redux';
+import { ArrowDropDown } from '@material-ui/icons';
 import setTerm from '../../../redux/actions/term';
 import * as defaultStyles from './SelectTerm.css';
 import * as navBarStyles from './NavBarSelectTerm.css';
 import { RootState } from '../../../redux/reducer';
-import { ArrowDropDown } from '@material-ui/icons';
 
 interface SelectTermProps {
   navBar?: boolean;
@@ -36,8 +36,8 @@ const useLandingPageStyles = makeStyles({
   endIcon: {
     position: 'absolute',
     right: '1rem',
-  }
-})
+  },
+});
 
 const SelectTerm: React.FC<SelectTermProps> = ({ navBar = false }) => {
   const dispatch = useDispatch();

--- a/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
+++ b/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {
-  Menu, MenuItem, Button,
+  Menu, MenuItem, Button, makeStyles,
 } from '@material-ui/core';
 import { navigate } from '@reach/router';
 import * as Cookies from 'js-cookie';
@@ -30,6 +30,15 @@ const getTermsJson = ((): () => Promise<any> => {
   };
 })();
 
+// Custom overrides for the landing page that forces
+// the dropdown icon to the far right of the button
+const useLandingPageStyles = makeStyles({
+  endIcon: {
+    position: 'absolute',
+    right: '1rem',
+  }
+})
+
 const SelectTerm: React.FC<SelectTermProps> = ({ navBar = false }) => {
   const dispatch = useDispatch();
   // anchorEl tells the popover menu where to center itself. Null means the menu is hidden
@@ -43,6 +52,7 @@ const SelectTerm: React.FC<SelectTermProps> = ({ navBar = false }) => {
   const globalTerm = useSelector<RootState, string>((state) => state.termData.term);
 
   const styles = navBar ? navBarStyles : defaultStyles;
+  const landingPageStyleOverrides = useLandingPageStyles();
 
   // Fetch all terms to use as ListItem options
   function getTerms(): void {
@@ -111,6 +121,9 @@ const SelectTerm: React.FC<SelectTermProps> = ({ navBar = false }) => {
         aria-haspopup="true"
         onClick={handleClick}
         endIcon={<ArrowDropDown />}
+        classes={{
+          endIcon: !navBar ? landingPageStyleOverrides.endIcon : null,
+        }}
       >
         {navBar
           // If we're on the navbar, show the user-friendly term. If it's null, show 'Select Term'


### PR DESCRIPTION
## Description

Adds dropdown V icons to SelectTerm. Note for the LandingPage one, I added custom styles which pushes the icon to the far right of it.

## How to test

Look at the landing page and make sure they look right on a variety of screen sizes.

## Screenshots

|Before|After|
|--|--|
|![chrome_lwGRb2EAAl](https://user-images.githubusercontent.com/7295783/111913068-a915c300-8a29-11eb-929d-82123d94cfe8.png)|![chrome_Ha2yqzHpGp](https://user-images.githubusercontent.com/7295783/111913070-aca94a00-8a29-11eb-8019-11d4fa3bd99b.png)|

## Related tasks

Closes #484 
