### PR TITLE
Fix actions backend linting

### DIFF
--- a/.github/lint-requirements.txt
+++ b/.github/lint-requirements.txt
@@ -2,6 +2,7 @@ aiohttp==3.6.2
 beautifulsoup4==4.8.2
 Django~=2.2.6
 djangorestframework~=3.9.2
+pylint==2.7.0
 pylint-django==2.4.2
 PyPDF2==1.26.0
 requests==2.21.0


### PR DESCRIPTION
## Description

Locks pylint to `2.7.0` in `lint-requirements.txt`

## How to test

Look at the checkmark
