### PR TITLE
Use production react/redux in production

### DIFF
--- a/autoscheduler/autoscheduler/settings/base.py
+++ b/autoscheduler/autoscheduler/settings/base.py
@@ -5,7 +5,7 @@ from autoscheduler.config import config
 load_dotenv()
 
 # What Google App Engine uses
-_IS_GCP = os.getenv('SERVER_SOFTWARE', '').startswith('gunicorn')
+IS_GCP = os.getenv('SERVER_SOFTWARE', '').startswith('gunicorn')
 # Environment variables for when we collect static files
 _IS_STATIC = os.getenv('SETTINGS_MODE') == 'static'
 # Env variable for connecting to Cloud SQL through cloud_sql_proxy
@@ -18,7 +18,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-if _IS_GCP:
+if IS_GCP:
     # For production, load the secret from secret.txt and set it
     # This is set from the GitHub actions secret DJANGO_SECRET in deploy-workflow.yml
     _SECRET_PATH = os.path.dirname(__file__) + "/secret.txt"
@@ -29,7 +29,7 @@ else:
     SECRET_KEY = 'ogxjva5h%&5c7&e#-2f1&+u5p#zygwffcy!@)k8i37#j_89xe2'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = not _IS_GCP
+DEBUG = not IS_GCP
 
 ALLOWED_HOSTS = [
     '*',
@@ -115,7 +115,7 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'autoscheduler.wsgi.application'
 
-if _IS_GCP:
+if IS_GCP:
     print("Connecting to Google Cloud SQL on App Engine")
     DATABASES = {
         'default': {
@@ -192,7 +192,7 @@ STATICFILES_DIRS = [
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
 
-if _IS_GCP or _IS_STATIC:
+if IS_GCP or _IS_STATIC:
     print("Using GCP/prod for static files")
     STATIC_ROOT = 'static'
     STATIC_URL = 'https://storage.googleapis.com/revregistration1.appspot.com'

--- a/autoscheduler/frontend/src/.eslintrc.js
+++ b/autoscheduler/frontend/src/.eslintrc.js
@@ -29,7 +29,9 @@ module.exports = {
     'react-hooks',
   ],
   globals: {
-    "document": false
+    "document": "readonly",
+    "STATIC_URL": "readonly",
+    "IS_PRODUCTION": "readonly",
   },
   settings: {
     "import/parsers": {

--- a/autoscheduler/frontend/src/components/NavBar/NavBar.tsx
+++ b/autoscheduler/frontend/src/components/NavBar/NavBar.tsx
@@ -6,7 +6,6 @@ import { navigate } from '@reach/router';
 import LoginButton from './LoginButton';
 import appTheme from '../../theme';
 import SelectTerm from '../LandingPage/SelectTerm/SelectTerm';
-import STATIC_URL from '../../globals';
 import LastUpdatedAt from '../LastUpdatedAt';
 
 const useStyles = makeStyles((theme) => ({

--- a/autoscheduler/frontend/src/globals.ts
+++ b/autoscheduler/frontend/src/globals.ts
@@ -1,3 +1,2 @@
 declare const STATIC_URL: string;
-
-export default STATIC_URL;
+declare const IS_PRODUCTION: string;

--- a/autoscheduler/frontend/src/index.tsx
+++ b/autoscheduler/frontend/src/index.tsx
@@ -10,20 +10,22 @@ import thunk from 'redux-thunk';
 import autoSchedulerReducer from './redux/reducer';
 import App from './components/App/App';
 
-// DEBUG
+// Allow use of thunks in Redux store
+let storeEnhancer: StoreEnhancer = applyMiddleware(thunk);
+
+// Use Redux DevTools only in development environments
 interface MyWindow {
   __REDUX_DEVTOOLS_EXTENSION_COMPOSE__: (arg: StoreEnhancer) => StoreEnhancer;
 }
-// when converting to production, remove this interface, the second argument
-// to createStore, and the ESLint overrides at the top
 
-// these lines allow us to use Redux DevTools for debugging
-const composeEnhancer = (window as MyWindow & Window
-  & typeof globalThis).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+if (!IS_PRODUCTION) {
+  const composeEnhancer = (window as MyWindow & Window
+    & typeof globalThis).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+  storeEnhancer = composeEnhancer(storeEnhancer);
+}
 
-// initialize Redux store with thunk
-const store = createStore(autoSchedulerReducer,
-  composeEnhancer(applyMiddleware(thunk)));
+// Create store with the proper enhancers applied
+const store = createStore(autoSchedulerReducer, storeEnhancer);
 
 ReactDom.render(
   <Provider store={store}>

--- a/autoscheduler/frontend/src/jest.config.js
+++ b/autoscheduler/frontend/src/jest.config.js
@@ -31,5 +31,6 @@ module.exports = {
     // Since running the tests won't have the variable set from the webpack config's
     // DefinePlugin usage, we have to manually set it in Jest
     STATIC_URL: '/static',
+    IS_PRODUCTION: true,
   },
 };

--- a/autoscheduler/frontend/src/tsconfig.json
+++ b/autoscheduler/frontend/src/tsconfig.json
@@ -5,6 +5,10 @@
         "noImplicitAny": true,
         "module": "commonjs",
         "target": "es2018",
+        "typeRoots": [
+            "./node_modules/@types",
+            "./globals.ts",
+        ],
         "jsx": "react"
     }
 }

--- a/autoscheduler/frontend/src/webpack.config.js
+++ b/autoscheduler/frontend/src/webpack.config.js
@@ -66,6 +66,7 @@ module.exports = {
     new webpack.DefinePlugin({
       STATIC_URL: JSON.stringify(process.env.PRODUCTION
         ? 'https://storage.googleapis.com/revregistration1.appspot.com' : '/static'),
+      IS_PRODUCTION: JSON.stringify(process.env.PRODUCTION),
     }),
   ],
 };

--- a/autoscheduler/frontend/templates/index.html
+++ b/autoscheduler/frontend/templates/index.html
@@ -50,9 +50,13 @@
         <div id="root"></div>
 
         <!-- Dependencies -->
-        <!-- I think we need these? -->
-        <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/react/16.12.0/umd/react.development.js"></script>
-        <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.11.0/umd/react-dom.development.js"></script>
+        {% if IS_GCP %}
+            <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/react/16.12.0/umd/react.production.min.js"></script>
+            <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.11.0/umd/react-dom.production.min.js"></script>
+        {% else %}
+            <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/react/16.12.0/umd/react.development.js"></script>
+            <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.11.0/umd/react-dom.development.js"></script>
+        {% endif %}
 
         {% load static %}
         <script src="{% static "main.js" %}"></script>

--- a/autoscheduler/frontend/views.py
+++ b/autoscheduler/frontend/views.py
@@ -1,6 +1,12 @@
+from django.conf import settings
 from django.shortcuts import render
+
+_INDEX_CONTEXT = {
+    'IS_GCP': settings.IS_GCP,
+}
 
 # Create your views here.
 def index(request):
     """ Renders index.html for React. Shouldn't need to be any other logic in here """
-    return render(request, 'index.html') # Automatically assumes index is in templates/
+    # Automatically assumes index is in templates/
+    return render(request, 'index.html', context=_INDEX_CONTEXT)


### PR DESCRIPTION
## Description
Uses minified production react when running on GCP, and doesn't give access to redux devtools when `npm run build` is run. I also improved the way globals work by letting our build tools know about their existence rather than having to manually import dummy variables to get around linter errors, since the old method only works if it uses a default export.

## Rationale
Using the new react versions in production should provide a significant speed boost (I've read ~2x-5x as fast from different sources— I'm surprised we hadn't really considered how much of a difference this might make), as well as saving ~150kB data transfer due to smaller file sizes. On the redux side I'm sure there are some small speed improvements since it doesn't need to add hooks to every dispatch.

## How to test
You can test the behavior for GCP by changing `_INDEX_CONTENT['IS_GCP']` in `autoscheduler/frontend/views.py` to `True` rather than using the environment variable, and `npm run build` to disable redux devtools.

## Related tasks
Closes #453.
