### PR TITLE
Set term to null on landing page

### DIFF
--- a/autoscheduler/frontend/src/components/LandingPage/LandingPage.tsx
+++ b/autoscheduler/frontend/src/components/LandingPage/LandingPage.tsx
@@ -1,22 +1,31 @@
 import * as React from 'react';
 import { RouteComponentProps } from '@reach/router';
+import { useDispatch } from 'react-redux';
 import HelpText from './HelpText/HelpText';
 import SelectTerm from './SelectTerm/SelectTerm';
 import * as styles from './LandingPage.css';
 import About from './About/About';
 import PrivacyPolicy from './PrivacyPolicy/PrivacyPolicy';
+import setTerm from '../../redux/actions/term';
 
-const LandingPage: React.FC<RouteComponentProps> = () => (
-  <div className={styles.container}>
-    <HelpText />
-    <SelectTerm />
-    <div className={styles.dialogContainer}>
-      <div className={styles.dialogLink}>
-        <About />
-        <PrivacyPolicy />
+const LandingPage: React.FC<RouteComponentProps> = () => {
+  const dispatch = useDispatch();
+  React.useEffect(() => {
+    dispatch(setTerm(null));
+  }, [dispatch]);
+
+  return (
+    <div className={styles.container}>
+      <HelpText />
+      <SelectTerm />
+      <div className={styles.dialogContainer}>
+        <div className={styles.dialogLink}>
+          <About />
+          <PrivacyPolicy />
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default LandingPage;

--- a/autoscheduler/frontend/src/tests/ui/LandingPage.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/LandingPage.test.tsx
@@ -28,8 +28,6 @@ describe('Landing Page', () => {
       </Provider>,
     );
 
-    // const all = getAllByText('Fall 2021 - College Station');
-
     // Assert
     expect(store.getState().termData.term).toBeNull();
   });

--- a/autoscheduler/frontend/src/tests/ui/LandingPage.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/LandingPage.test.tsx
@@ -1,0 +1,36 @@
+import fetchMock, { enableFetchMocks } from 'jest-fetch-mock';
+
+enableFetchMocks();
+
+/* eslint-disable import/first */ // enableFetchMocks must be called before others are imported
+import { render } from '@testing-library/react';
+import * as React from 'react';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+import LandingPage from '../../components/LandingPage/LandingPage';
+import autoSchedulerReducer from '../../redux/reducer';
+
+describe('Landing Page', () => {
+  test('sets term to null', async () => {
+    // Arrange
+    fetchMock.mockResponseOnce(JSON.stringify({ 'Fall 2021 - College Station': '202131' }));
+
+    const store = createStore(autoSchedulerReducer, {
+      termData: {
+        term: '202131',
+      },
+    });
+
+    // Act
+    render(
+      <Provider store={store}>
+        <LandingPage />
+      </Provider>,
+    );
+
+    // const all = getAllByText('Fall 2021 - College Station');
+
+    // Assert
+    expect(store.getState().termData.term).toBeNull();
+  });
+});


### PR DESCRIPTION
## Description

Re-adds the setting of null on the landing page that was accidentally removed in #515 so that the term in the navbar is reset to `Select Term`.

Also adds tests for it

## How to test

Do the action I did in my gif

## Screenshots

![set-term-null](https://user-images.githubusercontent.com/7295783/115162329-be493600-a057-11eb-9c93-68bfd3512708.gif)

## Related tasks

Closes #537 
