### PR TITLE
Fix scrape_grades route

### DIFF
--- a/autoscheduler/scraper/management/commands/scrape_grades.py
+++ b/autoscheduler/scraper/management/commands/scrape_grades.py
@@ -21,7 +21,7 @@ DISCORD_CHANNEL_ID = int(os.getenv('DISCORD_SCRAPE_CHANNEL_ID') or -1)
 # due to multiprocessing
 # pylint: disable=import-outside-toplevel
 
-ROOT_URL = "http://web-as.tamu.edu/gradereport"
+ROOT_URL = "http://web-as.tamu.edu/gradereports"
 PDF_URL = ROOT_URL + "/PDFREPORTS/{}/grd{}{}.pdf"
 
 PDF_DOWNLOAD_DIR = os.path.dirname("documents/grade_dists") # Folder to save all pdf's


### PR DESCRIPTION
## Description

`scrape_grades` was failing with the error: `requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://web-as.tamu.edu/gradereport`

Seems like they updated the url from `/gradereport` to `/gradereports`. This changes it to that!

## How to test

Run scrape grades locally, but I'm confident that this is going to work so I'm just going to merge it!
