### PR TITLE
One line navbar

### DIFF
--- a/autoscheduler/frontend/src/components/LandingPage/SelectTerm/NavBarSelectTerm.css
+++ b/autoscheduler/frontend/src/components/LandingPage/SelectTerm/NavBarSelectTerm.css
@@ -6,6 +6,7 @@
 .select-term-button {
     color: #fff !important;
     border: 1px solid rgba(255, 255, 255, 0.5) !important;
+    white-space: nowrap;
 }
 
 .menu-paper {

--- a/autoscheduler/frontend/src/components/LastUpdatedAt.tsx
+++ b/autoscheduler/frontend/src/components/LastUpdatedAt.tsx
@@ -110,17 +110,17 @@ const LastUpdatedAt: React.FC = () => {
   }, [lastUpdated]);
 
   return (
-    <div
+    <Typography
       style={{
-        display: 'flex',
-        alignItems: 'center',
         paddingLeft: 8,
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
       }}
+      variant="body2"
     >
-      <Typography variant="body2">
-        {lastUpdatedText ? `Last updated ${lastUpdatedText}` : null}
-      </Typography>
-    </div>
+      {lastUpdatedText ? `Last updated ${lastUpdatedText}` : null}
+    </Typography>
   );
 };
 

--- a/autoscheduler/frontend/src/components/NavBar/LoginButton.tsx
+++ b/autoscheduler/frontend/src/components/NavBar/LoginButton.tsx
@@ -78,6 +78,7 @@ const LoginButton: React.FC = () => {
       </div>
     ) : (
       <Button
+        className={styles.userName}
         color="inherit"
         onClick={(): void => {
           window.open(`/login/google-oauth2/?next=${window.location.href}`, '_self');

--- a/autoscheduler/frontend/src/components/NavBar/LoginButton.tsx
+++ b/autoscheduler/frontend/src/components/NavBar/LoginButton.tsx
@@ -61,8 +61,8 @@ const LoginButton: React.FC = () => {
   // and user's name depending on whether a user is logged in or not
   return (
     usersName !== undefined ? (
-      <div className={styles.nameAndButton}>
-        <Typography variant="subtitle1">
+      <div className={styles.logoutContainer}>
+        <Typography className={styles.userName} variant="subtitle1">
           {usersName}
         </Typography>
         <Button

--- a/autoscheduler/frontend/src/components/NavBar/NavBar.css
+++ b/autoscheduler/frontend/src/components/NavBar/NavBar.css
@@ -6,6 +6,4 @@
 
 .user-name {
     white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
 }

--- a/autoscheduler/frontend/src/components/NavBar/NavBar.css
+++ b/autoscheduler/frontend/src/components/NavBar/NavBar.css
@@ -1,4 +1,11 @@
-.name-and-button {
+.logout-container {
     display: flex;
     align-items: center;
+    min-width: 0;
+}
+
+.user-name {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }

--- a/autoscheduler/frontend/src/components/NavBar/NavBar.css
+++ b/autoscheduler/frontend/src/components/NavBar/NavBar.css
@@ -1,7 +1,6 @@
 .logout-container {
     display: flex;
     align-items: center;
-    min-width: 0;
 }
 
 .user-name {

--- a/autoscheduler/frontend/src/components/NavBar/NavBar.css.d.ts
+++ b/autoscheduler/frontend/src/components/NavBar/NavBar.css.d.ts
@@ -1,7 +1,9 @@
 declare namespace NavBarCssNamespace {
   export interface INavBarCss {
-    "name-and-button": string;
-    nameAndButton: string;
+    "logout-container": string;
+    logoutContainer: string;
+    "user-name": string;
+    userName: string;
   }
 }
 

--- a/autoscheduler/frontend/src/components/NavBar/NavBar.tsx
+++ b/autoscheduler/frontend/src/components/NavBar/NavBar.tsx
@@ -12,6 +12,9 @@ const useStyles = makeStyles((theme) => ({
   root: {
     flexGrow: 0,
   },
+  title: {
+    whiteSpace: 'nowrap',
+  },
   menuButton: {
     marginRight: theme.spacing(2),
   },
@@ -23,10 +26,10 @@ const useStyles = makeStyles((theme) => ({
     justifyContent: 'space-between',
     width: '100%',
   },
-
   titleAndSelectTerm: {
     display: 'flex',
-    width: '50%',
+    alignItems: 'center',
+    minWidth: 0,
   },
 }));
 
@@ -60,7 +63,7 @@ const NavBar: React.SFC = () => {
                       paddingRight: 4,
                     }}
                   />
-                  <Typography variant="h6">
+                  <Typography className={classes.title} variant="h6">
                     Rev Registration
                   </Typography>
                 </Button>


### PR DESCRIPTION
## Description
Makes the navbar stay on one line rather than become thicc af

## Rationale

It starts looking a bit weird when the width goes below 600px (term select clips with name):
![image](https://user-images.githubusercontent.com/28655462/115939192-f63ee780-a462-11eb-9150-5722f32180c9.png)
but this should be fixed with the mobile functionality PR and is incredibly unlikely on desktop so I don't think it's that big a deal

## How to test

Describe the best way to test the specific changes you made. If it's covering a special case,
make sure to include the situations they should check out (i.e. PHYS 207 - 501, term 202031)

## Screenshots
lol yikes

|Before|After|
|--|--|
| ![image](https://user-images.githubusercontent.com/28655462/115939132-bd067780-a462-11eb-8cc1-db9b6bf857a6.png) | ![image](https://user-images.githubusercontent.com/28655462/115939114-af50f200-a462-11eb-9c20-4ea25414673b.png) |

## Related tasks
Closes #517.