### PR TITLE
Fixed bug with infinitely growing cards

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/CourseSelectCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/CourseSelectCard.tsx
@@ -82,6 +82,7 @@ const CourseSelectCard: React.FC<CourseSelectCardProps> = ({
         <Switch
           aria-label="Disable"
           checked={!disabled}
+          inputProps={{ 'aria-checked': !disabled }}
           onClick={(evt): void => {
             dispatch(updateCourseCard(id, { disabled: !disabled }));
             evt.stopPropagation();

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
@@ -9,6 +9,7 @@
 
 .section-rows {
     overflow: auto;
+    padding-bottom: 2px !important;
 }
 
 .my-icon-button {

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionSelect.css
@@ -9,7 +9,7 @@
 
 .section-rows {
     overflow: auto;
-    padding-bottom: 2px !important;
+    margin-bottom: 2px !important;
 }
 
 .my-icon-button {

--- a/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/CourseSelectColumn/CourseSelectColumn.tsx
@@ -96,8 +96,7 @@ const CourseSelectColumn: React.FC = () => {
             }
             const availableHeight = Math.max(MIN_CARD_HEIGHT, col.clientHeight - otherKidsHeight)
               - CARD_CONTENT_BASE_HEIGHT;
-              // +1 prevents unnecessary scrollbar
-            const newHeight = Math.min(availableHeight, sectionRows[0].scrollHeight + 1);
+            const newHeight = Math.min(availableHeight, sectionRows[0].scrollHeight);
             (sectionRows[0] as HTMLDivElement).style.height = `${newHeight}px`;
           }
         }

--- a/autoscheduler/frontend/src/tests/ui/SchedulingPage.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SchedulingPage.test.tsx
@@ -229,7 +229,12 @@ describe('Scheduling Page UI', () => {
 
       // mock a bit of the browser's height functionality
       jest.spyOn(sectionRows, 'scrollHeight', 'get').mockImplementation(
-        () => Number.parseInt(sectionRows.style.height, 10),
+        () => {
+          const style = window.getComputedStyle(sectionRows);
+          return Number.parseInt(sectionRows.style.height, 10)
+            + Number.parseInt(style.paddingTop, 10)
+            + Number.parseInt(style.paddingBottom, 10);
+        },
       );
 
       // Act


### PR DESCRIPTION
## Description

This bug was originally discovered in #580, read the comments there for more context.

## Rationale

I elected to address both of the issues by adding 2px of padding-bottom to `.section-rows`, since we were going to do it anway in #523 

## How to test

Bug 1 - Disable, then enable a course card repeatedly. The card should not grow. There is also a Jest test to ensure that this bug does not relapse.

Bug 2 - Open SPAN 301 in Chrome (not Firefox), and make sure your window is big enough to accommodate all sections without scrolling. If not, zoom out, then close and open the course card. There should be no scroll bar in the list of sections.

## Screenshots

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/10082177/120127690-a6e88700-c185-11eb-8d88-7ed946c7ba90.png)|![image](https://user-images.githubusercontent.com/10082177/120127468-114cf780-c185-11eb-9250-e880af09d932.png)|

## Related Tasks

Closes #588 