### PR TITLE
Add automatic shifting of scrape courses schedule

### DIFF
--- a/gcp/cloud-function-update-scheduler.js
+++ b/gcp/cloud-function-update-scheduler.js
@@ -1,0 +1,38 @@
+const scheduler = require('@google-cloud/scheduler');
+
+// This function lives in Google Cloud Functions in two forms: One that uses everyDay and
+// another that uses every15, depending on what schedule we want to be set.
+// E.g., if it's at the start of pre-registration we'll call the every15 version, then
+// at the end of pre-registration we'll call the everyDay one.
+
+/**
+ * Triggered from a message on a Cloud Pub/Sub topic.
+ *
+ * @param {!Object} event Event payload.
+ * @param {!Object} context Metadata for the event.
+ */
+exports.updateScheduler24HrPubSub = async (event, context) => {
+  const every15 = '*/15 * * * *'; // Every 15 min
+  const everyDay = '0 12 * * *'; // once a day every day at noon
+  
+  // Create a client.
+  const client = new scheduler.CloudSchedulerClient();
+
+  // Construct the fully qualified location path.
+  const job = client.jobPath("revregistration1", "us-central1", "scrape-courses-start-instances");
+
+  // Construct the request body.
+  const request = {
+    job: {
+      name: job,
+      schedule: everyDay,
+    },
+    updateMask: {
+      paths: ['schedule'],
+    },
+  };
+
+  // Use the client to send the job update request.
+  const [response] = await client.updateJob(request);
+  console.log(`Updated job: ${response.name}`);
+};


### PR DESCRIPTION
## Description

Adds the shifting of scrape schedules between once a day to once every 15 minutes, using cloud scheduler.

No need to focus on the code exactly (and note that putting this in the repo is more for future reference, as it's currently stored in a cloud function).

## How to test

Go on console.cloud.google.com -> Cloud Scheduler and press "Run now" and ensure it updates the `scrape-courses-start-instance` frequency between once a day to once every 15 minutes.

Also ensure that the dates that are mentioned in the description reflect the frequencies.

## Screenshots

![chrome_rhxsQXtG97](https://user-images.githubusercontent.com/7295783/136128293-343e86ed-1090-444e-acfb-2f0a83274b80.png)

![chrome_IHP7Ch2thC](https://user-images.githubusercontent.com/7295783/136128662-08bc8146-4e14-497a-bf9f-42cbd7e51b56.png)

![chrome_LSKvuKXHld](https://user-images.githubusercontent.com/7295783/136128675-ca7f7a17-e74d-43da-b93f-7feb0eed0ae6.png)



## Related tasks

Closes #541 
