### PR TITLE
GradeDist fixes

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/GradeDist/GradeDist.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/GradeDist/GradeDist.tsx
@@ -62,7 +62,6 @@ const GradeDist: React.FC<GradeDistProps> = ({ grades }) => {
     <div className={styles.gradesContainer}>
       <Tooltip
         title={makeFromTotalSectionsTooltipText(grades.count)}
-        arrow
         PopperProps={{
           disablePortal: true,
         }}

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/ProfessorGroup.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/ProfessorGroup.tsx
@@ -14,18 +14,26 @@ import * as styles from './SectionSelect.css';
 interface ProfessorGroupProps {
   courseCardId: number;
   sectionRange: [number, number];
+  zIndex?: number;
 }
 
 /**
  * Renders a group of sections that have the same professors and honors status, including the
  * instructor header at the top.
  *
- * @param props This component takes 2 props, `courseCardId` and `sectionRange`. `sectionRange`
- * should be a tuple of 2 numbers `[startIdx, endIdx]`, where `startIdx` is the first section
- * that should be rendered in this group and `endIdx` is one more than the last section in this
- * group
+ * @param props
+ * sectionRange: A tuple of 2 numbers `[startIdx, endIdx]`, where `startIdx` is the first section
+ *   that should be rendered in this group and `endIdx` is one more than the last section in this
+ *   group
+ * courseCardId: ID of the course card containing the correct section data
+ * zIndex: z index to use, groups coming later in the document should have lower z indices
+ *   so that CSS stacking contexts are correctly ordered and tooltips appear above later headers
  */
-const ProfessorGroup: React.FC<ProfessorGroupProps> = ({ courseCardId, sectionRange }) => {
+const ProfessorGroup: React.FC<ProfessorGroupProps> = ({
+  courseCardId,
+  sectionRange,
+  zIndex = 0,
+}) => {
   const [startIdx, endIdx] = sectionRange;
 
   const dispatch = useDispatch();
@@ -42,7 +50,7 @@ const ProfessorGroup: React.FC<ProfessorGroupProps> = ({ courseCardId, sectionRa
   };
 
   const instructorHeader = (
-    <ListSubheader disableGutters className={styles.listSubheaderDense}>
+    <ListSubheader style={{ zIndex }} disableGutters className={styles.listSubheaderDense}>
       <div className={styles.listSubheaderContent}>
         <div className={styles.nameHonorsIcon}>
           <Button

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.tsx
@@ -103,6 +103,7 @@ const SectionSelect: React.FC<SectionSelectProps> = ({ id }): JSX.Element => {
         <ProfessorGroup
           sectionRange={[currProfGroupStart, secIdx + 1]}
           courseCardId={id}
+          zIndex={sections.length - secIdx}
           key={`${lastProf + lastHonors} ${sectionData.section.sectionNum}`}
         />
       );


### PR DESCRIPTION
## Description
Fixes #571 and #572

## Rationale
I fixed #571 by adding `zIndex` as a parameter of `<ProfessorGroup />`: due to [how stacking contexts work in CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context), since each professor name header is a `sticky` element with identical z indices the tooltips will render under sequential headers.
There are only two ways to fix this:
- Remove tooltips from the flow of the page so that they can be placed in a stacking group with higher priority (e.g. use portal again)
- Give headers descending z indices so that the tooltips won't show below sequential headers
I opted for the second choice given we've determined we don't want to ơ̴̬̩̈́̆̿̓p̸̘̙̎̑͌ȩ̸̛̳̉̊͆ṅ̶̢̪̻̼̰̊̀͘͝ ̷͚̐̐̆̅͝t̸̗̪̥̘̹͑̈́h̷̛͙̭̐e̴̻͖̓̎̈́̓͝ ̶͕̕ṕ̸͚̍͗o̷̡̰͂͌̈́ŕ̶̛͕̞̭̿̂̾t̵̨̛͉̬͔̀a̸̬̖͓̩̦̾́ḽ̶́͊̇ ̶͖͔̬̩̄̄͛̈͒a̸̘͖̝̋̊̄̈́͒g̸̗̭̣̉á̵͈̼̖͖̙̿̒̾͒ȉ̸̢͚̽͐n̷͍̅͛̍́̃. Note that if there was a case where tooltips could be positioned over previous section headers the problem would still happen in that case, but I don't think this is possible. As such I think this is an adequate fix for the issue.

## How to test
Hover tooltips and notice the lack of arrow as well as tooltips now showing correctly over professor name headers

## Screenshots
|Before|After|
|--|--|
| ![image](https://user-images.githubusercontent.com/28655462/119557766-377a2e00-bd66-11eb-9b3d-7119c4505c6b.png) | ![image](https://user-images.githubusercontent.com/28655462/119557667-1580ab80-bd66-11eb-9244-3b937f655017.png) |
## Related tasks

Closes #571 and #572.