### PR TITLE
Made select term on landing page golden

### DIFF
--- a/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.css
+++ b/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.css
@@ -7,7 +7,6 @@
 .select-term-button {
     width: 55%;
     max-width: 800px;
-    background-color: white !important;
 }
 
 .menu-paper {


### PR DESCRIPTION
## Description

Makes the select term button on the landing page golden.

## Rationale

It's ugly but it attracts the user's attention, which will help compensate for the wall of text that is the landing page

## Screenshots

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/10082177/116160815-52e71000-a6b8-11eb-90be-bc0c91c0c448.png)|![image](https://user-images.githubusercontent.com/10082177/116160784-4793e480-a6b8-11eb-91e9-317e17e30511.png)|

## Related tasks

None
