### PR TITLE
Remove arrow from GradeDist tooltips

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/GradeDist/GradeDist.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/GradeDist/GradeDist.tsx
@@ -37,7 +37,6 @@ const GradeDist: React.FC<GradeDistProps> = ({ grades }) => {
     return (
       <Tooltip
         title={tooltipText}
-        arrow
         PopperProps={{
           // Fixes Tooltip scroll issue. See: https://github.com/mui-org/material-ui/issues/14366
           disablePortal: true,


### PR DESCRIPTION
## Description

Fixes the GradeDist scroll problem by removing arrows from tooltips.

## Rationale
Gannon wanted to see how this looked locally, we should be able to compare it to the current behavior and find out what we like best

## Screenshots
| Deployment | This PR |
|--|--|
| ![image](https://user-images.githubusercontent.com/28655462/115162243-083a1800-a068-11eb-8808-3cd4471bc61b.png) | ![image](https://user-images.githubusercontent.com/28655462/115162287-459ea580-a068-11eb-896e-ac029a458e2f.png) |

(Note that instead adding `overflow-x: none` to the container looks identical to deployment but just doesn't add a horizontal scrollbar)

## Related tasks
Closes #310.
