### PR TITLE
Added discord webhook for feedback form

### DIFF
--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -24,7 +24,7 @@ jobs:
         run: bash fill_google_auth_credentials.sh ${{ secrets.GOOGLE_CLIENT_ID }} ${{ secrets.GOOGLE_CLIENT_SECRET }}
 
       - name: Fill .env Discord Credentials
-        run: bash fill_discord_credentials.sh ${{ secrets.DISCORD_BOT_TOKEN }} ${{ secrets.DISCORD_SCRAPE_CHANNEL_ID }} ${{ secrets.DISCORD_FEEDBACK_CHANNEL_ID }}
+        run: bash fill_discord_credentials.sh ${{ secrets.DISCORD_BOT_TOKEN }} ${{ secrets.DISCORD_SCRAPE_CHANNEL_ID }} ${{ secrets.DISCORD_FEEDBACK_WEBHOOK_URL }}
 
       - name: Initialize Google Cloud SDK
         uses: zxyle/publish-gae-action@master

--- a/autoscheduler/discord_bot.py
+++ b/autoscheduler/discord_bot.py
@@ -3,6 +3,8 @@ import os
 import time
 import discord
 from discord.client import Client
+import requests
+from discord import Webhook, RequestsWebhookAdapter
 
 DISCORD_BOT_TOKEN = os.getenv('DISCORD_BOT_TOKEN')
 
@@ -37,3 +39,7 @@ def send_discord_message(channel_id: int, message: str):
         client.run(DISCORD_BOT_TOKEN)
     finally:
         loop.close()
+
+def send_discord_message_webhook(webhook_url: str, message: str):
+    webhook = Webhook.from_url(webhook_url, adapter=RequestsWebhookAdapter())
+    webhook.send(message)

--- a/autoscheduler/feedback/views.py
+++ b/autoscheduler/feedback/views.py
@@ -3,9 +3,9 @@ from rest_framework.decorators import api_view, parser_classes
 from rest_framework.parsers import JSONParser
 from rest_framework.response import Response
 from feedback.models import FeedbackFormResponse
-from discord_bot import send_discord_message
+from discord_bot import send_discord_message_webhook
 
-DISCORD_CHANNEL_ID = int(os.getenv('DISCORD_FEEDBACK_CHANNEL_ID') or -1)
+DISCORD_FEEDBACK_WEBHOOK_URL = os.getenv('DISCORD_FEEDBACK_WEBHOOK_URL')
 
 @api_view(['POST'])
 @parser_classes([JSONParser])
@@ -19,5 +19,6 @@ def submit_feedback(request):
         return Response(status=400)
 
     FeedbackFormResponse(rating=rating, comment=comment).save()
-    send_discord_message(DISCORD_CHANNEL_ID, f'New rating ({rating}/5):\n\n{comment}')
+    send_discord_message_webhook(DISCORD_FEEDBACK_WEBHOOK_URL, f'New rating ({rating}/5):\n{comment}')
+
     return Response()

--- a/fill_discord_credentials.sh
+++ b/fill_discord_credentials.sh
@@ -1,3 +1,3 @@
 # -e enables interpretation of backslash escapes (so we can use \n for a new line)
 # Note that >> appends to a file, whereas just > will overwrite the file
-echo -e "DISCORD_BOT_TOKEN='$1'\nDISCORD_SCRAPE_CHANNEL_ID='$2'\nDISCORD_FEEDBACK_CHANNEL_ID='$3'" >> autoscheduler/autoscheduler/settings/.env
+echo -e "DISCORD_BOT_TOKEN='$1'\nDISCORD_SCRAPE_CHANNEL_ID='$2'\nDISCORD_FEEDBACK_WEBHOOK_URL='$3'" >> autoscheduler/autoscheduler/settings/.env


### PR DESCRIPTION
## Description

Adds the discord webhook for feedback form. I intentionally didn't add any error handling for this, as this shouldn't ever fail and when it does it should be loud about it.

## How to test

First, add `DISCORD_FEEDBACK_WEBHOOK_URL` to your `.env` with the link I sent in #feedback-form.

Then simply submit a feedback and ensure it works!

## Related tasks

Closes #624 
