### PR TITLE
Fix mobile view from screenshot schedules changes

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulingPage.css
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulingPage.css
@@ -79,8 +79,8 @@
 
 .screenshot-schedule {
     position: absolute;
-    top: 0;
-    left: 0;
+    top: -1600px;
+    left: -1900px;
     width: 1600px;
     height: 1900px;
     visibility: hidden;


### PR DESCRIPTION
## Description

Fixes the mobile view from screenshot schedules to position the screenshottable schedule from (0, 0) to (-WIDTH, -HEIGHT), which will ensure it's never going to appear "on" the screen.

## How to test

I've tested it on my phone - you can test it by going to the debug console and changing the view to whatever and ensure it switches into the mobile view correctly

## Screenshots

|Before|After|
|--|--|
|![chrome_KgBka8O70X](https://user-images.githubusercontent.com/7295783/140848318-3ec51326-d6ad-48b1-a213-7172542ee0f3.png)|![chrome_XH3nyRzpAj](https://user-images.githubusercontent.com/7295783/140848327-8b5379d2-f18b-43d3-85b9-6d81a717fb88.png)|

## Related tasks

Closes #615
