### PR TITLE
Term select loading indicator

### DIFF
--- a/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.css
+++ b/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.css
@@ -14,3 +14,9 @@
     width: 55% !important;
     max-width: 800px !important;
 }
+
+.loading-indicator {
+    display: flex;
+    justify-content: center;
+    min-width: 200px;
+}

--- a/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.css.d.ts
+++ b/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.css.d.ts
@@ -2,6 +2,8 @@ declare namespace SelectTermCssNamespace {
   export interface ISelectTermCss {
     "button-container": string;
     buttonContainer: string;
+    "loading-indicator": string;
+    loadingIndicator: string;
     "menu-paper": string;
     menuPaper: string;
     "select-term-button": string;

--- a/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
+++ b/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
@@ -120,7 +120,7 @@ const SelectTerm: React.FC<SelectTermProps> = ({ navBar = false }) => {
   };
 
   const menuContent = (loading && shouldDisplayLoading) ? (
-    <div className={defaultStyles.loadingIndicator}>
+    <div className={defaultStyles.loadingIndicator} data-testid="select-term-loading">
       <SmallFastProgress size="large" />
     </div>
   ) : (

--- a/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
+++ b/autoscheduler/frontend/src/components/LandingPage/SelectTerm/SelectTerm.tsx
@@ -10,6 +10,7 @@ import setTerm from '../../../redux/actions/term';
 import * as defaultStyles from './SelectTerm.css';
 import * as navBarStyles from './NavBarSelectTerm.css';
 import { RootState } from '../../../redux/reducer';
+import SmallFastProgress from '../../SmallFastProgress';
 
 interface SelectTermProps {
   navBar?: boolean;
@@ -45,6 +46,8 @@ const SelectTerm: React.FC<SelectTermProps> = ({ navBar = false }) => {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const [options, setOptions] = React.useState<string[]>([]);
   const [termMap, setTermMap] = React.useState<Map<string, string>>(new Map());
+  const [loading, setLoading] = React.useState(true);
+  const [shouldDisplayLoading, setShouldDisplayLoading] = React.useState(false);
   const open = Boolean(anchorEl);
 
   // Used for retrieving the user-friendly term phrase given the term code (e.g. "202031")
@@ -54,8 +57,14 @@ const SelectTerm: React.FC<SelectTermProps> = ({ navBar = false }) => {
   const styles = navBar ? navBarStyles : defaultStyles;
   const landingPageStyleOverrides = useLandingPageStyles();
 
-  // Fetch all terms to use as ListItem options
-  function getTerms(): void {
+
+  React.useEffect(() => {
+    // Show loading if fetch has taken over half a second
+    window.setTimeout(() => {
+      setShouldDisplayLoading(true);
+    }, 500);
+
+    // Fetch all terms to use as ListItem options
     getTermsJson().then(
       (res) => {
         const termsMap: Map<string, string> = new Map(Object.entries(res));
@@ -69,11 +78,10 @@ const SelectTerm: React.FC<SelectTermProps> = ({ navBar = false }) => {
         setTermMap(termsMap);
         setInverseTermMap(inverseTermsMap);
         setOptions(Array.from(termsMap.keys()));
+        setLoading(false);
       },
     );
-  }
-
-  React.useEffect(getTerms, []);
+  }, []);
 
   const [selectedTerm, setSelectedTerm] = React.useState(options[0]);
 
@@ -110,6 +118,22 @@ const SelectTerm: React.FC<SelectTermProps> = ({ navBar = false }) => {
       navigate('/schedule');
     });
   };
+
+  const menuContent = (loading && shouldDisplayLoading) ? (
+    <div className={defaultStyles.loadingIndicator}>
+      <SmallFastProgress size="large" />
+    </div>
+  ) : (
+    options.map((option) => (
+      <MenuItem
+        key={option}
+        selected={option === selectedTerm}
+        onClick={(): void => handleClose(option)}
+      >
+        {option}
+      </MenuItem>
+    ))
+  );
 
   return (
     <div className={styles.buttonContainer}>
@@ -149,18 +173,7 @@ const SelectTerm: React.FC<SelectTermProps> = ({ navBar = false }) => {
           className: styles.menuPaper,
         }}
       >
-        {
-            /* renders a menu item for each term */
-            options.map((option) => (
-              <MenuItem
-                key={option}
-                selected={option === selectedTerm}
-                onClick={(): void => handleClose(option)}
-              >
-                {option}
-              </MenuItem>
-            ))
-          }
+        {menuContent}
       </Menu>
     </div>
   );

--- a/autoscheduler/frontend/src/tests/ui/SelectTerm.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SelectTerm.test.tsx
@@ -148,6 +148,73 @@ describe('SelectTerm', () => {
   });
 });
 
+describe('SelectTerm loading indicator', () => {
+  afterEach(fetchMock.mockReset);
+
+  describe("doesn't display", () => {
+    test('when initially rendered', async () => {
+      // arrange
+      const store = createStore(autoSchedulerReducer);
+
+      const { getByText, queryByTestId } = render(
+        <Provider store={store}>
+          <SelectTerm />
+        </Provider>,
+      );
+
+      // act
+      const button = getByText('Select Term');
+      fireEvent.click(button);
+
+      // assert
+      expect(queryByTestId('select-term-loading')).toBeNull();
+    });
+
+    test('after terms have been fetched', async () => {
+      // arrange
+      const store = createStore(autoSchedulerReducer);
+
+      const { findByText, queryByTestId } = render(
+        <Provider store={store}>
+          <SelectTerm />
+        </Provider>,
+      );
+      mockTermsAPI();
+
+      // act
+      const button = await findByText('Select Term');
+      fireEvent.click(button);
+
+      // assert
+      expect(queryByTestId('select-term-loading')).toBeNull();
+    });
+  });
+
+  describe('displays', async () => {
+    test('after terms have been loading for one second', async () => {
+      // arrange
+      const store = createStore(autoSchedulerReducer);
+
+      const { findByText, queryByTestId } = render(
+        <Provider store={store}>
+          <SelectTerm />
+        </Provider>,
+      );
+      mockTermsAPI();
+
+      // act
+      const button = await findByText('Select Term');
+      fireEvent.click(button);
+
+      // assert
+      setTimeout(() => {
+        expect(queryByTestId('select-term-loading')).toBeTruthy();
+      }, 1000);
+      jest.runAllTimers();
+    });
+  });
+});
+
 describe('SelectTerm navBar', () => {
   afterEach(fetchMock.mockReset);
 


### PR DESCRIPTION
## Description
Adds a loading indicator to `<SelectTerm />` that shows up after loading for half a second

## Rationale
We said in the meeting last week that it would make the website seem unresponsive if the loading indicator showed up immediately, so I added a 500ms delay before starting to display the loading indicator: before that, the component displays as it did before.

## How to test
Make the following change to make fetching terms take long enough to see the loading indicator locally:
![image](https://user-images.githubusercontent.com/28655462/120898600-28f70680-c5f1-11eb-9b9c-badb1aa7ef6e.png)


## Screenshots
![loading](https://user-images.githubusercontent.com/28655462/120898610-31e7d800-c5f1-11eb-8951-5d5b623bcb0d.gif)

## Related tasks
Closes #375.