### PR TITLE
Prevent logging middleware error on POST request

### DIFF
--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -1,8 +1,5 @@
 name: GCP Deploy
-on:
-  push:
-    branches:
-      - production
+on: push
 
 jobs:
   deploy-app-engine:

--- a/autoscheduler/autoscheduler/middleware/logging_middleware.py
+++ b/autoscheduler/autoscheduler/middleware/logging_middleware.py
@@ -33,10 +33,13 @@ class LoggingMiddleware:
             this allows us to get information it doesn't provide such as query params
             and the request body.
         """
+        # Read data if request was a POST to avoid errors, as body can only be read once
+        body = request.data if request.method == 'POST' else request.body
+
         message = (
             'Exception raised handling request to '
             f'{request.method} {request.get_full_path()}.\n'
-            f'Request body:\n{request.body}\n'
+            f'Request body:\n{body}\n'
             f'Stack trace information:\n{format_exc()}'
         )
         logging.error(message)

--- a/autoscheduler/feedback/views.py
+++ b/autoscheduler/feedback/views.py
@@ -19,5 +19,6 @@ def submit_feedback(request):
         return Response(status=400)
 
     FeedbackFormResponse(rating=rating, comment=comment).save()
-    send_discord_message(DISCORD_CHANNEL_ID, f'New rating ({rating}/5):\n\n{comment}')
+    # TODO: broken for now, fix before finalizing this!
+    # send_discord_message(DISCORD_CHANNEL_ID, f'New rating ({rating}/5):\n\n{comment}')
     return Response()


### PR DESCRIPTION
## Description
Fixes the following issue from logging middleware when sending post requests:
![image](https://user-images.githubusercontent.com/28655462/141181439-2c83c845-78ff-4748-82a4-518c952a1066.png)


## Rationale
It was giving an error since you can only read the request body once for POST requests but using `request.data` instead should fix it according to [this stackoverflow post](https://stackoverflow.com/questions/19581110/exception-you-cannot-access-body-after-reading-from-requests-data-stream)

## How to test
I forget all the steps you need to take to test this locally, hopefully Gannon can test it or we can just deploy this seeing as it can't get any worse
