### PR TITLE
Fix instructor select bugs

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/ProfessorGroup.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/ProfessorGroup.tsx
@@ -44,22 +44,24 @@ const ProfessorGroup: React.FC<ProfessorGroupProps> = ({ courseCardId, sectionRa
   const instructorHeader = (
     <ListSubheader disableGutters className={styles.listSubheaderDense}>
       <div className={styles.listSubheaderContent}>
-        <Button
-          className={styles.nameHonorsIcon}
-          onClick={toggleAllSelected}
-          aria-label="Select all for professor"
-        >
-          <Checkbox
-            checked={areAnySelected}
-            indeterminate={areAnySelected && !areAllSelected}
-            size="small"
-            color="primary"
-            value={areAllSelected ? 'professor on' : 'professor off'}
-            classes={{ root: styles.lessCheckboxPadding }}
-          />
-          {firstSection.instructor.name}
+        <div className={styles.nameHonorsIcon}>
+          <Button
+            className={styles.profNameBtn}
+            onClick={toggleAllSelected}
+            aria-label="Select all for professor"
+          >
+            <Checkbox
+              checked={areAnySelected}
+              indeterminate={areAnySelected && !areAllSelected}
+              size="small"
+              color="primary"
+              value={areAllSelected ? 'professor on' : 'professor off'}
+              classes={{ root: styles.lessCheckboxPadding }}
+            />
+            {firstSection.instructor.name}
+          </Button>
           {firstSection.honors ? <HonorsIcon /> : null}
-        </Button>
+        </div>
         <GradeDist grades={firstSection.grades} />
       </div>
       <div className={styles.dividerContainer}>

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
@@ -48,15 +48,13 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
   const remainingSeatsColor = remainingSeats > 0 ? 'black' : 'red';
   // show section number and remaining seats if this is the first meeting for a section
   const sectionHeader = (
-    <Typography className={styles.denseListItem} component="div" style={{ display: 'flex', gridColumn: '1 / -1' }}>
-      <div style={{ flex: 1, display: 'flex', alignItems: 'center' }}>
+    <Typography className={`${styles.denseListItem} ${styles.sectionHeader}`} component="div">
+      <div className={styles.sectionNumAndIcon}>
         {section.sectionNum}
         &nbsp;
         <InstructionalMethodIcon instructionalMethod={section.instructionalMethod} />
       </div>
-      <div
-        style={{ flex: 3, color: remainingSeatsColor, textAlign: 'right' }}
-      >
+      <div style={{ color: remainingSeatsColor }} className={styles.remainingSeats}>
         {`${remainingSeats}/${section.maxEnrollment} seats left`}
       </div>
     </Typography>

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
@@ -49,7 +49,7 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
   // show section number and remaining seats if this is the first meeting for a section
   const sectionHeader = (
     <Typography className={styles.denseListItem} component="div" style={{ display: 'flex', gridColumn: '1 / -1' }}>
-      <div style={{ flex: 1, display: 'flex' }}>
+      <div style={{ flex: 1, display: 'flex', alignItems: 'center' }}>
         {section.sectionNum}
         &nbsp;
         <InstructionalMethodIcon instructionalMethod={section.instructionalMethod} />

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
@@ -87,6 +87,22 @@
     padding-inline-start: 0;
 }
 
+.section-header {
+    display: flex;
+    grid-column: 1 / -1;
+}
+
+.section-num-and-icon {
+    flex: 1;
+    display: flex;
+    align-items: center;
+}
+
+.remaining-seats {
+    flex: 3;
+    text-align: right;
+}
+
 .meeting-info-wrapper {
     display: contents;
 }

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
@@ -108,7 +108,7 @@
 }
 
 /* Removes background from 1-meeting sections */
-.meeting-info-wrapper:nth-child(2):last-child {
+.meeting-info-wrapper:nth-child(2):last-child div {
     background: unset;
 }
 

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
@@ -123,11 +123,6 @@
     background: #50000020;
 }
 
-/* Removes background from 1-meeting sections */
-.meeting-info-wrapper:nth-child(2):last-child div {
-    background: unset;
-}
-
 .meeting-info-wrapper > div {
     padding: 2px;
 }

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
@@ -40,7 +40,7 @@
     min-height: 20px;
 }
 
-.name-honors-icon:global(.MuiButton-root) {
+.prof-name-btn:global(.MuiButton-root) {
     text-transform: unset;
     color:rgb(97, 97, 97);
     padding: 0;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css.d.ts
@@ -38,6 +38,8 @@ declare namespace SectionSelectCssNamespace {
     noStartPadding: string;
     "placeholder-text": string;
     placeholderText: string;
+    "prof-name-btn": string;
+    profNameBtn: string;
     "remaining-seats": string;
     remainingSeats: string;
     "section-details-table": string;

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css.d.ts
@@ -38,11 +38,17 @@ declare namespace SectionSelectCssNamespace {
     noStartPadding: string;
     "placeholder-text": string;
     placeholderText: string;
+    "remaining-seats": string;
+    remainingSeats: string;
     "section-details-table": string;
+    "section-header": string;
     "section-name-container": string;
+    "section-num-and-icon": string;
     "section-rows": string;
     sectionDetailsTable: string;
+    sectionHeader: string;
     sectionNameContainer: string;
+    sectionNumAndIcon: string;
     sectionRows: string;
     "sort-menu-position": string;
     "sort-order-button": string;

--- a/autoscheduler/frontend/src/tests/ui/SectionSelect.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SectionSelect.test.tsx
@@ -184,7 +184,7 @@ describe('SectionSelect', () => {
       );
 
       // act
-      const profNames = await findAllByText('Aakash Tyagi');
+      const profNames = (await findAllByText('Aakash Tyagi')).map((el) => el.parentElement.parentElement.parentElement);
       expect(profNames).toHaveLength(2);
       const honorsSection = profNames[0];
       const regularSection = profNames[1];


### PR DESCRIPTION
## Description

After merging with master, we discovered that the changes to CSS grid at the end reverted some of the desired behaviors from  earlier work. Specifically, if there is a single meeting for a section, its background should be white, not red, and the section number is clearly no longer aligned with the instructional method icon. These have both been fixed by this patch.

## Rationale

Should be simple enough, as it's 2 lines of CSS. Ask if you have questions though

## How to test

Inspect visually in browser. See PSYC 107 for a class with 1-meeting sections and literally any class for the misalignes section number.

## Screenshots

If it's a frontend change, provide screenshots of it. If possible, show the change on different
resolutions/sizes.

If you're changing a existing frontend look, provide a before and after screenshot in the table below.

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/10082177/113944915-ee2c4a00-97ca-11eb-9c5b-7f9927e3737c.png)|![image](https://user-images.githubusercontent.com/10082177/113944970-0dc37280-97cb-11eb-9fb4-27adbf70a83e.png)|

## Related tasks

Quick patch for #473 
