### PR TITLE
Filter duplicate meetings on schedule

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/Schedule.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/Schedule.tsx
@@ -22,7 +22,7 @@ import useMeetingColor from './meetingColors';
 import InstructionsDialog from './InstructionsDialog/InstructionsDialog';
 import createThrottleFunction from '../../../utils/createThrottleFunction';
 import SmallFastProgress from '../../SmallFastProgress';
-import { filterDuplicateMeetings } from '../../../utils/meetingsForSection';
+import meetingsForSchedule from '../../../utils/meetingsForSchedule';
 
 // Creates a throttle function that shares state between calls
 const throttle = createThrottleFunction();
@@ -355,12 +355,6 @@ const Schedule: React.FC = () => {
 
   // let's see if useMemo reduces our render time
   const meetingsForDays = React.useMemo(() => {
-    // build each day based on schedule
-    function getMeetingsForDay(day: number): Meeting[] {
-      // meetingDays = UMTWRFS
-      // day = MTWRF
-      return schedule.filter((meeting) => meeting.meetingDays[day]);
-    }
     function renderMeeting(meeting: Meeting): JSX.Element {
       return (
         <MeetingCard
@@ -372,8 +366,8 @@ const Schedule: React.FC = () => {
         />
       );
     }
-    return [DayOfWeek.MON, DayOfWeek.TUE, DayOfWeek.WED, DayOfWeek.THU, DayOfWeek.FRI].map(
-      (idx) => filterDuplicateMeetings(getMeetingsForDay(idx)).map((mtg) => renderMeeting(mtg)),
+    return meetingsForSchedule(schedule).map(
+      (meetingsForDay) => meetingsForDay.map((meeting) => renderMeeting(meeting)),
     );
   }, [meetingColors, schedule]);
   const availabilitiesForDays = React.useMemo(() => {

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/Schedule.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/Schedule.tsx
@@ -22,6 +22,7 @@ import useMeetingColor from './meetingColors';
 import InstructionsDialog from './InstructionsDialog/InstructionsDialog';
 import createThrottleFunction from '../../../utils/createThrottleFunction';
 import SmallFastProgress from '../../SmallFastProgress';
+import { filterDuplicateMeetings } from '../../../utils/meetingsForSection';
 
 // Creates a throttle function that shares state between calls
 const throttle = createThrottleFunction();
@@ -372,7 +373,7 @@ const Schedule: React.FC = () => {
       );
     }
     return [DayOfWeek.MON, DayOfWeek.TUE, DayOfWeek.WED, DayOfWeek.THU, DayOfWeek.FRI].map(
-      (idx) => getMeetingsForDay(idx).map((mtg) => renderMeeting(mtg)),
+      (idx) => filterDuplicateMeetings(getMeetingsForDay(idx)).map((mtg) => renderMeeting(mtg)),
     );
   }, [meetingColors, schedule]);
   const availabilitiesForDays = React.useMemo(() => {

--- a/autoscheduler/frontend/src/tests/ui/Schedule.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/Schedule.test.tsx
@@ -42,11 +42,23 @@ const testSection = new Section({
 const testMeeting1 = new Meeting({
   id: 12345,
   building: 'HRBB',
-  meetingDays: new Array(7).fill(true),
+  meetingDays: [true, false, false, false, false, false, false],
   startTimeHours: 10,
   startTimeMinutes: 20,
   endTimeHours: 11,
   endTimeMinutes: 10,
+  meetingType: MeetingType.LEC,
+  section: testSection,
+});
+
+const testMeeting2 = new Meeting({
+  id: 12346,
+  building: 'HRBB',
+  meetingDays: [true, false, false, false, false, false, false],
+  startTimeHours: 10,
+  startTimeMinutes: 20,
+  endTimeHours: 11,
+  endTimeMinutes: 30,
   meetingType: MeetingType.LEC,
   section: testSection,
 });
@@ -222,5 +234,32 @@ describe('Schedule UI', () => {
         );
       });
     });
+  });
+
+  test('combines duplicate meetings', () => {
+      // arrange
+      const store = createStore(autoSchedulerReducer, {
+        termData: {
+          schedules: [
+            {
+              meetings: [testMeeting1, testMeeting2],
+              name: 'Schedule 1',
+              saved: false,
+            },
+          ],
+        },
+        selectedSchedule: 0,
+      });
+
+      // act
+      const { getAllByText } = render(
+        <Provider store={store}>
+          <Schedule />
+        </Provider>,
+      );
+
+      // assert
+      const numMeetingCards = getAllByText('CSCE 121');
+      expect(numMeetingCards.length).toEqual(1);
   });
 });

--- a/autoscheduler/frontend/src/tests/ui/Schedule.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/Schedule.test.tsx
@@ -237,29 +237,29 @@ describe('Schedule UI', () => {
   });
 
   test('combines duplicate meetings', () => {
-      // arrange
-      const store = createStore(autoSchedulerReducer, {
-        termData: {
-          schedules: [
-            {
-              meetings: [testMeeting1, testMeeting2],
-              name: 'Schedule 1',
-              saved: false,
-            },
-          ],
-        },
-        selectedSchedule: 0,
-      });
+    // arrange
+    const store = createStore(autoSchedulerReducer, {
+      termData: {
+        schedules: [
+          {
+            meetings: [testMeeting1, testMeeting2],
+            name: 'Schedule 1',
+            saved: false,
+          },
+        ],
+      },
+      selectedSchedule: 0,
+    });
 
-      // act
-      const { getAllByText } = render(
-        <Provider store={store}>
-          <Schedule />
-        </Provider>,
-      );
+    // act
+    const { getAllByText } = render(
+      <Provider store={store}>
+        <Schedule />
+      </Provider>,
+    );
 
-      // assert
-      const numMeetingCards = getAllByText('CSCE 121');
-      expect(numMeetingCards.length).toEqual(1);
+    // assert
+    const numMeetingCards = getAllByText('CSCE 121');
+    expect(numMeetingCards.length).toEqual(1);
   });
 });

--- a/autoscheduler/frontend/src/utils/meetingsForSchedule.ts
+++ b/autoscheduler/frontend/src/utils/meetingsForSchedule.ts
@@ -1,0 +1,26 @@
+import DayOfWeek from '../types/DayOfWeek';
+import Meeting from '../types/Meeting';
+import { filterDuplicateMeetings } from './meetingsForSection';
+
+/**
+ *  Gets all of the meetings for this specific day from the schedule
+ * @param day The day we want the meetings for
+ * @param schedule The schedule we're getting the Meetings from
+ * @returns Meetings for that day
+ */
+function getMeetingsForDay(day: number, schedule: Meeting[]): Meeting[] {
+  // meetingDays = UMTWRFS
+  // day = MTWRF
+  return schedule.filter((meeting) => meeting.meetingDays[day]);
+}
+
+/**
+ * Returns the unique meetings for a schedule, partioned by day of the week
+ * @param schedule The schedule to partion
+ * @returns 2D list of meetings to process
+ */
+export default function meetingsForSchedule(schedule: Meeting[]): Meeting[][] {
+  return [DayOfWeek.MON, DayOfWeek.TUE, DayOfWeek.WED, DayOfWeek.THU, DayOfWeek.FRI].map(
+    (idx) => filterDuplicateMeetings(getMeetingsForDay(idx, schedule)),
+  );
+}

--- a/autoscheduler/frontend/src/utils/meetingsForSection.ts
+++ b/autoscheduler/frontend/src/utils/meetingsForSection.ts
@@ -8,7 +8,7 @@ import Section from '../types/Section';
    * differ only in the end times will still be considered duplicates
    * @param arr
    */
-function filterDuplicateMeetings(meetings: Meeting[]): Meeting[] {
+export function filterDuplicateMeetings(meetings: Meeting[]): Meeting[] {
   // helper function to merge two meetings
   const mergeMeetings = (mtg1: Meeting, mtg2: Meeting): Meeting => {
     if (!mtg2) return mtg1;


### PR DESCRIPTION
## Description

This adds the filtering/combining of duplicate meetings on the schedule

## How to test

There's an example in Fall 2020, CSCE 121 - 597

## Screenshots

|Before|After|
|--|--|
|![chrome_Mreqe0x3kn](https://user-images.githubusercontent.com/7295783/112761405-07a1ea80-8fb0-11eb-8245-5680802d6370.png)|![chrome_u3FPCoBBfw](https://user-images.githubusercontent.com/7295783/112761408-0d97cb80-8fb0-11eb-9f1b-b60a6e1f64b1.png)|

## Related tasks

Closes #419
