### PR TITLE
Fix scrape courses --year parameter, check terms have data before saving

### DIFF
--- a/autoscheduler/scraper/management/commands/scrape_courses.py
+++ b/autoscheduler/scraper/management/commands/scrape_courses.py
@@ -325,7 +325,7 @@ def save_models(instructors: List[Instructor], sections: List[Section], # pylint
 
     print(f"Saved all in {elapsed_time:.2f} seconds")
 
-def save_terms(terms, options):
+def save_terms(terms, courses, options):
     """ Creates terms objects to save """
 
     start = time.time()
@@ -340,10 +340,7 @@ def save_terms(terms, options):
             queryset = Term.objects.all()
 
         # Only save terms that actually have courses so that users don't see empty terms
-        terms_with_courses = set(
-            course['term'] for course in
-            Course.objects.distinct('term').filter(term__in=terms).values('term')
-        )
+        terms_with_courses = set(course.term for course in courses)
         terms_to_save = [
             Term(code=term, last_updated=now) for term in terms
             if term in terms_with_courses
@@ -390,6 +387,6 @@ class Command(base.BaseCommand):
 
         instructors, sections, meetings, courses = get_course_data(depts_terms)
         save_models(instructors, sections, meetings, courses, terms, options)
-        save_terms(terms, options)
+        save_terms(terms, courses, options)
 
         print(f"Finished scraping in {time.time() - start_all:.2f} seconds")

--- a/autoscheduler/scraper/management/commands/scrape_courses.py
+++ b/autoscheduler/scraper/management/commands/scrape_courses.py
@@ -383,7 +383,7 @@ class Command(base.BaseCommand):
         if options['term']:
             terms = [options['term']]
         elif options['year']:
-            terms = get_all_terms(options['year'])
+            terms = get_all_terms(year=options['year'])
         elif options['recent']:
             terms = get_recent_terms()
         else:

--- a/autoscheduler/scraper/management/commands/scrape_courses.py
+++ b/autoscheduler/scraper/management/commands/scrape_courses.py
@@ -353,7 +353,7 @@ def save_terms(terms, options):
         queryset.delete()
         Term.objects.bulk_create(terms_to_save)
 
-        term_len = len(terms) if terms else 1
+        term_len = len(terms_to_save) if terms else 1
 
         print(f"Saved {term_len} term(s) in {(time.time()-start):.2f} seconds")
 

--- a/autoscheduler/scraper/management/commands/scrape_courses.py
+++ b/autoscheduler/scraper/management/commands/scrape_courses.py
@@ -1,4 +1,3 @@
-import sys
 import asyncio
 from html import unescape
 import time
@@ -351,12 +350,19 @@ class Command(base.BaseCommand):
     """ Gets course information from banner and adds it to the database """
 
     def add_arguments(self, parser):
-        parser.add_argument('--term', '-t', type=str,
-                            help="A valid term code, such as 201931")
-        parser.add_argument('--year', '-y', type=int,
-                            help="A year to scrape all courses for, such as 2019")
-        parser.add_argument('--recent', '-r', action='store_true',
-                            help="Scrapes the most recent semester(s) for all locations")
+        time_args = parser.add_mutually_exclusive_group()
+        time_args.add_argument(
+            '--term', '-t', type=str,
+            help="A valid term code, such as 201931"
+        )
+        time_args.add_argument(
+            '--year', '-y', type=int,
+            help="A year to scrape all courses for, such as 2019"
+        )
+        time_args.add_argument(
+            '--recent', '-r', action='store_true',
+            help="Scrapes the most recent semester(s) for all locations"
+        )
 
     def handle(self, *args, **options):
         depts_terms = []
@@ -364,22 +370,13 @@ class Command(base.BaseCommand):
         terms = None
 
         if options['term']:
-            if options['year'] or options['recent']:
-                print("ERROR: Too many arguments!")
-                sys.exit(1)
-
             terms = [options['term']]
-
+        elif options['year']:
+            terms = get_all_terms(options['year'])
+        elif options['recent']:
+            terms = get_recent_terms()
         else:
-            if options['year'] and options['recent']:
-                print("ERROR: Too many arguments!")
-                sys.exit(1)
-
             terms = get_all_terms()
-            if options['year']:
-                terms = get_all_terms(options['year'])
-            elif options['recent']:
-                terms = get_recent_terms()
 
         depts_terms = get_department_names(terms)
 

--- a/autoscheduler/scraper/management/commands/scrape_courses.py
+++ b/autoscheduler/scraper/management/commands/scrape_courses.py
@@ -348,7 +348,6 @@ def save_terms(terms, options):
             Term(code=term, last_updated=now) for term in terms
             if term in terms_with_courses
         ]
-        print(terms_to_save)
 
         queryset.delete()
         Term.objects.bulk_create(terms_to_save)

--- a/autoscheduler/scraper/management/commands/scrape_courses.py
+++ b/autoscheduler/scraper/management/commands/scrape_courses.py
@@ -352,9 +352,7 @@ def save_terms(terms, options):
         queryset.delete()
         Term.objects.bulk_create(terms_to_save)
 
-        term_len = len(terms_to_save) if terms else 1
-
-        print(f"Saved {term_len} term(s) in {(time.time()-start):.2f} seconds")
+        print(f"Saved {len(terms_to_save)} term(s) in {(time.time()-start):.2f} seconds")
 
 class Command(base.BaseCommand):
     """ Gets course information from banner and adds it to the database """

--- a/autoscheduler/scraper/management/commands/utils/scraper_utils.py
+++ b/autoscheduler/scraper/management/commands/utils/scraper_utils.py
@@ -10,13 +10,16 @@ def get_all_terms(year: int = -1, now=datetime.now()) -> List[str]:
     """
 
     current_year = now.year
-    years = range(2013, current_year)
 
     # If the year was given, only scrape for that year
     # If it's the same year as the current year, then wait till the end so we can only
     # scrape the "recent terms"
-    if year != -1 and year != current_year: # pylint: disable=consider-using-in
+    if year == -1:
+        years = range(2013, current_year)
+    elif year < current_year:
         years = [year]
+    else:
+        years = []
 
     semesters = range(1, 4)
     locations = range(1, 4)
@@ -32,7 +35,7 @@ def get_all_terms(year: int = -1, now=datetime.now()) -> List[str]:
     spring_reg_start = datetime.strptime(f'10/26/{current_year}', date_format)
 
     # Required so that we don't scrape any extra terms
-    if year == -1 or year == current_year: # pylint: disable=consider-using-in
+    if year in [-1, current_year]:
         semesters = []
 
         if now < summer_fall_reg_start:

--- a/autoscheduler/scraper/management/commands/utils/scraper_utils.py
+++ b/autoscheduler/scraper/management/commands/utils/scraper_utils.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import List
 from itertools import product
 
-def get_all_terms(year: int = None, now=datetime.now()) -> List[str]:
+def get_all_terms(*_, year: int = None, now=datetime.now()) -> List[str]:
     """ Generates all of the terms, from 2013 until now
 
         If a specific year is given, then this will scrape all semesters/locations

--- a/autoscheduler/scraper/management/commands/utils/scraper_utils.py
+++ b/autoscheduler/scraper/management/commands/utils/scraper_utils.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import List
 from itertools import product
 
-def get_all_terms(year: int = -1, now=datetime.now()) -> List[str]:
+def get_all_terms(year: int = None, now=datetime.now()) -> List[str]:
     """ Generates all of the terms, from 2013 until now
 
         If a specific year is given, then this will scrape all semesters/locations
@@ -11,45 +11,13 @@ def get_all_terms(year: int = -1, now=datetime.now()) -> List[str]:
 
     current_year = now.year
 
-    # If the year was given, only scrape for that year
-    # If it's the same year as the current year, then wait till the end so we can only
-    # scrape the "recent terms"
-    if year == -1:
-        years = range(2013, current_year)
-    elif year < current_year:
-        years = [year]
-    else:
-        years = []
+    years = [year] if year else range(2013, current_year + 1)
 
     semesters = range(1, 4)
     locations = range(1, 4)
 
-    ret = [f"{year}{semester}{location}"
-           for year, semester, location in product(years, semesters, locations)]
-
-    # The above gets us past terms in bulk
-    # Now we need to decide what of the recent terms we're going to include in this
-
-    date_format = '%m/%d/%Y'
-    summer_fall_reg_start = datetime.strptime(f'03/22/{current_year}', date_format)
-    spring_reg_start = datetime.strptime(f'10/26/{current_year}', date_format)
-
-    # Required so that we don't scrape any extra terms
-    if year in [-1, current_year]:
-        semesters = []
-
-        if now < summer_fall_reg_start:
-            semesters.append(f"{current_year}1")
-        elif summer_fall_reg_start <= now < spring_reg_start:
-            semesters.extend([f"{current_year}1", f"{current_year}2", f"{current_year}3"])
-        else:
-            semesters.extend([f"{current_year}1", f"{current_year}2", f"{current_year}3",
-                              f"{current_year + 1}1"])
-
-        ret.extend([f"{year_semester}{location}"
-                    for year_semester, location in product(semesters, locations)])
-
-    return set(ret)
+    return set(f"{year}{semester}{location}"
+               for year, semester, location in product(years, semesters, locations))
 
 def get_recent_semesters(now=datetime.now()) -> List[str]:
     """ Calculates and returns which semester(s) we should be scraping for.

--- a/autoscheduler/scraper/tests/commands/scrape_courses_tests.py
+++ b/autoscheduler/scraper/tests/commands/scrape_courses_tests.py
@@ -427,17 +427,18 @@ class ScrapeCoursesTests(django.test.TestCase):
         # Arrange
         terms = ['202131', '202132']
         term_with_course = terms[0]
-        Course(
+        courses = [Course(
             dept='WUMB',
             course_num='101',
             title='Wumbology',
             credit_hours=3,
             term=term_with_course,
-        ).save()
+        )]
+        Course.objects.bulk_create(courses)
         options = defaultdict(lambda: None)
 
         # Act
-        save_terms(terms, options)
+        save_terms(terms, courses, options)
 
         # Assert
         self.assertEqual(len(Term.objects.all()), 1)

--- a/autoscheduler/scraper/tests/commands/scraper_utils_tests.py
+++ b/autoscheduler/scraper/tests/commands/scraper_utils_tests.py
@@ -55,35 +55,29 @@ class GetRecentTermsTests(unittest.TestCase):
 
 class GetAllTermsTests(unittest.TestCase):
     """ Tests for get_all_terms """
-    def test_feb_is_only_3_terms(self):
-        """ Tests that when its 2/1/2013, we only get the spring 2013 terms """
-        # Arrange
-        expected = set(['201311', '201312', '201313'])
-        now = datetime(2013, 2, 1)
-        # Act
-        result = get_all_terms(now=now)
-        # Assert
-        self.assertEqual(expected, result)
-
-    def test_may_is_all_terms(self):
-        """ Tests that when it's 5/1/2013, we get all terms for 2013 """
-        # Arrange
-        expected = set(['201311', '201312', '201313', '201321', '201322', '201323',
-                        '201331', '201332', '201333'])
-        now = datetime(2013, 5, 1)
-        # Act
-        result = get_all_terms(now=now)
-        # Assert
-        self.assertEqual(expected, result)
-
-    def test_dec_is_this_year_and_next(self):
-        """ Tests that when it's 12/1/2013, we get all terms for 2013 + first semester
-            for 2014
+    def test_get_all_2013(self):
+        """ Tests that when it's 2013 and no year is provided,
+            all terms in 2013 are returned
         """
         # Arrange
         expected = set(['201311', '201312', '201313', '201321', '201322', '201323',
-                        '201331', '201332', '201333', '201411', '201412', '201413'])
-        now = datetime(2013, 12, 1)
+                        '201331', '201332', '201333'])
+        now = datetime(2013, 1, 1)
+        # Act
+        result = get_all_terms(now=now)
+        # Assert
+        self.assertEqual(expected, result)
+
+    def test_get_all_2014(self):
+        """ Tests that when it's 2014 and no year is provided,
+            all terms in 2013 and 2014 are returned
+        """
+        # Arrange
+        expected = set(['201311', '201312', '201313', '201321', '201322', '201323',
+                        '201331', '201332', '201333',
+                        '201411', '201412', '201413', '201421', '201422', '201423',
+                        '201431', '201432', '201433'])
+        now = datetime(2014, 1, 1)
         # Act
         result = get_all_terms(now=now)
         # Assert
@@ -103,12 +97,13 @@ class GetAllTermsTests(unittest.TestCase):
         # Assert
         self.assertEqual(expected, result)
 
-    def test_year_param_gets_only_recent_terms_for_current_year(self):
-        """ For the year parameter, if it's 1/1/2015 and we pass in 2015, we should only
-            get the first semesters worth of terms in 2015
+    def test_year_param_gets_all_of_current_year(self):
+        """ For the year parameter, if it's 1/1/2015 and we pass in 2015,
+            all terms for 2015 should be returned
         """
         # Arrange
-        expected = set(['201511', '201512', '201513'])
+        expected = set(['201511', '201512', '201513', '201521', '201522', '201523',
+                        '201531', '201532', '201533'])
         year = 2015
         now = datetime(year, 1, 1)
         # Act

--- a/autoscheduler/scraper/tests/commands/scraper_utils_tests.py
+++ b/autoscheduler/scraper/tests/commands/scraper_utils_tests.py
@@ -104,14 +104,15 @@ class GetAllTermsTests(unittest.TestCase):
         self.assertEqual(expected, result)
 
     def test_year_param_gets_only_recent_terms_for_current_year(self):
-        """ For the year parameter, if it's 1/1/2013 and we pass in 2013, we should only
-            get the first semesters worth of terms in 2013
+        """ For the year parameter, if it's 1/1/2015 and we pass in 2015, we should only
+            get the first semesters worth of terms in 2015
         """
         # Arrange
-        expected = set(['201311', '201312', '201313'])
-        year = 2013
-        now = datetime(2013, 1, 1)
+        expected = set(['201511', '201512', '201513'])
+        year = 2015
+        now = datetime(year, 1, 1)
         # Act
         result = get_all_terms(year, now)
         # Assert
+        print(result, expected)
         self.assertEqual(result, expected)

--- a/autoscheduler/scraper/tests/commands/scraper_utils_tests.py
+++ b/autoscheduler/scraper/tests/commands/scraper_utils_tests.py
@@ -45,13 +45,41 @@ class GetRecentTermsTests(unittest.TestCase):
         These are really only testing the product functionality of
         get_recent_terms, and really aren't that important.
     """
-    def test_does_product_location_and_semesters_correctly(self):
-        """ Tests that it does all of the correct locations for summer/fall 2020 """
+    def test_feb_gives_spring_terms(self):
+        """ Tests that when its 2/1/2013, we only get the spring 2013 terms """
+        # Arrange
+        expected = ['201311', '201312', '201313']
+        now = datetime(2013, 2, 1)
+
+        # Act
+        result = get_recent_terms(now=now)
+
+        # Assert
+        self.assertEqual(expected, result)
+
+    def test_april_gives_summer_and_fall_terms(self):
+        """ Tests that 2020/4/1 gives all of the terms for summer/fall 2020 """
+        # Arrange
+        expected = ['202021', '202022', '202023', '202031', '202032', '202033']
         date = datetime(2020, 4, 1)
+
+        # Act
         result = get_recent_terms(date)
 
-        self.assertEqual(result, ['202021', '202022', '202023',
-                                  '202031', '202032', '202033'])
+        # Assert
+        self.assertEqual(result, expected)
+
+    def test_november_gives_spring_terms_for_next_year(self):
+        """ Tests that when it's 11/1/2013, we get spring terms for 2014 """
+        # Arrange
+        expected = ['201411', '201412', '201413']
+        now = datetime(2013, 11, 1)
+
+        # Act
+        result = get_recent_terms(now=now)
+
+        # Assert
+        self.assertEqual(expected, result)
 
 class GetAllTermsTests(unittest.TestCase):
     """ Tests for get_all_terms """

--- a/autoscheduler/scraper/tests/commands/scraper_utils_tests.py
+++ b/autoscheduler/scraper/tests/commands/scraper_utils_tests.py
@@ -137,5 +137,4 @@ class GetAllTermsTests(unittest.TestCase):
         # Act
         result = get_all_terms(year=year, now=now)
         # Assert
-        print(result, expected)
         self.assertEqual(result, expected)

--- a/autoscheduler/scraper/tests/commands/scraper_utils_tests.py
+++ b/autoscheduler/scraper/tests/commands/scraper_utils_tests.py
@@ -61,7 +61,7 @@ class GetAllTermsTests(unittest.TestCase):
         expected = set(['201311', '201312', '201313'])
         now = datetime(2013, 2, 1)
         # Act
-        result = get_all_terms(-1, now)
+        result = get_all_terms(now=now)
         # Assert
         self.assertEqual(expected, result)
 
@@ -72,7 +72,7 @@ class GetAllTermsTests(unittest.TestCase):
                         '201331', '201332', '201333'])
         now = datetime(2013, 5, 1)
         # Act
-        result = get_all_terms(-1, now)
+        result = get_all_terms(now=now)
         # Assert
         self.assertEqual(expected, result)
 
@@ -85,7 +85,7 @@ class GetAllTermsTests(unittest.TestCase):
                         '201331', '201332', '201333', '201411', '201412', '201413'])
         now = datetime(2013, 12, 1)
         # Act
-        result = get_all_terms(-1, now)
+        result = get_all_terms(now=now)
         # Assert
         self.assertEqual(expected, result)
 
@@ -99,7 +99,7 @@ class GetAllTermsTests(unittest.TestCase):
         year = 2014
         now = datetime(2015, 1, 1)
         # Act
-        result = get_all_terms(year, now)
+        result = get_all_terms(year=year, now=now)
         # Assert
         self.assertEqual(expected, result)
 
@@ -112,7 +112,7 @@ class GetAllTermsTests(unittest.TestCase):
         year = 2015
         now = datetime(year, 1, 1)
         # Act
-        result = get_all_terms(year, now)
+        result = get_all_terms(year=year, now=now)
         # Assert
         print(result, expected)
         self.assertEqual(result, expected)


### PR DESCRIPTION
## Description
The initial plan was for this PR to just fix the `--year` parameter for `scrape_courses`, but trying to do so I noticed that terms were being saved that didn't have any courses. This made me realize we could simplify the logic by ignoring these extra terms instead of the band-aid fix of manually checking the terms to fix (which could break if TAMU hasn't posted classes for a term when we scrape, leading to a term that shows up but has no courses).

## Rationale
This could really be a 2-line PR if we just wanted to restore the previous behavior, but I think the simplification of our codebase and more robust term checking is worth the extra effort.

## How to test
Try scraping the current year as well as next year, and notice that only terms with data are being saved. I added tests for terms without courses being saved and moved existing get_all_terms tests to get_recent_terms tests with its expected behavior, since that function didn't have as many tests made for it.

## Related tasks
Closes #547.
