### PR TITLE
Fixed bug where large cards take up extra space

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
@@ -95,7 +95,9 @@ const CourseSelectColumn: React.FC = () => {
             }
             const availableHeight = Math.max(MIN_CARD_HEIGHT, col.clientHeight - otherKidsHeight)
               - CARD_CONTENT_BASE_HEIGHT;
-            (sectionRows[0] as HTMLDivElement).style.height = `${availableHeight}px`;
+              // +1 prevents unnecessary scrollbar
+            const newHeight = Math.min(availableHeight, sectionRows[0].scrollHeight + 1);
+            (sectionRows[0] as HTMLDivElement).style.height = `${newHeight}px`;
           }
         }
       }


### PR DESCRIPTION
## Description

Setting the height in JavaScript is tricky because it means manually handling a lot of things that CSS usually manages. For cards larger than 500px, I had set the height to take up the maximum available space, but in reality, the height needs to be capped at the height of sectionRows

## How to test

I originally missed this bug because my screen was too small, so make sure your screen is fairly large. Next, open a card that is larger than 500px but can fit within your screen. I used SPAN 301 atfer zooming out my screen to 50%. The card should take up only as much space as it needs, not the whole column.

## Screenshots

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/10082177/116316011-f5fe5f00-a776-11eb-9745-201b894085f2.png)|![image](https://user-images.githubusercontent.com/10082177/116315867-c0597600-a776-11eb-9a01-0f6a9c93c4fb.png)|

## Related tasks

Bug originally caused by mistake in #474
Does not address #548, which will be a slightly more involved PR
