### PR TITLE
Fix unavailable section handling for /get_saved_schedules

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/SchedulePreview.tsx
@@ -69,7 +69,12 @@ const SchedulePreview: React.FC<SchedulePreviewProps> = ({
       }))).then((savedSchedules: Schedule[]) => {
         dispatch(setSchedules(savedSchedules, term));
         setIsLoadingSchedules(false);
-      });
+      })
+        .catch(() => {
+          // Hide loading indicator if there's an error
+          // Otherwise, loading indicator would display indefinitely
+          setIsLoadingSchedules(false);
+        });
     }
 
     // on unmount, clear schedules

--- a/autoscheduler/scheduler/tests/api_tests.py
+++ b/autoscheduler/scheduler/tests/api_tests.py
@@ -89,11 +89,27 @@ class SchedulingAPITests(APITestCase):
         """ Tests that _serialize_schedules handles an unavailable section """
 
         # Arrange
-        schedule = [(2, 3)] # 3 doesn't exist
+        schedule = [(2, 3)] # section with id = 3 doesn't exist
 
         expected = [
             [SectionSerializer(self.sections[1]).data]
         ]
+
+        # Act
+        result = _serialize_schedules(schedule)
+
+        # Assert
+        self.assertEqual(result, expected)
+
+    def test_serialize_schedules_handles_sole_unavailable_section(self):
+        """ Tests that _serialize_schedules handles an unavailable section when its the
+            only section in the schedule
+        """
+
+        # Arrange
+        schedule = [(3,)] # section with id = 3 doesn't exist
+
+        expected = []
 
         # Act
         result = _serialize_schedules(schedule)

--- a/autoscheduler/scheduler/tests/api_tests.py
+++ b/autoscheduler/scheduler/tests/api_tests.py
@@ -85,6 +85,22 @@ class SchedulingAPITests(APITestCase):
         # Assert
         self.assertEqual(result, expected)
 
+    def test_serialize_schedules_handles_unavailable_section(self):
+        """ Tests that _serialize_schedules handles an unavailable section """
+
+        # Arrange
+        schedule = [(2, 3)] # 3 doesn't exist
+
+        expected = [
+            [SectionSerializer(self.sections[1]).data]
+        ]
+
+        # Act
+        result = _serialize_schedules(schedule)
+
+        # Assert
+        self.assertEqual(result, expected)
+
     # Replaces the create_schedules import that's imported in scheduler.views
     @patch('scheduler.views.create_schedules')
     def test_route_scheduling_generate_is_correct(self, create_schedules_mock):

--- a/autoscheduler/scheduler/views.py
+++ b/autoscheduler/scheduler/views.py
@@ -62,12 +62,18 @@ def _serialize_schedules(schedules: List[Tuple[str]]) -> List[List]:
     sections_dict = {section.id: section for section in models}
 
     def sections_for_schedule(schedule):
-        sections = (sections_dict.get(section) for section in schedule
+        sections = (sections_dict[section] for section in schedule
                     if section in sections_dict)
 
         return SectionSerializer(sections, many=True).data
 
-    return [sections_for_schedule(schedule) for schedule in schedules]
+    ret = []
+    for schedule in schedules:
+        serialized_schedule = sections_for_schedule(schedule)
+        if serialized_schedule:
+            ret.append(serialized_schedule)
+
+    return ret
 
 class ScheduleView(APIView):
     """ Handles requests to the generate schedules algorithm  """

--- a/autoscheduler/scheduler/views.py
+++ b/autoscheduler/scheduler/views.py
@@ -62,7 +62,8 @@ def _serialize_schedules(schedules: List[Tuple[str]]) -> List[List]:
     sections_dict = {section.id: section for section in models}
 
     def sections_for_schedule(schedule):
-        sections = (sections_dict[section] for section in schedule)
+        sections = (sections_dict.get(section) for section in schedule
+                    if section in sections_dict)
 
         return SectionSerializer(sections, many=True).data
 


### PR DESCRIPTION
## Description

We've been getting an error from `/get_saved_schedules` which results from people having saved schedules with sections that are no longer available (since the previous Fall 2021 sections got nuked by the new ones). As such, this handles the situation by simply returning nothing when they're encountered. This will result in empty schedules which ofc isn't ideal, but at least they can recover from this (instead of being completely unable to use the schedule preview column)

## How to test

To test the frontend handling:

~~Save a schedule (make sure `/get_saved_schedules` is called), then on line 67 in scheduler/views.py set `sections = ()` in the `sections_for_schedule` function to mimic it returning `None` for a section. Then refresh and ensure it shows an empty schedule (without the frontend change, it would render forever)~~ actually I don't think this would test it correctly

In `user_sessions/views.py` add `return Response(status=400)` around line 115 (anywhere in `get_saved_schedules` really) then ensure the loading indicator stops displaying.

Honestly not sure how we'd test the backend handling, other than the test I wrote.

## Screenshots

![chrome_GaeASM5Xqh](https://user-images.githubusercontent.com/7295783/116638013-3518e580-a91a-11eb-93a3-26b96169d568.png)

## Related tasks

Closes #567
