### PR TITLE
Fix default sort direction and add direction to sessions

### DIFF
--- a/autoscheduler/frontend/src/redux/actions/courseCards.ts
+++ b/autoscheduler/frontend/src/redux/actions/courseCards.ts
@@ -27,6 +27,7 @@ function createEmptyCourseCard(): CourseCardOptions {
     includeFull: false,
     collapsed: false,
     sortType: SortType.DEFAULT,
+    sortIsDescending: true,
   };
 }
 
@@ -331,6 +332,7 @@ function deserializeCourseCard(courseCard: SerializedCourseCardOptions): CourseC
     sections: [],
     loading: true,
     sortType: courseCard.sortType,
+    sortIsDescending: courseCard.sortIsDescending,
   };
 }
 

--- a/autoscheduler/frontend/src/tests/ui/CourseSelectColumn.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/CourseSelectColumn.test.tsx
@@ -258,4 +258,33 @@ describe('CourseSelectColumn', () => {
       expectCardsNotToBeSavedForTerm('202031');
     });
   });
+
+  describe('sort by direction', () => {
+    describe('defaults to descending', () => {
+      test('when the second course card is added', () => {
+        // arrange
+        const store = createStore(autoSchedulerReducer, applyMiddleware(thunk));
+        store.dispatch(setTerm('201931'));
+
+        // sessions/get_saved_courses
+        fetchMock.mockResponseOnce(JSON.stringify({}));
+
+        const { getByText } = render(
+          <Provider store={store}>
+            <CourseSelectColumn />
+          </Provider>,
+        );
+
+        // act
+        // Press the button
+        act(() => { fireEvent.click(getByText('Add Course')); });
+
+        // assert
+        // There should be now be two since it defaults to one at the beginning
+        const second = store.getState().termData.courseCards[1];
+
+        expect(second.sortIsDescending).toEqual(true);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Description

Fixes the default sort direction (for the second course card, it works on the first one) and added sort direction to sessions.

## How to test

Add two course cards (one new one) and double check they have the correct default sort direction. Change the sort direction to something else and ensure it saves it in the session

## Related tasks

Closes #521 
