### PR TITLE
Added credit hour range for Schedule Details + bottom schedule bar

### DIFF
--- a/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleDetails/ScheduleDetails.tsx
+++ b/autoscheduler/frontend/src/components/SchedulingPage/SchedulePreview/ScheduleDetails/ScheduleDetails.tsx
@@ -19,6 +19,7 @@ import CRNDisplay from './CRNDisplay/CRNDisplay';
 import SectionAttributeIcons from '../../CourseSelectColumn/CourseSelectCard/ExpandedCourseCard/SectionSelect/SectionAttributeIcons/SectionAttributeIcons';
 import DialogWithClose from '../../../DialogWithClose/DialogWithClose';
 import hoursForSchedule from '../../../../utils/hoursForSchedule';
+import hoursForSection from '../../../../utils/hoursForSection';
 
 interface ScheduleDetailsProps {
   open: boolean;
@@ -65,8 +66,6 @@ const ScheduleDetails: React.FC<ScheduleDetailsProps> = ({
       </React.Fragment>
     ) : null;
 
-    const sectionHoursText = `${section.minCredits} hour${section.minCredits === 1 ? '' : 's'}`;
-
     const sectionInfo = (
       <Typography className={styles.sectionInfo} component="div">
         <span className={styles.sectionInfoItem}>
@@ -83,7 +82,7 @@ const ScheduleDetails: React.FC<ScheduleDetailsProps> = ({
           <CRNDisplay crn={section.crn} />
         </span>
         <span className={styles.rightAlign}>
-          {sectionHoursText}
+          {hoursForSection(section)}
         </span>
       </Typography>
     );

--- a/autoscheduler/frontend/src/tests/testSchedules.ts
+++ b/autoscheduler/frontend/src/tests/testSchedules.ts
@@ -375,9 +375,82 @@ const testMeeting13 = new Meeting({
   section: testSectionH,
 });
 
+const testSectionWith3MaxCredits = new Section({
+  minCredits: 2,
+  maxCredits: 3,
+  id: 720072,
+  crn: 720072,
+  subject: 'FILM',
+  courseNum: '251',
+  sectionNum: '527',
+  currentEnrollment: 0,
+  maxEnrollment: 24,
+  honors: false,
+  remote: false,
+  asynchronous: false,
+  mcallen: false,
+  instructor: new Instructor({ name: 'Morgan Freeman' }),
+  grades: null,
+  instructionalMethod: InstructionalMethod.NONE,
+});
+
+const testMeetingWith3MaxCredits = new Meeting({
+  id: 131313,
+  building: 'MPHY',
+  meetingDays: DAYS_MWF,
+  startTimeHours: 16,
+  startTimeMinutes: 10,
+  endTimeHours: 17,
+  endTimeMinutes: 0,
+  meetingType: MeetingType.LEC,
+  section: testSectionWith3MaxCredits,
+});
+
+const testSectionWithEqualMinAndMaxCredits = new Section({
+  minCredits: 3,
+  maxCredits: 3,
+  id: 17,
+  crn: 17,
+  subject: 'FILM',
+  courseNum: '251',
+  sectionNum: '528',
+  currentEnrollment: 0,
+  maxEnrollment: 24,
+  honors: false,
+  remote: false,
+  asynchronous: false,
+  mcallen: false,
+  instructor: new Instructor({ name: 'Morgan Freeman' }),
+  grades: null,
+  instructionalMethod: InstructionalMethod.NONE,
+});
+
+const testMeetingWithEqualMinAndMaxCredits = new Meeting({
+  id: 171717,
+  building: 'MPHY',
+  meetingDays: DAYS_MWF,
+  startTimeHours: 16,
+  startTimeMinutes: 10,
+  endTimeHours: 17,
+  endTimeMinutes: 0,
+  meetingType: MeetingType.LEC,
+  section: testSectionWithEqualMinAndMaxCredits,
+});
+
 export const testSchedule1 = [testMeeting, testMeeting2, testMeeting3, testMeeting4];
 export const testSchedule2 = [testMeeting, testMeeting2, testMeeting5, testMeeting6];
 export const testSchedule3 = [
   testMeeting, testMeeting2, testMeeting3, testMeeting7, testMeeting8,
   testMeeting9, testMeeting10, testMeeting11, testMeeting12, testMeeting13,
 ];
+
+export const testScheduleWith6MinCreditHoursAndNullMaxCredits = [testMeeting, testMeeting3];
+
+// testMeeting has 3 min credits & null max credits, testMeetingWith3MaxCredits has 2 min & 3 max
+// Meaning this will be "5 - 6" credit hours
+export const testScheduleWith5MinCreditHoursAnd1ExtraMaxCreditHours = [
+  testMeeting, testMeetingWith3MaxCredits,
+];
+
+// Has 3 hours for both min and max
+export const testScheduleWithEqualMinAndMaxCredits = [testMeetingWithEqualMinAndMaxCredits];

--- a/autoscheduler/frontend/src/tests/utilTests/hoursForSchedule.test.ts
+++ b/autoscheduler/frontend/src/tests/utilTests/hoursForSchedule.test.ts
@@ -1,0 +1,76 @@
+import hoursForSchedule from '../../utils/hoursForSchedule';
+import {
+  testScheduleWith5MinCreditHoursAnd1ExtraMaxCreditHours,
+  testScheduleWith6MinCreditHoursAndNullMaxCredits,
+  testScheduleWithEqualMinAndMaxCredits,
+} from '../testSchedules';
+import Schedule from '../../types/Schedule';
+
+describe('hoursForSchedule', () => {
+  // when max credits is null, returns just min credits
+  // when max credits is null for some sections but not others
+  describe('when max credits is null', () => {
+    test('it only returns min credits & adds correctly', () => {
+      // Arrange
+      const schedule: Schedule = {
+        meetings: testScheduleWith6MinCreditHoursAndNullMaxCredits,
+        name: 'Schedule 1',
+        locked: false,
+      };
+
+      // Act
+      const result = hoursForSchedule(schedule);
+
+      // Assert
+      const expected = '6';
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when max credits is null for some sections but not others', () => {
+    test('it adds the max credits correctly', () => {
+      // Arrange
+      const schedule: Schedule = {
+        meetings: testScheduleWith5MinCreditHoursAnd1ExtraMaxCreditHours,
+        name: 'Schedule 1',
+        locked: false,
+      };
+
+      // Act
+      const result = hoursForSchedule(schedule);
+
+      // Assert
+      const expected = '5 - 6';
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when min credits equals max credits', () => {
+    test('it does not display max credits', () => {
+      // Arrange
+      const schedule: Schedule = {
+        meetings: testScheduleWithEqualMinAndMaxCredits,
+        name: 'Schedule 1',
+        locked: false,
+      };
+
+      // Act
+      const result = hoursForSchedule(schedule);
+
+      // Assert
+      const expected = '3';
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe('when schedule is null', () => {
+    test('it returns "-"', () => {
+      // Act
+      const result = hoursForSchedule(null);
+
+      // Assert
+      const expected = '-';
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/autoscheduler/frontend/src/tests/utilTests/hoursForSection.test.ts
+++ b/autoscheduler/frontend/src/tests/utilTests/hoursForSection.test.ts
@@ -91,7 +91,7 @@ describe('hoursForSection', () => {
         // Assert
         const expected = '3 hours';
         expect(result).toEqual(expected);
-      })
-    })
+      });
+    });
   });
 });

--- a/autoscheduler/frontend/src/tests/utilTests/hoursForSection.test.ts
+++ b/autoscheduler/frontend/src/tests/utilTests/hoursForSection.test.ts
@@ -1,0 +1,97 @@
+import Grades from '../../types/Grades';
+import Instructor from '../../types/Instructor';
+import Section, { InstructionalMethod } from '../../types/Section';
+import hoursForSection from '../../utils/hoursForSection';
+
+const dummySectionData = {
+  id: 0,
+  crn: 0,
+  subject: 'CSCE',
+  courseNum: '121',
+  sectionNum: '501',
+  currentEnrollment: 0,
+  maxEnrollment: 0,
+  honors: false,
+  remote: false,
+  asynchronous: false,
+  mcallen: false,
+  instructor: new Instructor({ name: 'Something' }),
+  grades: null as Grades,
+  instructionalMethod: InstructionalMethod.NONE,
+};
+
+describe('hoursForSection', () => {
+  describe('when maxCredits is null', () => {
+    describe('and minCredits == 1', () => {
+      test('uses singular hour', () => {
+        // Arrange
+        const section = new Section({
+          ...dummySectionData,
+          minCredits: 1,
+          maxCredits: null,
+        });
+
+        // Act
+        const result = hoursForSection(section);
+
+        // Assert
+        const expected = '1 hour';
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe('and minCredits > 1', () => {
+      test('uses plural hours', () => {
+        // Arrange
+        const section = new Section({
+          ...dummySectionData,
+          minCredits: 3,
+          maxCredits: null,
+        });
+
+        // Act
+        const result = hoursForSection(section);
+
+        // Assert
+        const expected = '3 hours';
+        expect(result).toEqual(expected);
+      });
+    });
+  });
+
+  describe('when maxCredits is not null', () => {
+    test('returns the correct range', () => {
+      // Arrange
+      const section = new Section({
+        ...dummySectionData,
+        minCredits: 3,
+        maxCredits: 5,
+      });
+
+      // Act
+      const result = hoursForSection(section);
+
+      // Assert
+      const expected = '3 - 5 hours';
+      expect(result).toEqual(expected);
+    });
+
+    describe('and when maxCredits equals minCredits', () => {
+      test('returns only minCredits', () => {
+        // Arrange
+        const section = new Section({
+          ...dummySectionData,
+          minCredits: 3,
+          maxCredits: 3,
+        });
+
+        // Act
+        const result = hoursForSection(section);
+
+        // Assert
+        const expected = '3 hours';
+        expect(result).toEqual(expected);
+      })
+    })
+  });
+});

--- a/autoscheduler/frontend/src/utils/hoursForSchedule.ts
+++ b/autoscheduler/frontend/src/utils/hoursForSchedule.ts
@@ -1,9 +1,26 @@
 import Schedule from '../types/Schedule';
 import sectionsForSchedule from './sectionsForSchedule';
 
+/**
+ * Returns the total number of hours of sections in a schedule.
+ * If there are `maxCredits` in the sections, it will return a range (e.g. "1 - 3")
+ * Otherwise, it will just add up all of the `minCredit`s.
+ */
 export default function hoursForSchedule(schedule: Schedule): string {
   if (!schedule) return '-';
-  return String(sectionsForSchedule(schedule).reduce((acc, section) => (
-    acc + section.minCredits
+  const minCredits = String(sectionsForSchedule(schedule).reduce((acc, section) => (
+    acc + (section.minCredits)
   ), 0));
+
+  const maxCredits = String(sectionsForSchedule(schedule).reduce((acc, section) => (
+    acc + (section.maxCredits ?? section.minCredits)
+  ), 0));
+
+  // There's a few sections where maxCredits is the same as minCredits (about 1%)
+  // as such, don't show a range of this case.
+  if (minCredits === maxCredits) {
+    return minCredits;
+  }
+
+  return `${minCredits} - ${maxCredits}`;
 }

--- a/autoscheduler/frontend/src/utils/hoursForSection.ts
+++ b/autoscheduler/frontend/src/utils/hoursForSection.ts
@@ -1,0 +1,16 @@
+import Section from '../types/Section';
+
+/**
+ * Returns the number of hours for a schedule, depending on if there is a range or not (aka
+ * if `maxCredits` is non-null).
+ * If there is a range, it will return "{minCredit} - {maxCredit} hours"
+ * Also handles "hour" plural handling for `minCredit` (when `maxCredit` is null).
+ */
+export default function hoursForSection(section: Section): string {
+  if (section.maxCredits === null || section.minCredits === section.maxCredits) {
+    const minCreditsPlural = section.minCredits > 1 ? 's' : '';
+    return `${section.minCredits} hour${minCreditsPlural}`;
+  }
+
+  return `${section.minCredits} - ${section.maxCredits} hours`;
+}


### PR DESCRIPTION
## Description

Adds a credit hour range like we discussed in #632 

Note that there's like ~3k sections that have `minCredits` == `maxCredits` for whatever reason, so I added case to check for it.

Could also change the dash to "to" if we'd prefer that

## How to test

Test cases are pretty good IMO

## Screenshots

If it's a frontend change, provide screenshots of it. If possible, show the change on different
resolutions/sizes.

If you're changing a existing frontend look, provide a before and after screenshot in the table below.

|Schedule Details|Main Schedule|
|--|--|
|![chrome_rXLiTbH39G](https://user-images.githubusercontent.com/7295783/160736272-7ff72ac0-8f4e-4197-b854-496f351bbc59.png)|![chrome_xwQxTbWX34](https://user-images.githubusercontent.com/7295783/160736285-e1336698-6973-41f4-90bf-de09d150b11d.png)|


## Related tasks

Closes #632 
