### PR TITLE
Improve course search behavior

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/CourseSelectCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/CourseSelectCard.tsx
@@ -148,16 +148,12 @@ const CourseSelectCard: React.FC<CourseSelectCardProps> = ({
         options={options}
         size="small"
         autoHighlight
-        autoSelect
         disabled={loading}
         inputValue={inputValue}
         value={course}
         multiple={false}
         filterOptions={(): any[] => options} // Options are not filtered
         getOptionSelected={(option): boolean => option === options[0]}
-        onClose={(): void => {
-          if (options.length === 0) setInputValue('');
-        }}
         onChange={(_evt: object, val: string): void => {
           dispatch(updateCourseCard(id, {
             course: val,


### PR DESCRIPTION
## Description
Improves the functionality of the course select autocomplete in a couple ways:
- Clicking outside of the dropdown will no longer select the last hovered course
- No dropdown results no longer clears the text showing what course is selected (note that even before this PR it would keep the selected course, just not display it until the card is collapsed/expanded again)

## Rationale
We talked about these behaviors being undesired during the last meeting since they're unintuitive and annoying in most cases

## How to test
Try replicating the gifs on this branch vs. deployment. Actual tests don't very worthwhile for this PR given it's just using default material UI behavior but can be added if someone thinks it's worth doing

## Screenshots
|Before|After|
|--|--|
| ![1](https://user-images.githubusercontent.com/28655462/117584076-51621280-b0d0-11eb-90a6-a18386b3d0de.gif) | ![2](https://user-images.githubusercontent.com/28655462/117584086-5b841100-b0d0-11eb-8520-6d2462573b06.gif) |

## Related tasks
No related issue, just discussed in meetings