### PR TITLE
Fix meeting card flash

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/MeetingCard/MeetingCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/MeetingCard/MeetingCard.tsx
@@ -62,9 +62,13 @@ const MeetingCard: React.FC<MeetingCardProps> = ({
               {`${MeetingType[meetingType]}`}
             </Typography>
           )}
-        <Typography variant="subtitle2" style={{ display: isBig ? 'block' : 'none' }}>
-          {MeetingType[meetingType]}
-        </Typography>
+        {isBig
+          ? (
+            <Typography variant="subtitle2" style={{ display: isBig ? 'block' : 'none' }}>
+              {MeetingType[meetingType]}
+            </Typography>
+          )
+          : null}
       </Typography>
     </ScheduleCard>
   );

--- a/autoscheduler/frontend/src/components/SchedulingPage/Schedule/MeetingCard/MeetingCard.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/Schedule/MeetingCard/MeetingCard.tsx
@@ -24,10 +24,19 @@ const MeetingCard: React.FC<MeetingCardProps> = ({
   } = meeting;
   const [isBig, setIsBig] = React.useState(true);
 
+  // Only render text after first component render to prevent text from flashing due to resizing
+  const text = React.useRef<HTMLElement>();
+  const [shouldRenderText, setShouldRenderText] = React.useState(false);
+  React.useEffect(() => {
+    setShouldRenderText(Boolean(text.current));
+  }, [text]);
+
   // hide meeting type if the card is small
   const handleResize = React.useCallback((newVal: boolean): void => {
     setIsBig(newVal);
   }, []);
+
+  const textStyle: React.CSSProperties = shouldRenderText ? {} : { visibility: 'hidden' };
 
   return (
     <ScheduleCard
@@ -43,7 +52,7 @@ const MeetingCard: React.FC<MeetingCardProps> = ({
       backgroundColor={bgColor}
       borderColor={bgColor}
     >
-      <Typography variant="body2" data-testid="meeting-card-primary-content" className={styles.meetingCardText}>
+      <Typography style={textStyle} variant="body2" data-testid="meeting-card-primary-content" className={styles.meetingCardText} ref={text}>
         {`${section.subject} ${section.courseNum}`}
         {isBig
           ? `-${section.sectionNum}`
@@ -53,9 +62,9 @@ const MeetingCard: React.FC<MeetingCardProps> = ({
               {`${MeetingType[meetingType]}`}
             </Typography>
           )}
-      </Typography>
-      <Typography variant="subtitle2" style={{ display: isBig ? 'block' : 'none' }}>
-        {MeetingType[meetingType]}
+        <Typography variant="subtitle2" style={{ display: isBig ? 'block' : 'none' }}>
+          {MeetingType[meetingType]}
+        </Typography>
       </Typography>
     </ScheduleCard>
   );

--- a/autoscheduler/frontend/src/tests/ui/SchedulingPage.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SchedulingPage.test.tsx
@@ -157,8 +157,9 @@ describe('Scheduling Page UI', () => {
       // Schedule 2 has section 200 (LAB) instead
       // we check Tuesday to avoid selecting the equivalent text in SchedulePreview
       const selectedCSCE = await findByContainerText(calendarDay, /CSCE 121.*/);
-      await expect(findByContainerText(selectedCSCE, 'LEC')).rejects;
+      await expect(findByContainerText(selectedCSCE, 'LEC')).rejects.toThrow();
       expect(await findByContainerText(selectedCSCE, 'LAB')).toBeTruthy();
+      await new Promise(setImmediate);
     });
   });
 

--- a/autoscheduler/frontend/src/tests/ui/SchedulingPage.test.tsx
+++ b/autoscheduler/frontend/src/tests/ui/SchedulingPage.test.tsx
@@ -8,7 +8,7 @@ import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 import {
-  render, fireEvent, waitFor, queryByText as queryContainerByText,
+  render, fireEvent, waitFor, findByText as findByContainerText,
 } from '@testing-library/react';
 import * as router from '@reach/router';
 import autoSchedulerReducer from '../../redux/reducer';
@@ -156,9 +156,9 @@ describe('Scheduling Page UI', () => {
       // Schedule 1 has section 501 (LEC) in it
       // Schedule 2 has section 200 (LAB) instead
       // we check Tuesday to avoid selecting the equivalent text in SchedulePreview
-      const selectedCSCE = queryContainerByText(calendarDay, /CSCE 121.*/);
-      expect(queryContainerByText(selectedCSCE, 'LEC')).toBeFalsy();
-      expect(queryContainerByText(selectedCSCE, 'LAB')).toBeTruthy();
+      const selectedCSCE = await findByContainerText(calendarDay, /CSCE 121.*/);
+      await expect(findByContainerText(selectedCSCE, 'LEC')).rejects;
+      expect(await findByContainerText(selectedCSCE, 'LAB')).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
## Description
Fixes the bug described in #589.

## Rationale
Contrary to the issue description, this behavior has always existed as far as I can tell from checking out old commits so I couldn't just see when the behavior regressed and restore the old code. Due to needing the actual height of the meeting card component, it needs to render *something* before determining whether it has enough space, text will not be rendered until the card has rendered for the first time.

## How to test
Open side-by-side with deployment and compare how one-line meeting cards look.

## Screenshots
| Deployment | This PR |
|-|-|
|![dep](https://user-images.githubusercontent.com/28655462/122827653-3deabf80-d2aa-11eb-8547-523643c87670.gif) | ![me](https://user-images.githubusercontent.com/28655462/122827322-d16fc080-d2a9-11eb-91f6-d7240a754f60.gif) |
 

## Related tasks
Closes #589.
