### PR TITLE
Restored transtion after removing collapsed card

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
@@ -29,9 +29,10 @@ const CourseSelectColumn: React.FC = () => {
   const [wasCourseRemoved, setCourseRemoved] = React.useState(false);
 
   const removeCallback = React.useCallback((id: number) => {
+    const needToDisableTransition = !courseCards[id].collapsed;
     dispatch(removeCourseCard(id));
-    setCourseRemoved(true);
-  }, [dispatch, setCourseRemoved]);
+    if (needToDisableTransition) setCourseRemoved(true);
+  }, [courseCards, dispatch]);
 
   const resetAnimations = React.useCallback(() => {
     setCourseRemoved(false);


### PR DESCRIPTION
## Description

Fixes a bug from #471 that Ryan reported. Closes #548 

## Rationale

I chose not to fix the lack of a transition when the user removes an expanded card. This is because the transition that plays by default feels off, in that the removed card disappears, the newly expanded card teleports up into its place, and then the new card expands with a transition. During #471, we decided that this was worse than not having any transition at all, which is what led me to disable this specific transition. Instead, when you remove a card, the new card magically pops into place (as it did before #471). I acknowledge that this is not the ideal, which would be to gradually collapse the card to be deleted while expanding the new card, then delete the old card. However, when I attempted to implement this, there was a lag between the collapse transition and the deletion of the card. Here's a GIF of what that looks like:
![collapse_then_remove](https://user-images.githubusercontent.com/10082177/117089458-3d5a9180-ad1b-11eb-807d-3b2da0172472.gif)

If y'all think that this GIF is not that bad, I could change to that behavior instead of playing no transition at all.

## How to test

1. Create at least 2 course cards
2. Collapse all of them
3. Remove one
4. Expand one of the remaining cards
5. Assert that the transition played

To test that this doesn't break normal functionality,
1. Create at least 2 course cards
3. Remove the expanded course card
4. Assert that no transition plays and the next course card is now expanded

## Screenshots

|Initial state|Before|After|
|--|--|--|
|Collapsed|![before_collapsed](https://user-images.githubusercontent.com/10082177/117735215-a4b08f80-b1ba-11eb-8046-3afc5d80c6bd.gif)|![after_collapsed](https://user-images.githubusercontent.com/10082177/117735228-ada16100-b1ba-11eb-8c72-9786dbc91849.gif)|
|Expanded|![after_expanded](https://user-images.githubusercontent.com/10082177/117735282-c6117b80-b1ba-11eb-84df-8b87b2187efc.gif)|<-- same|


## Related tasks

Closes #548