### PR TITLE
Change calendar width

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/GradeDist/GradeDist.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/GradeDist/GradeDist.css
@@ -2,8 +2,7 @@
     display: flex;
     align-items: center;
     flex-grow: 1;
-
-    max-width: 10rem;
+    max-width: 20rem;
 }
 
 .grades-dist {

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionInfo.tsx
@@ -65,7 +65,7 @@ const SectionInfo: React.FC<SectionInfoProps> = ({
       {showSectionNum ? sectionHeader : null}
       <Typography className={`${styles.denseListItem} ${styles.meetingInfoWrapper}`} color="textSecondary" component="div">
         <div><MeetingTypeDisplay meeting={mtg} /></div>
-        <div>{meetingBuilding(mtg)}</div>
+        <div className={styles.meetingBuilding}>{meetingBuilding(mtg)}</div>
         <div className={styles.meetingDays}>{formatMeetingDays(mtg)}</div>
         <div className={styles.meetingTime}>{getMeetingTimeText(mtg)}</div>
       </Typography>

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
@@ -124,11 +124,7 @@
     white-space: nowrap; /* ensures that meeting times don't wrap */
 }
 
-.meeting-time {
-    text-align: center;
-}
-
-.meeting-days {
+.meeting-time, .meeting-days, .meeting-building {
     text-align: center;
 }
 

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
@@ -38,6 +38,7 @@
     display: flex;
     align-items: center;
     min-height: 20px;
+    margin-right: 8px;
 }
 
 .prof-name-btn:global(.MuiButton-root) {

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
@@ -107,18 +107,6 @@
     display: contents;
 }
 
-@media (max-width: 1600px) {
-    .section-details-table {
-        grid-template-columns: 1fr 1fr;
-    }
-    .meeting-info-wrapper > div:nth-child(2) {
-        text-align: right; /* applies to building in 2-column view */
-    }
-    .meeting-info-wrapper > div:nth-child(3) {
-        text-align: left; /* applies to days in 2-column view */
-    }
-}
-
 .meeting-info-wrapper:nth-child(2n) div {
     background: #50000020;
 }

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css.d.ts
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css.d.ts
@@ -16,10 +16,12 @@ declare namespace SectionSelectCssNamespace {
     "list-subheader-dense": string;
     listSubheaderContent: string;
     listSubheaderDense: string;
+    "meeting-building": string;
     "meeting-days": string;
     "meeting-info-wrapper": string;
     "meeting-time": string;
     "meeting-type": string;
+    meetingBuilding: string;
     meetingDays: string;
     meetingInfoWrapper: string;
     meetingTime: string;

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulingPage.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulingPage.css
@@ -27,6 +27,16 @@
     margin-bottom: 16px;
 }
 
+@media screen and (min-width: 1024px) {
+    .middle-column {    
+        max-width: 500px;
+    }
+    /* TODO fix after rebasing with mobile-improvements*/
+    .schedule-container {
+        max-width: 750px;
+    }
+}
+
 .course-card-column-container {
     margin: 4px;
     padding: 4px;

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulingPage.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulingPage.css
@@ -25,6 +25,7 @@
     margin-top: 8px;
     margin-left: 8px;
     margin-bottom: 16px;
+    max-width: 550px;
 }
 
 .course-card-column-container {

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulingPage.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulingPage.css
@@ -12,7 +12,7 @@
 }
 
 .schedule-container {
-    flex-grow: 1;
+    flex-grow: 2;
     flex-basis: 0;
 }
 
@@ -27,19 +27,10 @@
     margin-bottom: 16px;
 }
 
-@media screen and (min-width: 1024px) {
-    .middle-column {    
-        max-width: 500px;
-    }
-    /* TODO fix after rebasing with mobile-improvements*/
-    .schedule-container {
-        max-width: 750px;
-    }
-}
-
 .course-card-column-container {
     margin: 4px;
     padding: 4px;
+    min-width: 400px;
     flex-basis: 0;
     flex-grow: 1;
 }

--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulingPage.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulingPage.tsx
@@ -37,14 +37,12 @@ const SchedulingPage: React.FC<SchedulingPageProps> = ({
 
   return (
     <div className={styles.pageContainer}>
-      <div className={styles.leftContainer}>
-        <div className={styles.courseCardColumnContainer}>
-          <CourseSelectColumn />
-        </div>
-        <div className={styles.middleColumn}>
-          <GenerateSchedulesButton />
-          <SchedulePreview hideLoadingIndicator={hideSchedulesLoadingIndicator} />
-        </div>
+      <div className={styles.courseCardColumnContainer}>
+        <CourseSelectColumn />
+      </div>
+      <div className={styles.middleColumn}>
+        <GenerateSchedulesButton />
+        <SchedulePreview hideLoadingIndicator={hideSchedulesLoadingIndicator} />
       </div>
       <div className={styles.scheduleContainer}>
         <Schedule />


### PR DESCRIPTION
## Description

Changes how space is distributed between the 3 columns on the SchedulingPage. Course cards will now always render on one line, with no wrapping. This is achieved by setting `min-width: 400px`. The remaining space is split in a 1:1:2 ratio between course column, the middle column, and the schedule, respectively. However, the middle column has a maximum width of 550px, after which point the remaining space is split between the course card column and the schedule in a 1:2 ratio. Neither the first nor the last column has a maximum width.

This PR also increases the `max-width` of grade distributions from `10rem` to `20rem`. 8px of margin have also been added between the instructor name and grade container in order to make this look good on small screens.

## Rationale

Earlier, we had discussed possibly setting a maximum width for course cards to prevent them from getting too stretched out. However, the cards look reasonable to me on all screen sizes (720p, 1080p, 1440p, and 4k)

## How to test

Describe the best way to test the specific changes you made. If it's covering a special case,
make sure to include the situations they should check out (i.e. PHYS 207 - 501, term 202031)

## Screenshots

### 720p:
![image](https://user-images.githubusercontent.com/10082177/119746248-a2566280-be55-11eb-8f0b-8bbc65c24db7.png)

### 1080p:
![127 0 0 1_8000_schedule (4)](https://user-images.githubusercontent.com/10082177/119746218-8fdc2900-be55-11eb-850b-25606367159c.png)

### 1440p:
![127 0 0 1_8000_schedule (3)](https://user-images.githubusercontent.com/10082177/119746168-6de2a680-be55-11eb-9dd5-8237110c6dae.png)

### 4k:
![127 0 0 1_8000_schedule (2)](https://user-images.githubusercontent.com/10082177/119746125-51466e80-be55-11eb-9cff-a30ca3a3d825.png)

## Related tasks

Closes #568 
Closes #570 
